### PR TITLE
Changes to ignore conversion to PST for legislative and CFR due dates…

### DIFF
--- a/request-management-api/request_api/services/events/duecalculator.py
+++ b/request-management-api/request_api/services/events/duecalculator.py
@@ -23,14 +23,11 @@ class duecalculator:
             return self.getpreviousbusinessday(_prevbusinessday,ca_holidays)
  
     def gettoday(self):
-        now_utc = datetime2.now()
-        now_pst = maya.parse(now_utc).datetime(to_timezone=self.__getdefaulttimezone(), naive=False)
+        now_pst = maya.parse(maya.now()).datetime(to_timezone=self.__getdefaulttimezone(), naive=False)
         return now_pst.strftime(self.__getdefaultdateformat()) 
     
     def formatduedate(self,input):
-        dt = maya.parse(input).datetime(to_timezone=self.__getdefaulttimezone(), naive=False)
-        due_pst = dt
-        return due_pst.strftime(self.__getdefaultdateformat())
+        return input.strftime(self.__getdefaultdateformat())
     
     def getholidays(self):        
         ca_holidays = []


### PR DESCRIPTION
Fix to remove the conversion of legislative and CFR due date to PST from backend; as they are already sent in PST from view tier.