### PR TITLE
Changes to ignore closed and onhold request from reminders + Use maya…

### DIFF
--- a/apps/forms-flow-ai/forms-flow-bpm/src/main/resources/processes/foi-duedate-reminder.bpmn
+++ b/apps/forms-flow-ai/forms-flow-bpm/src/main/resources/processes/foi-duedate-reminder.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1te5mlw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
-  <bpmn:process id="Process_0g2ilhp" isExecutable="true">
+  <bpmn:process id="due_reminder_notifications" name="Due Reminder Notifications" isExecutable="true" camunda:versionTag="1">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0qym7g1</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0f35rt9">
@@ -107,7 +107,7 @@ connector.getVariable("statusCode");</camunda:script>
   <bpmn:error id="Error_06fsjjn" name="FOI-REMINDER-API-ERR" camunda:errorMessage="FOI Request invocation failed." />
   <bpmn:message id="Message_1yee5gs" name="foi-reminder-error" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0g2ilhp">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="due_reminder_notifications">
       <bpmndi:BPMNEdge id="Flow_017kmm6_di" bpmnElement="Flow_017kmm6">
         <di:waypoint x="585" y="290" />
         <di:waypoint x="712" y="290" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - OSS_S3_REGION=${OSS_S3_REGION}
       - OSS_S3_SERVICE=${OSS_S3_SERVICE}
       - FOI_NOTIFICATION_DAYS=${FOI_NOTIFICATION_DAYS}
-        
+      - FOI_ADDITIONAL_HOLIDAYS=${FOI_ADDITIONAL_HOLIDAYS}
   foi-requests-DB:
     image: postgres
     container_name: aot_foi_requests_db_pg

--- a/request-management-api/request_api/models/FOIMinistryRequests.py
+++ b/request-management-api/request_api/models/FOIMinistryRequests.py
@@ -203,7 +203,7 @@ class FOIMinistryRequest(db.Model):
     @classmethod
     def getupcomingcfrduerecords(cls):
         sql = """select distinct on (filenumber) filenumber, cfrduedate, foiministryrequestid, version, foirequest_id, created_at, createdby from "FOIMinistryRequests" fpa 
-                    where isactive = true and cfrduedate is not null 
+                    where isactive = true and cfrduedate is not null and requeststatusid not in (3,10,11)  
                     and cfrduedate between NOW()::DATE-EXTRACT(DOW FROM NOW())::INTEGER-7 AND NOW()::DATE-EXTRACT(DOW from NOW())::INTEGER+7 
                     order by filenumber , version desc;""" 
         rs = db.session.execute(text(sql))
@@ -215,7 +215,7 @@ class FOIMinistryRequest(db.Model):
     @classmethod
     def getupcominglegislativeduerecords(cls):
         sql = """select distinct on (filenumber) filenumber, duedate, foiministryrequestid, version, foirequest_id, created_at, createdby from "FOIMinistryRequests" fpa 
-                    where isactive = true and duedate is not null 
+                    where isactive = true and duedate is not null and requeststatusid not in (3,10,11)     
                     and duedate between NOW()::DATE-EXTRACT(DOW FROM NOW())::INTEGER-7 AND NOW()::DATE-EXTRACT(DOW from NOW())::INTEGER+7 
                     order by filenumber , version desc;""" 
         rs = db.session.execute(text(sql))

--- a/request-management-api/request_api/services/events/duecalculator.py
+++ b/request-management-api/request_api/services/events/duecalculator.py
@@ -2,6 +2,7 @@
 from os import stat
 from re import VERBOSE
 import json
+from datetime import datetime as datetime2
 from datetime import datetime, timedelta
 import holidays
 import maya
@@ -22,12 +23,13 @@ class duecalculator:
             return self.getpreviousbusinessday(_prevbusinessday,ca_holidays)
  
     def gettoday(self):
-        now_utc = datetime.now(timezone('UTC'))
-        now_pst = now_utc.astimezone(timezone(self.__getdefaulttimezone()))
+        now_utc = datetime2.now()
+        now_pst = maya.parse(now_utc).datetime(to_timezone=self.__getdefaulttimezone(), naive=False)
         return now_pst.strftime(self.__getdefaultdateformat()) 
     
     def formatduedate(self,input):
-        due_pst = input.astimezone(timezone(self.__getdefaulttimezone()))
+        dt = maya.parse(input).datetime(to_timezone=self.__getdefaulttimezone(), naive=False)
+        due_pst = dt
         return due_pst.strftime(self.__getdefaultdateformat())
     
     def getholidays(self):        


### PR DESCRIPTION
Amendments to 1242:
1. Changes to ignore closed and onhold request status from reminder notification
2. Leverage maya api for PST timezone instead of asttimezone conversion
3.  Provided valid name and version to reminder bpm process.

Use Case Done:
1. Call for Records due on Date [insert next business day]
2. Call for Records due Today
3. Legislated Due Date is due date [insert business date]
4. Legislated Due Date is Today
5. Please note these are achieved by manipulating data manually.

Sanity Test:
1. Create new Request
2. State Navigation from Intake in Progress -> Open -> CFR -> Harms Assessment -> Closed
3. Change Assignment
4. Adding Comment and replies
5. Modifying request through IAO and ministry request

To Know:
New environment variable added "FOI_NOTIFICATION_DAYS" to accommodate additional BC holidays which are not listed from Holidays api "holidays==0.12"