### PR TITLE
SonarCloud source properties file

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,17 @@
+sonar.projectName=foi-flow
+
+# Path to sources
+sonar.sources=request-management-api/
+#sonar.exclusions=
+#sonar.inclusions=
+
+# Path to tests
+# sonar.tests=
+#sonar.test.exclusions=
+#sonar.test.inclusions=
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+#sonar.cpd.exclusions=


### PR DESCRIPTION
This should not trigger a test deploy as the file isn't in the watched folders.

File must be in root dir as per SonarCloud