### PR TITLE
Changes to ignore conversion of due date in previous day reminder and…

### DIFF
--- a/request-management-api/request_api/models/FOIMinistryRequests.py
+++ b/request-management-api/request_api/models/FOIMinistryRequests.py
@@ -204,7 +204,7 @@ class FOIMinistryRequest(db.Model):
     def getupcomingcfrduerecords(cls):
         sql = """select distinct on (filenumber) filenumber, cfrduedate, foiministryrequestid, version, foirequest_id, created_at, createdby from "FOIMinistryRequests" fpa 
                     where isactive = true and cfrduedate is not null and requeststatusid not in (3,10,11)  
-                    and cfrduedate between NOW()::DATE-EXTRACT(DOW FROM NOW())::INTEGER-7 AND NOW()::DATE-EXTRACT(DOW from NOW())::INTEGER+7 
+                    and cfrduedate between  NOW() - INTERVAL '7 DAY' AND NOW() + INTERVAL '7 DAY'
                     order by filenumber , version desc;""" 
         rs = db.session.execute(text(sql))
         upcomingduerecords = []
@@ -216,7 +216,7 @@ class FOIMinistryRequest(db.Model):
     def getupcominglegislativeduerecords(cls):
         sql = """select distinct on (filenumber) filenumber, duedate, foiministryrequestid, version, foirequest_id, created_at, createdby from "FOIMinistryRequests" fpa 
                     where isactive = true and duedate is not null and requeststatusid not in (3,10,11)     
-                    and duedate between NOW()::DATE-EXTRACT(DOW FROM NOW())::INTEGER-7 AND NOW()::DATE-EXTRACT(DOW from NOW())::INTEGER+7 
+                    and duedate between  NOW() - INTERVAL '7 DAY' AND NOW() + INTERVAL '7 DAY'
                     order by filenumber , version desc;""" 
         rs = db.session.execute(text(sql))
         upcomingduerecords = []

--- a/request-management-api/request_api/services/events/cfrdate.py
+++ b/request-management-api/request_api/services/events/cfrdate.py
@@ -26,11 +26,11 @@ class cfrdateevent(duecalculator):
             ca_holidays = self.getholidays()
             _upcomingdues = FOIMinistryRequest.getupcomingcfrduerecords()
             for entry in _upcomingdues:
-                _duedate = self.formatduedate(entry['cfrduedate'])  
+                _duedate = self.formatduedate(entry['cfrduedate']) 
                 message = None
                 if  _duedate == _today:                
                     message = self.__todayduemessage()     
-                elif  self.getpreviousbusinessday(_duedate,ca_holidays) == _today:
+                elif  self.getpreviousbusinessday(entry['cfrduedate'],ca_holidays) == _today:
                     message = self.__upcomingduemessage(_duedate)
                 self.__createnotification(message,entry['foiministryrequestid'])
             return DefaultMethodResult(True,'CFR reminder notifications created',_today)

--- a/request-management-api/request_api/services/events/duecalculator.py
+++ b/request-management-api/request_api/services/events/duecalculator.py
@@ -40,15 +40,14 @@ class duecalculator:
         return ca_holidays    
         
     def __getpreviousweekday(self, cfrduedate):
-        _cfrdate = datetime.strptime(cfrduedate, self.__getdefaultdateformat())
         diff = 1
-        if _cfrdate.weekday() == 0:
+        if cfrduedate.weekday() == 0:
             diff = 3
-        elif _cfrdate.weekday() == 6:
+        elif cfrduedate.weekday() == 6:
             diff = 2
         else :
             diff = 1  
-        res = _cfrdate - timedelta(days=diff)
+        res = cfrduedate - timedelta(days=diff)
         return res.strftime(self.__getdefaultdateformat())            
    
     def __isholiday(self, input, ca_holidays):

--- a/request-management-api/request_api/services/events/legislativedate.py
+++ b/request-management-api/request_api/services/events/legislativedate.py
@@ -31,7 +31,7 @@ class legislativedateevent(duecalculator):
                 message = None
                 if  _duedate == _today:                
                     message = self.__todayduemessage()     
-                elif  self.getpreviousbusinessday(_duedate,ca_holidays) == _today:
+                elif  self.getpreviousbusinessday(entry['duedate'],ca_holidays) == _today:
                     message = self.__upcomingduemessage(_duedate)
                 self.__createnotification(message,entry['foiministryrequestid'])
             return DefaultMethodResult(True,'Legislative reminder notifications created',_today)


### PR DESCRIPTION
Amendment:
Changes to ignore PST conversion for previous date calculation + fetch logic criteria change for due date calculation.

Use Case Done:
1. Call for Records due on Date [insert next business day]
2. Call for Records due Today
3. Legislated Due Date is due date [insert business date]
4. Legislated Due Date is Today
5. Please note these are achieved by manipulating data manually.

Sanity Test:
1. Create new Request
2. State Navigation from Intake in Progress -> Open -> CFR -> Harms Assessment -> Closed
3. Change Assignment
4. Adding Comment and replies
5. Modifying request through IAO and ministry request

