### PR TITLE
Exclude test files in scanning for bugs/copy-paste

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -2,7 +2,7 @@ sonar.projectName=foi-flow
 
 # Path to sources
 sonar.sources=request-management-api/,apps/forms-flow-ai/forms-flow-bpm,apps/forms-flow-ai/forms-flow-web
-#sonar.exclusions=
+sonar.exclusions=**/*.test.js
 #sonar.inclusions=
 
 # Path to tests
@@ -14,4 +14,4 @@ sonar.sources=request-management-api/,apps/forms-flow-ai/forms-flow-bpm,apps/for
 sonar.sourceEncoding=UTF-8
 
 # Exclusions for copy-paste detection
-#sonar.cpd.exclusions=
+sonar.cpd.exclusions=**/*.test.js


### PR DESCRIPTION
Copying and pasting is normal and unavoidable with
tests - it's only bad in application code.