### PR TITLE
Add backup-container

### DIFF
--- a/openshift/templates/backup/backup-build.yaml
+++ b/openshift/templates/backup/backup-build.yaml
@@ -1,0 +1,74 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}-build-template
+  creationTimestamp: null
+objects:
+  - kind: ImageStream
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+  - kind: BuildConfig
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+      labels:
+        app: ${NAME}
+    spec:
+      triggers:
+        - type: ImageChange
+        - type: ConfigChange
+      runPolicy: Serial
+      source:
+        type: Git
+        git:
+          uri: ${GIT_REPO_URL}
+          ref: ${GIT_REF}
+        contextDir: ${SOURCE_CONTEXT_DIR}
+      strategy:
+        type: Docker
+        dockerStrategy:
+          from:
+            kind: DockerImage
+            name: ${BASE_IMAGE_FOR_BUILD}
+          dockerfilePath: ${DOCKER_FILE_PATH}
+      output:
+        to:
+          kind: ImageStreamTag
+          name: ${NAME}:${OUTPUT_IMAGE_TAG}
+parameters:
+  - name: NAME
+    displayName: Name
+    description: The name assigned to all of the resources.  Use 'backup-{database name}' depending on your database provider
+    required: true
+    value: backup-postgres
+  - name: GIT_REPO_URL
+    displayName: Git Repo URL
+    description: The URL to your GIT repo.
+    required: true
+    value: https://github.com/BCDevOps/backup-container.git
+  - name: GIT_REF
+    displayName: Git Reference
+    description: The git reference or branch.
+    required: true
+    value: master
+  - name: SOURCE_CONTEXT_DIR
+    displayName: Source Context Directory
+    description: The source context directory.
+    required: false
+    value: /docker
+  - name: DOCKER_FILE_PATH
+    displayName: Docker File
+    description: The path and file of the docker file defining the build.  Choose either 'Dockerfile' for Postgres builds or 'Dockerfile_Mongo' for MongoDB builds or 'Dockerfile_MSSQL' for MSSQL builds.
+    required: false
+    value: Dockerfile
+  - name: OUTPUT_IMAGE_TAG
+    displayName: Output Image Tag
+    description: The tag given to the built image.
+    required: true
+    value: latest
+  - name: BASE_IMAGE_FOR_BUILD
+    displayName: FROM Image Tag
+    description: Base image to build from.  Docker creds or Artificatory setup may be needed to alleviate docker rate-limiting
+    required: true
+    value: docker.io/centos/postgresql-12-centos7:20200917-804ef01

--- a/openshift/templates/backup/backup-deploy.yaml
+++ b/openshift/templates/backup/backup-deploy.yaml
@@ -1,0 +1,447 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: ${NAME}-deployment-template
+objects:
+  - kind: NetworkPolicy
+    apiVersion: networking.k8s.io/v1
+    metadata:
+      name: ${NAME}
+      labels:
+        name: ${NAME}
+        app: ${APP_NAME}
+        env: ${TAG_NAME}
+    spec:
+      description: |
+        Allow the ${NAME} to access databases in this namespace.
+      ingress:
+        - from:
+            - podSelector:
+                matchLabels:
+                  name: ${NAME}
+                  app: ${APP_NAME}
+                  role: ${ROLE}
+                  env: ${TAG_NAME}
+              namespaceSelector:
+                matchLabels:
+                  name: ${NAMESPACE_NAME}
+                  environment: ${TAG_NAME}
+      podSelector:
+        matchLabels:
+          backup: "true"
+          env: ${TAG_NAME}
+
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: ${BACKUP_VOLUME_NAME}
+      labels:
+        name: ${NAME}
+        app: ${APP_NAME}
+        role: ${ROLE}
+        env: ${TAG_NAME}
+    spec:
+      storageClassName: ${BACKUP_VOLUME_CLASS}
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: ${BACKUP_VOLUME_SIZE}
+
+  - kind: PersistentVolumeClaim
+    apiVersion: v1
+    metadata:
+      name: ${VERIFICATION_VOLUME_NAME}
+      labels:
+        name: ${NAME}
+        app: ${APP_NAME}
+        role: ${ROLE}
+        env: ${TAG_NAME}
+    spec:
+      storageClassName: ${VERIFICATION_VOLUME_CLASS}
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: ${VERIFICATION_VOLUME_SIZE}
+
+  - kind: Secret
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+      labels:
+        name: ${NAME}
+        app: ${APP_NAME}
+        role: ${ROLE}
+        env: ${TAG_NAME}
+    type: Opaque
+    stringData:
+      webhook-url: ${WEBHOOK_URL}
+      webhook-url-host: ${WEBHOOK_URL_HOST}
+
+  - kind: Secret
+    apiVersion: v1
+    metadata:
+      name: ${FTP_SECRET_KEY}
+      labels:
+        name: ${NAME}
+        app: ${APP_NAME}
+        role: ${ROLE}
+        env: ${TAG_NAME}
+    type: Opaque
+    stringData:
+      ftp-url: ${FTP_URL}
+      ftp-user: ${FTP_USER}
+      ftp-password: ${FTP_PASSWORD}
+      ftp-url-host: ${FTP_URL_HOST}
+
+  - kind: DeploymentConfig
+    apiVersion: v1
+    metadata:
+      name: ${NAME}
+      labels:
+        name: ${NAME}
+        app: ${APP_NAME}
+        role: ${ROLE}
+        env: ${TAG_NAME}
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+        - type: ConfigChange
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - ${NAME}
+            from:
+              kind: ImageStreamTag
+              namespace: ${IMAGE_NAMESPACE}
+              name: ${SOURCE_IMAGE_NAME}:${TAG_NAME}
+      replicas: 1
+      selector:
+        name: ${NAME}
+      template:
+        metadata:
+          name: ${NAME}
+          labels:
+            name: ${NAME}
+            app: ${APP_NAME}
+            role: ${ROLE}
+            env: ${TAG_NAME}
+        spec:
+          volumes:
+            - name: ${BACKUP_VOLUME_NAME}
+              persistentVolumeClaim:
+                claimName: ${BACKUP_VOLUME_NAME}
+            - name: ${VERIFICATION_VOLUME_NAME}
+              persistentVolumeClaim:
+                claimName: ${VERIFICATION_VOLUME_NAME}
+            - name: ${NAME}-config-volume
+              configMap:
+                name: ${CONFIG_MAP_NAME}
+                items:
+                  - key: ${CONFIG_FILE_NAME}
+                    path: ${CONFIG_FILE_NAME}
+          containers:
+            - name: ${NAME}
+              image: ""
+              ports: []
+              env:
+                - name: BACKUP_STRATEGY
+                  value: ${BACKUP_STRATEGY}
+                - name: BACKUP_DIR
+                  value: ${BACKUP_DIR}
+                - name: NUM_BACKUPS
+                  value: ${NUM_BACKUPS}
+                - name: DAILY_BACKUPS
+                  value: ${DAILY_BACKUPS}
+                - name: WEEKLY_BACKUPS
+                  value: ${WEEKLY_BACKUPS}
+                - name: MONTHLY_BACKUPS
+                  value: ${MONTHLY_BACKUPS}
+                - name: BACKUP_PERIOD
+                  value: ${BACKUP_PERIOD}
+                - name: DATABASE_SERVICE_NAME
+                  value: ${DATABASE_SERVICE_NAME}
+                - name: DATABASE_NAME
+                  value: ${DATABASE_NAME}
+                - name: MONGODB_AUTHENTICATION_DATABASE
+                  value: ${MONGODB_AUTHENTICATION_DATABASE}
+                - name: TABLE_SCHEMA
+                  value: ${TABLE_SCHEMA}
+                - name: DATABASE_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${DATABASE_DEPLOYMENT_NAME}
+                      key: ${DATABASE_USER_KEY_NAME}
+                - name: DATABASE_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${DATABASE_DEPLOYMENT_NAME}
+                      key: ${DATABASE_PASSWORD_KEY_NAME}
+                - name: FTP_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${FTP_SECRET_KEY}
+                      key: ftp-url
+                - name: FTP_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${FTP_SECRET_KEY}
+                      key: ftp-user
+                - name: FTP_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${FTP_SECRET_KEY}
+                      key: ftp-password
+                - name: WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${NAME}
+                      key: webhook-url
+                - name: ENVIRONMENT_FRIENDLY_NAME
+                  value: ${ENVIRONMENT_FRIENDLY_NAME}
+                - name: ENVIRONMENT_NAME
+                  value: ${ENVIRONMENT_NAME}
+              resources:
+                requests:
+                  cpu: ${CPU_REQUEST}
+                  memory: ${MEMORY_REQUEST}
+                limits:
+                  cpu: ${CPU_LIMIT}
+                  memory: ${MEMORY_LIMIT}
+              volumeMounts:
+                - name: ${BACKUP_VOLUME_NAME}
+                  mountPath: ${BACKUP_DIR}
+                - name: ${VERIFICATION_VOLUME_NAME}
+                  mountPath: ${VERIFICATION_VOLUME_MOUNT_PATH}
+                - name: ${NAME}-config-volume
+                  mountPath: ${CONFIG_MOUNT_PATH}${CONFIG_FILE_NAME}
+                  subPath: ${CONFIG_FILE_NAME}
+
+parameters:
+  - name: NAME
+    displayName: Name
+    description: The name assigned to all of the resources.  Use 'backup-{database name}' depending on your database provider
+    required: true
+    value: backup-postgres
+  - name: SOURCE_IMAGE_NAME
+    displayName: Source Image Name
+    description: The name of the image to use for this resource.  Use 'backup-{database name}' depending on your database provider
+    required: true
+    value: backup-postgres
+  - name: APP_NAME
+    displayName: App Name
+    description: Used to group resources together.  Defaults to backup-container
+    required: true
+    value: backup-container
+  - name: ROLE
+    displayName: ROLE
+    description: The role assigned to all of the resources.  Defaults to backup-container
+    required: true
+    value: backup-container
+  - name: NAMESPACE_NAME
+    displayName: Namespace Name
+    description: The name of the namespace being deployed to..
+    required: true
+    value: devex-von-image
+  - name: IMAGE_NAMESPACE
+    displayName: Image Namespace
+    description: The namespace of the OpenShift project containing the imagestream for the application.
+    required: true
+    value:
+  - name: TAG_NAME
+    displayName: Environment TAG name
+    description: The TAG name for this environment, e.g., dev, test, prod
+    required: true
+    value: dev
+  - name: DATABASE_SERVICE_NAME
+    displayName: Database Service Name
+    description: Used for backward compatibility only. Not needed when using the recommended 'backup.conf' configuration.  The name of the database service.
+    required: false
+    value: ""
+  - name: DATABASE_NAME
+    displayName: Database Name
+    description: Used for backward compatibility only. Not needed when using the recommended 'backup.conf' configuration.  The name of the database.
+    required: false
+    value: ""
+  - name: MONGODB_AUTHENTICATION_DATABASE
+    displayName: MongoDB Authentication Database
+    description: This is only required if you are backing up mongo database with a separate authentication database.
+    required: false
+    value: ""
+  - name: DATABASE_DEPLOYMENT_NAME
+    displayName: Database Deployment Name
+    description: The name associated to the database deployment resources.  In particular, this is used to wire up the credentials associated to the database.
+    required: true
+    value: postgresql
+  - name: DATABASE_USER_KEY_NAME
+    displayName: Database User Key Name
+    description: The database user key name stored in database deployment resources specified by DATABASE_DEPLOYMENT_NAME.
+    required: true
+    value: database-user
+  - name: DATABASE_PASSWORD_KEY_NAME
+    displayName: Database Password Key Name
+    description: The database password key name stored in database deployment resources specified by DATABASE_DEPLOYMENT_NAME.
+    required: true
+    value: database-password
+  - name: MSSQL_SA_PASSWORD
+    displayName: MSSQL SA Password
+    description: The database password to use for the local backup database.
+    required: false
+  - name: TABLE_SCHEMA
+    displayName: Table Schema
+    description: The table schema for your database.  Used for Postgres backups.
+    required: true
+    value: public
+  - name: BACKUP_STRATEGY
+    displayName: Backup Strategy
+    description: The strategy to use for backups; for example daily, or rolling.
+    required: true
+    value: rolling
+  - name: FTP_SECRET_KEY
+    displayName: FTP Secret Key
+    description: The FTP secret key is used to wire up the credentials associated to the FTP.
+    required: false
+    value: ftp-secret
+  - name: FTP_URL
+    displayName: FTP Server URL
+    description: The URL of the backup FTP server
+    required: false
+    value: ""
+  - name: FTP_URL_HOST
+    displayName: Ftp URL Hostname
+    description: Ftp URL Hostname.  The backup-deploy.overrides.sh will parse this from the supplied FTP_URL, and fetch it from a secret for updates.
+    required: false
+    value:
+  - name: FTP_USER
+    displayName: FTP user name
+    description: FTP user name
+    required: false
+    value: ""
+  - name: FTP_PASSWORD
+    displayName: FTP password
+    description: FTP password
+    required: false
+    value: ""
+  - name: WEBHOOK_URL
+    displayName: Webhook URL
+    description: The URL of the webhook to use for notifications.  If not specified, the webhook integration feature is disabled.
+    required: false
+    value: ""
+  - name: WEBHOOK_URL_HOST
+    displayName: Webhook URL Hostname
+    description: Webhook URL Hostname.  The backup-deploy.overrides.sh will parse this from the supplied WEBHOOK_URL, and fetch it from a secret for updates.
+    required: false
+    value:
+  - name: ENVIRONMENT_FRIENDLY_NAME
+    displayName: Friendly Environment Name
+    description: The human readable name of the environment.  This variable is used by the webhook integration to identify the environment in which the backup notifications originate.
+    required: false
+    value: ""
+  - name: ENVIRONMENT_NAME
+    displayName: Environment Name (Environment Id)
+    description: The name or Id of the environment.  This variable is used by the webhook integration and by the NetworkSecurityPolicies to identify the environment in which the backup notifications originate.
+    required: true
+    value: ""
+  - name: BACKUP_DIR
+    displayName: The root backup directory
+    description: The name of the root backup directory.  The backup volume will be mounted to this directory.
+    required: true
+    value: /backups/
+  - name: NUM_BACKUPS
+    displayName: The number of backup files to be retained
+    description: Used for backward compatibility only.  Ignored when using the recommended `rolling` backup strategy.  The number of backup files to be retained.  Used for the `daily` backup strategy.
+    required: false
+    value: ""
+  - name: DAILY_BACKUPS
+    displayName: Number of Daily Backups to Retain
+    description: The number of daily backup files to be retained.  Used for the `rolling` backup strategy.
+    required: false
+    value: ""
+  - name: WEEKLY_BACKUPS
+    displayName: Number of Weekly Backups to Retain
+    description: The number of weekly backup files to be retained.  Used for the `rolling` backup strategy.
+    required: false
+    value: ""
+  - name: MONTHLY_BACKUPS
+    displayName: Number of Monthly Backups to Retain
+    description: The number of monthly backup files to be retained.  Used for the `rolling` backup strategy.
+    required: false
+    value: ""
+  - name: BACKUP_PERIOD
+    displayName: Period (d,m,s) between backups in a format used by the sleep command
+    description: Used for backward compatibility only.  Ignored when using the recommended `backup.conf` and cron backup strategy.  Period (d,m,s) between backups in a format used by the sleep command
+    required: false
+    value: ""
+  - name: CONFIG_FILE_NAME
+    displayName: Config File Name
+    description: The name of the configuration file.
+    required: true
+    value: backup.conf
+  - name: CONFIG_MAP_NAME
+    displayName: Config Map Name
+    description: The name of the configuration map.
+    required: true
+    value: backup-conf
+  - name: CONFIG_MOUNT_PATH
+    displayName: Config Mount Path
+    description: The path to use to mount the config file.
+    required: true
+    value: /
+  - name: BACKUP_VOLUME_NAME
+    displayName: Backup Volume Name
+    description: The name of the persistent volume used to store the backups.
+    required: true
+    value: backup
+  - name: BACKUP_VOLUME_SIZE
+    displayName: Backup Volume Size
+    description: The size of the persistent volume used to store the backups, e.g. 512Mi, 1Gi, 2Gi.  Ensure this is sized correctly.  Refer to the container documentation for details.
+    required: true
+    value: 5Gi
+  - name: BACKUP_VOLUME_CLASS
+    displayName: Backup Volume Class
+    description: The class of the persistent volume used to store the backups; netapp-file-standard is the recommended default.
+    required: true
+    value: netapp-file-backup
+  - name: VERIFICATION_VOLUME_NAME
+    displayName: Verification Volume Name
+    description: The name for the verification volume, used for restoring and verifying backups.
+    required: false
+    value: backup-verification
+  - name: VERIFICATION_VOLUME_SIZE
+    displayName: Backup Volume Size
+    description: The size of the persistent volume used for restoring and verifying backups, e.g. 512Mi, 1Gi, 2Gi.  Ensure this is sized correctly.  It should be large enough to contain your largest database.
+    required: true
+    value: 1Gi
+  - name: VERIFICATION_VOLUME_CLASS
+    displayName: Backup Volume Class
+    description: The class of the persistent volume used for restoring and verifying backups; netapp-file-standard, netapp-block-standard.
+    required: true
+    value: netapp-file-standard
+  - name: VERIFICATION_VOLUME_MOUNT_PATH
+    displayName: Verification Volume Mount Path
+    description: The path on which to mount the verification volume.  This is used by the database server to contain the database configuration and data files. For Mongo, please use /var/lib/mongodb/data . For MSSQL, please use /var/opt/mssql/data. For MariaDB, please use /var/lib/mysql/data
+    required: true
+    value: /var/lib/pgsql/data
+  - name: CPU_REQUEST
+    displayName: Resources CPU Request
+    description: The resources CPU request (in cores) for this build.
+    required: true
+    value: "0"
+  - name: CPU_LIMIT
+    displayName: Resources CPU Limit
+    description: The resources CPU limit (in cores) for this build.
+    required: true
+    value: "0"
+  - name: MEMORY_REQUEST
+    displayName: Resources Memory Request
+    description: The resources Memory request (in Mi, Gi, etc) for this build.
+    required: true
+    value: 0Mi
+  - name: MEMORY_LIMIT
+    displayName: Resources Memory Limit
+    description: The resources Memory limit (in Mi, Gi, etc) for this build.
+    required: true
+    value: 0Mi

--- a/openshift/templates/backup/backup.conf
+++ b/openshift/templates/backup/backup.conf
@@ -1,0 +1,56 @@
+# ============================================================
+# Databases:
+# ------------------------------------------------------------
+# List the databases you want backed up here.
+# Databases will be backed up in the order they are listed.
+#
+# The entries must be in one of the following forms:
+# - <Hostname/>/<DatabaseName/>
+# - <Hostname/>:<Port/>/<DatabaseName/>
+# - <DatabaseType>=<Hostname/>/<DatabaseName/>
+# - <DatabaseType>=<Hostname/>:<Port/>/<DatabaseName/>
+# <DatabaseType> can be postgres, mongo or mssql
+# <DatabaseType> MUST be specified when you are sharing a
+# single backup.conf file between postgres, mongo and mssql
+# backup containers.  If you do not specify <DatabaseType>
+# the listed databases are assumed to be valid for the
+# backup container in which the configuration is mounted.
+#
+# Examples:
+# - postgres=postgresql/my_database
+# - postgres=postgresql:5432/my_database
+# - mongo=mongodb/my_database
+# - mongo=mongodb:27017/my_database
+# - mssql=mssql_server:1433/my_database
+# -----------------------------------------------------------
+# Cron Scheduling:
+# -----------------------------------------------------------
+# List your backup and verification schedule(s) here as well.
+# The schedule(s) must be listed as cron tabs that 
+# execute the script in 'scheduled' mode:
+#   - ./backup.sh -s
+#
+# Examples (assuming system's TZ is set to PST):
+# - 0 1 * * * default ./backup.sh -s
+#   - Run a backup at 1am Pacific every day.
+#
+# - 0 4 * * * default ./backup.sh -s -v all
+#   - Verify the most recent backups for all datbases
+#     at 4am Pacific every day.
+# -----------------------------------------------------------
+# Full Example:
+# -----------------------------------------------------------
+# postgres=postgresql:5432/TheOrgBook_Database
+# mongo=mender-mongodb:27017/useradm
+# postgres=wallet-db/tob_issuer
+# mssql=pims-db-dev:1433/pims
+# mariadb=matomo-db:3306/matomo
+#
+# 0 1 * * * default ./backup.sh -s
+# 0 4 * * * default ./backup.sh -s -v all
+# ============================================================
+postgres=patroni-master-001/foi
+
+# Backup at 1am PST, and verify backups at 4am PST.
+0 1 * * * default ./backup.sh -s
+0 4 * * * default ./backup.sh -s -v all

--- a/openshift/templates/backup/readme.md
+++ b/openshift/templates/backup/readme.md
@@ -1,0 +1,28 @@
+# Readme - Backup Container
+
+All original commands were found in official [backup-container](https://github.com/BCDevOps/backup-container) repo.
+
+No passwords or secrets are stored in this file as it's publicly available.
+
+## Commands
+
+
+oc -n d7abee-tools process -f ./openshift/templates/backup/backup-build.yaml \
+  -p NAME=foi-bkup OUTPUT_IMAGE_TAG=v1 | oc -n d7abee-tools create -f -
+
+
+oc -n d7abee-prod create configmap backup-conf --from-file=./openshift/templates/backup/backup.conf
+oc -n d7abee-prod label configmap backup-conf app=foi-bkup
+
+oc -n d7abee-prod process -f ./openshift/templates/backup/backup-deploy.yaml \
+  -p NAME=foi-bkup \
+  -p IMAGE_NAMESPACE=d7abee-tools \
+  -p SOURCE_IMAGE_NAME=foi-bkup \
+  -p TAG_NAME=v1 \
+  -p BACKUP_VOLUME_NAME=foi-bkup-pvc -p BACKUP_VOLUME_SIZE=20Gi \
+  -p VERIFICATION_VOLUME_SIZE=5Gi \
+  -p ENVIRONMENT_NAME=d7abee-prod \
+  -p DATABASE_DEPLOYMENT_NAME=patroni-001 \
+  -p DATABASE_USER_KEY_NAME=app-db-username \
+  -p DATABASE_PASSWORD_KEY_NAME=app-db-password \
+  -p ENVIRONMENT_FRIENDLY_NAME='FOI DB Backups' | oc -n d7abee-prod create -f -


### PR DESCRIPTION
Add backup container scripts (already deployed in prod).

@abin-aot - I'll draw your attention to `backup.conf`.  If we ever need to do automated backups of additional DBs, we can easily add them here. 

Right now this is setup to do a 1am backup of the DB, and a 4am verification of the backup (all times PST).  These were the default suggestions from the bcgov backup repo, so I went with them.  If we ever need to move the cron time, we could do it here.  Also, if we ever want to do an off-site backup, it's as simple as setting up a job to pull the files off the backup machine and store them elsewhere.