### PR TITLE
Fix subtract business days calculation

### DIFF
--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/ExtensionDetails/AddExtensionModal.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/ExtensionDetails/AddExtensionModal.js
@@ -20,6 +20,7 @@ import CircularProgress from "@material-ui/core/CircularProgress";
 import {
   formatDate,
   addBusinessDays,
+  removeBusinessDays,
   ConditionalComponent,
 } from "../../../../helper/FOI/helper";
 import clsx from "clsx";
@@ -146,11 +147,12 @@ const AddExtensionModal = () => {
 
       const daysToSubtract = selectedExtension.approvednoofdays || selectedExtension.extendedduedays;
       setPreExtendedDate(
-        addBusinessDays(
+        removeBusinessDays(
           formatDate(selectedExtension.extendedduedate),
-          daysToSubtract * -1
+          daysToSubtract
         )
       );
+
       setDeniedDate(
         formatDate(selectedExtension.denieddate) || formatDate(new Date())
       );

--- a/apps/forms-flow-ai/forms-flow-web/src/helper/FOI/helper.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/helper/FOI/helper.js
@@ -87,6 +87,26 @@ const addBusinessDays = (dateText, days) => {
 	return reconcilePublicHoliDays(startDate,endDate).format('YYYY-MM-DD');	
 }
 
+const revertReconciledPublicHolidays = (startDate, endDate) => {
+  let publicHoliDays = getPublicHoliDays(startDate, endDate);
+  endDate = endDate.businessDaysSubtract(publicHoliDays);
+  startDate = endDate;
+  if (publicHoliDays != 0) {
+    reconcilePublicHoliDays(startDate, endDate);
+  }
+  return endDate;
+};
+
+const removeBusinessDays = (dateText, days) => {
+  if (!dateText) {
+    return 0;
+  }
+  let startDate = dayjs(dateText);
+  let endDate = startDate.businessDaysSubtract(days);
+
+  return revertReconciledPublicHolidays(startDate, endDate).format("YYYY-MM-DD");
+};
+
 const countWeekendDays = (startDate, endDate) =>
 {  
   var ndays = 1 + Math.round((endDate.getTime()-startDate.getTime())/(24*3600*1000));
@@ -268,4 +288,5 @@ export {
   getAssignToList,
   getFullnameTeamList,
   ConditionalComponent,
+  removeBusinessDays,
 };


### PR DESCRIPTION
There was a bug in calculating the previous extended date on the extension modal by using addBusinessDays with a negative number to subtract business days which produced wrong results due to the reconcilePublicHolidays method. I added two methods in the helper.js to subtract business days and used them instead