### PR TITLE
Changes to resolve save failures for request with team name only.

### DIFF
--- a/request-management-api/request_api/resources/request.py
+++ b/request-management-api/request_api/resources/request.py
@@ -136,7 +136,6 @@ class FOIRawRequestBPMProcess(Resource):
             try:
 
                 _wfinstanceid = request_json['wfinstanceid']
-                status = request_json['status'] if request_json.get('status') is not None else 'Intake in Progress'
                 notes = request_json['notes'] if request_json.get('notes') is not None else 'Workflow Update'
                 requestid = int(_requestid)                                                               
                 result = rawrequestservice().updateworkflowinstancewithstatus(_wfinstanceid,requestid,status,notes,AuthHelper.getuserid())


### PR DESCRIPTION
Hot Fix:
To resolve save failure for scenario : Saving an unopened request with team name only.

Sanity Testing:

Create new request with team name only
Update request
Change states Intake in progress -> Open -> call for records
Watch /Unwatch
Add comments