### PR TITLE
Fix double and unnecessary calling of API endpoints 

### DIFF
--- a/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiMasterDataServices.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiMasterDataServices.js
@@ -111,12 +111,12 @@ import {
 
   export const fetchFOIProcessingTeamList = (requestType) => {
     let apiUrlGETAssignedToList = API.FOI_GET_ASSIGNEDTO_ALLGROUP_LIST_API;
-    if (requestType) {     
+    if (requestType) {
       apiUrlGETAssignedToList = replaceUrl(
         API.FOI_GET_PROCESSINGTEAMLIST_API,
         "<requesttype>",
         requestType
-      );      
+      );
     }
     return (dispatch) => {
       httpGETRequest(apiUrlGETAssignedToList, {}, UserService.getToken())
@@ -129,36 +129,45 @@ import {
             dispatch(setFOIProcessingTeamList(data));
             dispatch(setFOILoader(false));
           } else {
-            console.log(`Error while fetching assigned to master data based on requestType ${requestType} `, res);
+            console.log(
+              `Error while fetching assigned to master data based on requestType ${requestType} `,
+              res
+            );
             dispatch(serviceActionError(res));
             dispatch(setFOILoader(false));
           }
         })
         .catch((error) => {
-          console.log(`Error while fetching assigned to master data based on requestType ${requestType}`, error);
+          console.log(
+            `Error while fetching assigned to master data based on requestType ${requestType}`,
+            error
+          );
           dispatch(serviceActionError(error));
           dispatch(setFOILoader(false));
         });
     };
   };
-  
+
   export const fetchFOIFullAssignedToList = (...rest) => {
     let fullnameTeamArray = getFullnameTeamList();
-    if(!fullnameTeamArray || !Array.isArray(fullnameTeamArray)) {
+    if (!fullnameTeamArray || !Array.isArray(fullnameTeamArray)) {
       fullnameTeamArray = [];
     }
-  
-      if(fullnameTeamArray.includes("iao")) {
+
+    if (fullnameTeamArray.includes("iao")) {
       return (dispatch) => {
         dispatch(setFOIFullAssignedToList(getAssignToList("iao")));
         dispatch(setFOIAssignedToListLoader(false));
       };
-  
-      } else {
-        const done = fnDone(rest);
-  
+    } else {
+      const done = fnDone(rest);
+
       return (dispatch) => {
-        httpGETRequest(API.FOI_GET_ASSIGNEDTO_ALLGROUP_LIST_API, {}, UserService.getToken())
+        httpGETRequest(
+          API.FOI_GET_ASSIGNEDTO_ALLGROUP_LIST_API,
+          {},
+          UserService.getToken()
+        )
           .then((res) => {
             if (res.data) {
               const foiFullAssignedToList = res.data;
@@ -170,19 +179,24 @@ import {
               dispatch(setFOIAssignedToListLoader(false));
               done(null, res.data);
             } else {
-              console.log("Error while fetching IAO assigned to master data", res);
+              console.log(
+                "Error while fetching IAO assigned to master data",
+                res
+              );
               dispatch(serviceActionError(res));
               dispatch(setFOIAssignedToListLoader(false));
             }
           })
           .catch((error) => {
-            console.log("Error while fetching IAO assigned to master data", error);
+            console.log(
+              "Error while fetching IAO assigned to master data",
+              error
+            );
             dispatch(serviceActionError(error));
             dispatch(setFOIAssignedToListLoader(false));
             done(error);
           });
       };
-  
     }
   };
   

--- a/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
@@ -155,10 +155,9 @@ export const fetchFOIMinistryRequestListByPage = (page = 1, size = 10, sort = [{
 };
 
 export const fetchFOIRequestDetailsWrapper = (requestId, ministryId) => {
-  if(ministryId) {
+  if (ministryId) {
     return fetchFOIRequestDetails(requestId, ministryId);
-  }
-  else {
+  } else {
     return fetchFOIRawRequestDetails(requestId);
   }
 };

--- a/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
@@ -29,7 +29,6 @@ export const fetchFOIRequestList = () => {
             return { ...foiRequest };
           });
           dispatch(clearRequestDetails({}));
-          dispatch(fetchFOIAssignedToList("", "", ""));
           dispatch(setFOIRequestList(data));
         } else {
           dispatch(serviceActionError(res));
@@ -77,7 +76,6 @@ export const fetchFOIRequestListByPage = (
       .then((res) => {
         if (res.data) {
           dispatch(clearRequestDetails({}));
-          dispatch(fetchFOIAssignedToList("", "", ""));
           dispatch(setFOIRequestList(res.data));
         } else {
           dispatch(serviceActionError(res));

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/Dashboard/IAO/Queue.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/Dashboard/IAO/Queue.js
@@ -37,9 +37,6 @@ const Queue = ({ userDetail, tableInfo }) => {
   const isLoading = useSelector((state) => state.foiRequests.isLoading);
 
   const classes = useStyles();
-  useEffect(() => {
-    dispatch(fetchFOIRequestListByPage());
-  }, [dispatch]);
 
   const defaultRowsState = { page: 0, pageSize: 10 };
   const [rowsState, setRowsState] = React.useState(defaultRowsState);

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/Dashboard/MinistryDashboard.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/Dashboard/MinistryDashboard.js
@@ -12,71 +12,96 @@ import useStyles from './CustomStyle';
 import { useDispatch, useSelector } from "react-redux";
 import {push} from "connected-react-router";
 import { fetchFOIMinistryRequestListByPage } from "../../../apiManager/services/FOI/foiRequestServices";
-import { fetchFOIFullAssignedToList } from "../../../apiManager/services/FOI/foiMasterDataServices";
 import { formatDate } from "../../../helper/FOI/helper";
 import Loading from "../../../containers/Loading";
-import { StateEnum } from '../../../constants/FOI/statusEnum';
-import { debounce } from './utils';
-import Grid from "@material-ui/core/Grid"
-import Radio from "@material-ui/core/Radio"
-import RadioGroup from "@material-ui/core/RadioGroup"
-import FormControlLabel from "@material-ui/core/FormControlLabel"
-import SearchIcon from '@material-ui/icons/Search';
+import { StateEnum } from "../../../constants/FOI/statusEnum";
+import { debounce } from "./utils";
+import Grid from "@material-ui/core/Grid";
+import Radio from "@material-ui/core/Radio";
+import RadioGroup from "@material-ui/core/RadioGroup";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import SearchIcon from "@material-ui/icons/Search";
 
-const MinistryDashboard = ({userDetail}) => {
+const MinistryDashboard = ({ userDetail }) => {
+  const dispatch = useDispatch();
 
-  const dispatch = useDispatch(); 
- 
-  const requestQueue = useSelector(state=> state.foiRequests.foiMinistryRequestsList);
-  const isLoading = useSelector(state=> state.foiRequests.isLoading);
+  const requestQueue = useSelector(
+    (state) => state.foiRequests.foiMinistryRequestsList
+  );
+  const isLoading = useSelector((state) => state.foiRequests.isLoading);
 
   const classes = useStyles();
-  useEffect(()=>{
-    dispatch(fetchFOIFullAssignedToList());
-    dispatch(fetchFOIMinistryRequestListByPage());
-  },[dispatch]);
 
-  const defaultRowsState = {page: 0, pageSize: 10};
+  const defaultRowsState = { page: 0, pageSize: 10 };
   const [rowsState, setRowsState] = React.useState(defaultRowsState);
-  
-  const defaultSortModel = [{field: 'currentState', sort: 'asc'}, {field: 'cfrduedate', sort: 'asc'}];
+
+  const defaultSortModel = [
+    { field: "currentState", sort: "asc" },
+    { field: "cfrduedate", sort: "asc" },
+  ];
   const [sortModel, setSortModel] = React.useState(defaultSortModel);
   let serverSortModel;
   const [filterModel, setFilterModel] = React.useState({
-    fields: ['applicantcategory', 'requestType', 'idNumber', 'currentState', 'assignedministrypersonLastName', 'assignedministrypersonFirstName'],
-    keyword: null 
+    fields: [
+      "applicantcategory",
+      "requestType",
+      "idNumber",
+      "currentState",
+      "assignedministrypersonLastName",
+      "assignedministrypersonFirstName",
+    ],
+    keyword: null,
   });
   const [requestFilter, setRequestFilter] = useState("All");
 
   useEffect(() => {
     serverSortModel = updateSortModel();
     // page+1 here, because initial page value is 0 for mui-data-grid
-    dispatch(fetchFOIMinistryRequestListByPage(rowsState.page+1, rowsState.pageSize, serverSortModel, filterModel.fields, filterModel.keyword, requestFilter, userDetail.preferred_username));
+    dispatch(
+      fetchFOIMinistryRequestListByPage(
+        rowsState.page + 1,
+        rowsState.pageSize,
+        serverSortModel,
+        filterModel.fields,
+        filterModel.keyword,
+        requestFilter,
+        userDetail.preferred_username
+      )
+    );
   }, [rowsState, sortModel, filterModel, requestFilter]);
 
   // update sortModel for records due, ldd & assignedTo
-  const updateSortModel = (() => {
+  const updateSortModel = () => {
     let smodel = JSON.parse(JSON.stringify(sortModel));
-    if(smodel) {
-      smodel.map( (row) => {
-        if(row.field === 'CFRDueDateValue' || row.field === 'DueDateValue')
-          row.field = 'cfrduedate';
+    if (smodel) {
+      smodel.map((row) => {
+        if (row.field === "CFRDueDateValue" || row.field === "DueDateValue")
+          row.field = "cfrduedate";
       });
 
       let field = smodel[0]?.field;
       let order = smodel[0]?.sort;
-      if(field == 'assignedToName') {
+      if (field == "assignedToName") {
         smodel.shift();
-        smodel.unshift({field: 'assignedministrypersonLastName', sort: order},{field: 'assignedministrypersonFirstName', sort: order})
+        smodel.unshift(
+          { field: "assignedministrypersonLastName", sort: order },
+          { field: "assignedministrypersonFirstName", sort: order }
+        );
       }
     }
 
     return smodel;
-  });
+  };
 
   function getAssigneeValue(row) {
-    const groupName = row.assignedministrygroup ? row.assignedministrygroup : "Unassigned";
-    return row.assignedministryperson && row.assignedministrypersonFirstName && row.assignedministrypersonLastName ? `${row.assignedministrypersonLastName}, ${row.assignedministrypersonFirstName}` : groupName;    
+    const groupName = row.assignedministrygroup
+      ? row.assignedministrygroup
+      : "Unassigned";
+    return row.assignedministryperson &&
+      row.assignedministrypersonFirstName &&
+      row.assignedministrypersonLastName
+      ? `${row.assignedministrypersonLastName}, ${row.assignedministrypersonFirstName}`
+      : groupName;
   }
 
   function getRecordsDue(params) {
@@ -100,185 +125,209 @@ const MinistryDashboard = ({userDetail}) => {
   }
 
   const columns = React.useRef([
-    { 
-      field: 'idNumber', 
-      headerName: 'ID NUMBER',
-      width: 150, 
-      headerAlign: 'left',      
+    {
+      field: "idNumber",
+      headerName: "ID NUMBER",
+      width: 150,
+      headerAlign: "left",
     },
-    { 
-      field: 'applicantcategory', 
-      headerName: 'APPLICANT TYPE',  
-      width: 180, 
-      headerAlign: 'left'    
-    },
-    { 
-      field: 'requestType', 
-      headerName: 'REQUEST TYPE',  
-      width: 150, 
-      headerAlign: 'left'       
-    },
-    
-    { field: 'currentState', 
-      headerName: 'REQUEST STATE',  
-      width: 180, 
-      headerAlign: 'left'      
-    },    
-    {      
-      field: 'assignedToName',
-      headerName: 'ASSIGNEE',
+    {
+      field: "applicantcategory",
+      headerName: "APPLICANT TYPE",
       width: 180,
-      headerAlign: 'left',
+      headerAlign: "left",
     },
-    { 
-      field: 'CFRDueDateValue', 
-      headerName: 'RECORDS DUE', 
-      width: 150,    
-      headerAlign: 'left',
+    {
+      field: "requestType",
+      headerName: "REQUEST TYPE",
+      width: 150,
+      headerAlign: "left",
+    },
+
+    {
+      field: "currentState",
+      headerName: "REQUEST STATE",
+      width: 180,
+      headerAlign: "left",
+    },
+    {
+      field: "assignedToName",
+      headerName: "ASSIGNEE",
+      width: 180,
+      headerAlign: "left",
+    },
+    {
+      field: "CFRDueDateValue",
+      headerName: "RECORDS DUE",
+      width: 150,
+      headerAlign: "left",
       valueGetter: getRecordsDue,
-    },    
-    { 
-      field: 'DueDateValue', 
-      headerName: 'LDD', 
-      width: 150,    
-      headerAlign: 'left',
+    },
+    {
+      field: "DueDateValue",
+      headerName: "LDD",
+      width: 150,
+      headerAlign: "left",
       valueGetter: getLDD,
     },
-    { field: 'cfrduedate', headerName: '', width: 0, hide: true, renderCell:(params)=>(<span></span>)}
+    {
+      field: "cfrduedate",
+      headerName: "",
+      width: 0,
+      hide: true,
+      renderCell: (params) => <span></span>,
+    },
   ]);
 
+  const requestFilterChange = (e) => {
+    setRowsState(defaultRowsState);
+    setRequestFilter(e.target.value);
+  };
 
-const requestFilterChange = (e) => { 
-  setRowsState(defaultRowsState);
-  setRequestFilter(e.target.value);
-}
+  const setSearch = debounce((e) => {
+    var keyword = e.target.value;
+    setFilterModel((prev) => ({ ...prev, keyword }));
+    setRowsState(defaultRowsState);
+  }, 500);
 
-const setSearch = debounce((e) => {
-  var keyword = e.target.value;
-  setFilterModel((prev) => ({ ...prev, keyword}));
-  setRowsState(defaultRowsState);
-}, 500)
+  const updateAssigneeName = (data) => {
+    if (data)
+      return data.map((row) => ({
+        ...row,
+        assignedToName: getAssigneeValue(row),
+      }));
+    else return data;
+  };
 
-const updateAssigneeName = (data) => {
-  if(data)
-    return data.map(row=> ({ ...row, assignedToName: getAssigneeValue(row) }));
-  else
-    return data;
-}
+  const renderReviewRequest = (e) => {
+    if (e.row.ministryrequestid) {
+      dispatch(
+        push(
+          `/foi/ministryreview/${e.row.id}/ministryrequest/${e.row.ministryrequestid}`
+        )
+      );
+    }
+  };
 
-const renderReviewRequest = (e) => {
-  if (e.row.ministryrequestid) {    
-    dispatch(push(`/foi/ministryreview/${e.row.id}/ministryrequest/${e.row.ministryrequestid}`));
-  }
-}
-
-return (
-  <div className="container foi-container">
-    <Grid container direction="row" className="foi-grid-container" spacing={1}>
+  return (
+    <div className="container foi-container">
       <Grid
-        item
         container
         direction="row"
-        alignItems="center"
-        xs={12}
-        className="foi-dashboard-row2"
+        className="foi-grid-container"
+        spacing={1}
       >
-        <Grid item xs={12}>
-          <h3 className="foi-request-queue-text">Your FOI Request Queue</h3>
+        <Grid
+          item
+          container
+          direction="row"
+          alignItems="center"
+          xs={12}
+          className="foi-dashboard-row2"
+        >
+          <Grid item xs={12}>
+            <h3 className="foi-request-queue-text">Your FOI Request Queue</h3>
+          </Grid>
         </Grid>
-      </Grid>
-      <>
-        {!isLoading ? (
-          <>
-            <Grid item container alignItems="center" xs={12}>
-              <Grid item xs={12} lg={6} className="form-group has-search">
-                <SearchIcon className="form-control-search" />
-                <input
-                  type="text"
-                  className="form-control"
-                  placeholder="Search . . ."
-                  onChange={setSearch}
+        <>
+          {!isLoading ? (
+            <>
+              <Grid item container alignItems="center" xs={12}>
+                <Grid item xs={12} lg={6} className="form-group has-search">
+                  <SearchIcon className="form-control-search" />
+                  <input
+                    type="text"
+                    className="form-control"
+                    placeholder="Search . . ."
+                    onChange={setSearch}
+                  />
+                </Grid>
+
+                <Grid item container lg={6} xs={12} justifyContent="flex-end">
+                  <RadioGroup
+                    name="controlled-radio-buttons-group"
+                    value={requestFilter}
+                    onChange={requestFilterChange}
+                    row
+                  >
+                    <FormControlLabel
+                      className="form-control-label"
+                      value="myRequests"
+                      control={<Radio className="mui-radio" color="primary" />}
+                      label="My Requests"
+                    />
+                    <FormControlLabel
+                      className="form-control-label"
+                      value="watchingRequests"
+                      control={<Radio className="mui-radio" color="primary" />}
+                      label="Watching Requests"
+                    />
+                    <FormControlLabel
+                      className="form-control-label"
+                      value="All"
+                      control={<Radio className="mui-radio" color="primary" />}
+                      label="My Team Requests"
+                    />
+                  </RadioGroup>
+                </Grid>
+              </Grid>
+              <Grid
+                item
+                xs={12}
+                style={{ height: 450 }}
+                className={classes.root}
+              >
+                <DataGrid
+                  className="foi-data-grid"
+                  getRowId={(row) => row.idNumber}
+                  rows={updateAssigneeName(requestQueue.data)}
+                  columns={columns.current}
+                  rowHeight={30}
+                  headerHeight={50}
+                  rowCount={requestQueue?.meta?.total}
+                  pageSize={rowsState.pageSize}
+                  rowsPerPageOptions={[10]}
+                  hideFooterSelectedRowCount={true}
+                  disableColumnMenu={true}
+                  pagination
+                  paginationMode="server"
+                  page={rowsState.page}
+                  onPageChange={(page) =>
+                    setRowsState((prev) => ({ ...prev, page }))
+                  }
+                  onPageSizeChange={(pageSize) =>
+                    setRowsState((prev) => ({ ...prev, pageSize }))
+                  }
+                  components={{
+                    Pagination: CustomPagination,
+                  }}
+                  sortingOrder={["desc", "asc"]}
+                  sortModel={sortModel}
+                  sortingMode={"server"}
+                  onSortModelChange={(model) => setSortModel(model)}
+                  getRowClassName={(params) =>
+                    `super-app-theme--${params.row.currentState
+                      .toLowerCase()
+                      .replace(/ +/g, "")}-${params.row.cfrstatus
+                      .toLowerCase()
+                      .replace(/ +/g, "")}`
+                  }
+                  onRowClick={renderReviewRequest}
+                  loading={isLoading}
                 />
               </Grid>
-
-              <Grid item container lg={6} xs={12} justifyContent="flex-end">
-                <RadioGroup
-                  name="controlled-radio-buttons-group"
-                  value={requestFilter}
-                  onChange={requestFilterChange}
-                  row
-                >
-                  <FormControlLabel
-                    className="form-control-label"
-                    value="myRequests"
-                    control={<Radio className="mui-radio" color="primary" />}
-                    label="My Requests"
-                  />
-                  <FormControlLabel
-                    className="form-control-label"
-                    value="watchingRequests"
-                    control={<Radio className="mui-radio" color="primary" />}
-                    label="Watching Requests"
-                  />
-                  <FormControlLabel
-                    className="form-control-label"
-                    value="All"
-                    control={<Radio className="mui-radio" color="primary" />}
-                    label="My Team Requests"
-                  />
-                </RadioGroup>
-              </Grid>
-            </Grid>
-            <Grid item xs={12} style={{ height: 450 }} className={classes.root}>
-              <DataGrid
-                className="foi-data-grid"
-                getRowId={(row) => row.idNumber}
-                rows={updateAssigneeName(requestQueue.data)}
-                columns={columns.current}
-                rowHeight={30}
-                headerHeight={50}
-                rowCount={requestQueue?.meta?.total}
-                pageSize={rowsState.pageSize}
-                rowsPerPageOptions={[10]}
-                hideFooterSelectedRowCount={true}
-                disableColumnMenu={true}
-                pagination
-                paginationMode="server"
-                page = {rowsState.page}
-                onPageChange={(page) =>
-                  setRowsState((prev) => ({ ...prev, page }))
-                }
-                onPageSizeChange={(pageSize) =>
-                  setRowsState((prev) => ({ ...prev, pageSize }))
-                }
-                components={{
-                  Pagination: CustomPagination,
-                }}
-                sortingOrder={["desc", "asc"]}
-                sortModel={sortModel}
-                sortingMode={"server"}
-                onSortModelChange={(model) => setSortModel(model)}
-                getRowClassName={(params) =>
-                  `super-app-theme--${params.row.currentState
-                    .toLowerCase()
-                    .replace(/ +/g, "")}-${params.row.cfrstatus
-                    .toLowerCase()
-                    .replace(/ +/g, "")}`
-                }
-                onRowClick={renderReviewRequest}
-                loading={isLoading}
+            </>
+          ) : (
+            <Grid item xs={12} container alignItems="center">
+              <Loading
+                costumStyle={{ position: "relative", marginTop: "4em" }}
               />
             </Grid>
-          </>
-        ) : (
-          <Grid item xs={12} container alignItems="center">
-            <Loading costumStyle={{ position: "relative", marginTop: "4em" }} />
-          </Grid>
-        )}
-      </>
-    </Grid>
-  </div>
-);
+          )}
+        </>
+      </Grid>
+    </div>
+  );
 };
 
 const CustomPagination = () => {

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/ExtensionDetails/ActionContext.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/ExtensionDetails/ActionContext.js
@@ -19,26 +19,26 @@ export const ActionProvider = ({ children, requestDetails }) => {
 
   const [saveModalOpen, setSaveModalOpen] = useState(false);
   const [extensionLoading, setExtensionLoading] = useState(true)
-  const [extensionReasons, setExtensionReasons] = useState()
+  const [extensionReasons, setExtensionReasons] = useState(null);
 
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
-  const [extensionId, setExtensionId] = useState(null)
-  const [selectedExtension, setSelectedExtension] = useState(null)
+  const [extensionId, setExtensionId] = useState(null);
+  const [selectedExtension, setSelectedExtension] = useState(null);
 
-  const currentDueDate = formatDate(requestDetails.dueDate)
+  const currentDueDate = formatDate(requestDetails.dueDate);
   const startDate = formatDate(requestDetails.requestProcessStart);
   const originalDueDate = formatDate(requestDetails.originalDueDate);
   const extensions = useSelector(
     (state) => state.foiRequests.foiRequestExtesions
   );
-  const idNumber = requestDetails?.idNumber
+  const idNumber = requestDetails?.idNumber;
   const pendingExtensionExists = extensions.some(
     (ex) => ex.extensionstatusid === extensionStatusId.pending
   );
 
   useEffect(() => {
-    if (requestId) {
+    if (requestId && !extensionReasons) {
       fetchExtensionReasons({
         callback: (data) => {
           setExtensionReasons(data);

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -155,15 +155,13 @@ const FOIRequest = React.memo(({ userDetail }) => {
       dispatch(fetchFOIRequestAttachmentsList(requestId, ministryId));
     }
 
-    dispatch(fetchFOIFullAssignedToList());
     dispatch(fetchFOICategoryList());
     dispatch(fetchFOIProgramAreaList());
     dispatch(fetchFOIReceivedModeList());
     dispatch(fetchFOIDeliveryModeList());
     dispatch(fetchClosingReasonList());
 
-    if (bcgovcode)
-      dispatch(fetchFOIMinistryAssignedToList(bcgovcode));
+    if (bcgovcode) dispatch(fetchFOIMinistryAssignedToList(bcgovcode));
   }, [requestId, ministryId, comment, attachments]);
 
 

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -148,8 +148,7 @@ const FOIRequest = React.memo(({ userDetail }) => {
   useEffect(() => {
     if (isAddRequest) {
       dispatch(fetchFOIAssignedToList("", "", ""));
-    }
-    else {
+    } else {
       dispatch(fetchFOIRequestDetailsWrapper(requestId, ministryId));
       dispatch(fetchFOIRequestDescriptionList(requestId, ministryId));
       dispatch(fetchFOIRequestNotesList(requestId, ministryId));

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/MinistryReview.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/MinistryReview.js
@@ -152,7 +152,6 @@ const MinistryReview = React.memo(({ userDetail }) => {
       dispatch(fetchFOIRequestDescriptionList(requestId, ministryId));
       dispatch(fetchFOIRequestNotesList(requestId, ministryId));
       dispatch(fetchFOIRequestAttachmentsList(requestId, ministryId));
-      dispatch(fetchFOIFullAssignedToList());
       if (bcgovcode) dispatch(fetchFOIMinistryAssignedToList(bcgovcode));
     }
   }, [requestId]);

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/MinistryReview.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/MinistryReview.js
@@ -487,7 +487,6 @@ const MinistryReview = React.memo(({ userDetail }) => {
                 : ""}
             </div>
             <div
-              className="tablinks"
               className={clsx("tablinks", {
                 active: tabLinksStatuses.Option4.active,
               })}

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/RequestHeader.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/RequestHeader.js
@@ -15,14 +15,18 @@ const RequestHeader = React.memo(({requestDetails, userDetail, handleMinistryAss
     const _requestDetails = requestDetails;
     const ministryAssignedToList = useSelector(state=> state.foiRequests.foiMinistryAssignedToList);
     const requestState = requestDetails?.currentState;
+    const assignedToList = useSelector(
+      (state) => state.foiRequests.foiFullAssignedToList
+    );
     const preventDefault = (event) => event.preventDefault();
 
     const dispatch = useDispatch();
     useEffect(() => {
-      dispatch(fetchFOIFullAssignedToList());
-    },[dispatch]); 
+      if (!assignedToList || assignedToList.length === 0) {
+        dispatch(fetchFOIFullAssignedToList());
+      }
+    }, [dispatch]); 
 
-    const assignedToList = useSelector((state) => state.foiRequests.foiFullAssignedToList);
     function getFullName(assignedToList, requestDetails) {
         const groupName = requestDetails.assignedGroup ? requestDetails.assignedGroup : "Unassigned";
         const assignedTo = requestDetails.assignedTo ? requestDetails.assignedTo : groupName;

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/utils.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/utils.js
@@ -8,7 +8,6 @@ export const getMinistryBottomTextMap = (
   _cfrDaysRemaining,
   requestExtensions
 ) => {
-  console.log(requestDetails);
   const _daysRemaining = calculateDaysRemaining(requestDetails.dueDate);
 
   const _daysRemainingText =

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/Header/FOIHeader.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/Header/FOIHeader.js
@@ -14,148 +14,192 @@ import {
 } from "../../../apiManager/services/FOI/foiNotificationServices";
 import {isMinistryLogin, getMinistryCode} from "../../../helper/FOI/helper";
 import io from "socket.io-client";
-import {SOCKETIO_CONNECT_URL, SOCKETIO_RECONNECTION_DELAY, SOCKETIO_RECONNECTION_DELAY_MAX} from "../../../constants/constants";
-import { fetchFOIFullAssignedToList } from "../../../apiManager/services/FOI/foiMasterDataServices";
+import {
+  SOCKETIO_CONNECT_URL,
+  SOCKETIO_RECONNECTION_DELAY,
+  SOCKETIO_RECONNECTION_DELAY_MAX,
+} from "../../../constants/constants";
 
+const FOIHeader = React.memo(({ unauthorized = false }) => {
+  const dispatch = useDispatch();
+  const isAuthenticated = useSelector((state) => state.user.isAuthenticated);
+  const user = useSelector((state) => state.user.userDetail);
+  let isMinistry = false;
+  let ministryCode = "";
+  const [screenPosition, setScreenPosition] = useState(0);
+  const [open, setOpen] = useState(false);
+  const closeModal = () => setOpen(false);
+  const openModal = (coordinates) => {
+    const screenX = coordinates.pageX;
+    setScreenPosition(screenX);
+    setOpen(!open);
+  };
+  const [messageData, setMessageData] = useState([]);
+  let foiNotifications = useSelector(
+    (state) => state.notifications.foiNotifications
+  );
+  const [socket, setSocket] = useState(null);
 
-const FOIHeader = React.memo(({unauthorized=false}) => { 
+  const userGroups = user?.groups?.map((group) => group.slice(1));
+  isMinistry = isMinistryLogin(userGroups);
+  ministryCode = getMinistryCode(userGroups);
 
-const dispatch = useDispatch(); 
-const isAuthenticated = useSelector((state) => state.user.isAuthenticated);
-const user = useSelector((state) => state.user.userDetail);
-let isMinistry = false;
-let ministryCode ="";
-const [screenPosition, setScreenPosition] = useState(0);
-const [open, setOpen] = useState(false);
-const closeModal = () => setOpen(false);
-const openModal = (coordinates) => {
-  const screenX = coordinates.pageX;
-  setScreenPosition(screenX);
-  setOpen(!open);
-}
-const [messageData, setMessageData] = useState([]);
-let foiNotifications = useSelector(state=> state.notifications.foiNotifications);
-const [socket, setSocket] = useState(null);
-
-const userGroups = user?.groups?.map(group => group.slice(1));
-isMinistry = isMinistryLogin(userGroups);
-ministryCode = getMinistryCode(userGroups);
-
-useEffect(() => {     
-  if(!unauthorized && isAuthenticated){
-    dispatch(fetchFOIFullAssignedToList());
-    dispatch(fetchFOINotifications());  
-    const options = {
-      reconnectionDelay:SOCKETIO_RECONNECTION_DELAY?SOCKETIO_RECONNECTION_DELAY:20000,
-      reconnectionDelayMax:SOCKETIO_RECONNECTION_DELAY_MAX?SOCKETIO_RECONNECTION_DELAY_MAX :30000,
-      path:'/api/v1/socket.io',
-      transports: ['websocket'],
-      auth: { "x-jwt-token": UserService.getToken() }
-    };
-    setSocket(io.connect(SOCKETIO_CONNECT_URL, options));
-  
-    setInterval(() => {
+  useEffect(() => {
+    if (!unauthorized && isAuthenticated) {
       dispatch(fetchFOINotifications());
-    }, 900000);
-  }
-},[]);
+      const options = {
+        reconnectionDelay: SOCKETIO_RECONNECTION_DELAY
+          ? SOCKETIO_RECONNECTION_DELAY
+          : 20000,
+        reconnectionDelayMax: SOCKETIO_RECONNECTION_DELAY_MAX
+          ? SOCKETIO_RECONNECTION_DELAY_MAX
+          : 30000,
+        path: "/api/v1/socket.io",
+        transports: ["websocket"],
+        auth: { "x-jwt-token": UserService.getToken() },
+      };
+      setSocket(io.connect(SOCKETIO_CONNECT_URL, options));
 
-useEffect(() => {     
-    socket?.on(user.preferred_username, data => {
-     if(data.action === 'delete'){
-      setMessageData((oldMessageData) => oldMessageData.filter((msg) => msg.notificationid !== data.notificationid))
-     }
-     else{
-      setMessageData(oldMessageData => [data, ...oldMessageData])
-     }
+      setInterval(() => {
+        dispatch(fetchFOINotifications());
+      }, 900000);
+    }
+  }, []);
+
+  useEffect(() => {
+    socket?.on(user.preferred_username, (data) => {
+      if (data.action === "delete") {
+        setMessageData((oldMessageData) =>
+          oldMessageData.filter(
+            (msg) => msg.notificationid !== data.notificationid
+          )
+        );
+      } else {
+        setMessageData((oldMessageData) => [data, ...oldMessageData]);
+      }
     });
-  },[socket]);
+  }, [socket]);
 
-useEffect(() => {     
-  if(foiNotifications){
-    setMessageData(foiNotifications);
-  }
-},[foiNotifications]);
+  useEffect(() => {
+    if (foiNotifications) {
+      setMessageData(foiNotifications);
+    }
+  }, [foiNotifications]);
 
-
- const signout = () => {
+  const signout = () => {
     socket?.disconnect();
-    localStorage.removeItem('authToken');
+    localStorage.removeItem("authToken");
     dispatch(push(`/`));
-    UserService.userLogout(); 
-}
+    UserService.userLogout();
+  };
 
-const triggerPopup = () => {
-  return(
-    <> 
-    <Badge badgeContent={messageData?.length} color="secondary">
-      <i style={{color: open? "#003366" : "white",cursor: "pointer"}} className="fa fa-bell-o foi-bell"></i>
-    </Badge>
-   </>
-  )
-}
+  const triggerPopup = () => {
+    return (
+      <>
+        <Badge badgeContent={messageData?.length} color="secondary">
+          <i
+            style={{ color: open ? "#003366" : "white", cursor: "pointer" }}
+            className="fa fa-bell-o foi-bell"
+          ></i>
+        </Badge>
+      </>
+    );
+  };
 
   return (
     <div>
-    <div className="row ">
-    <Navbar collapseOnSelect fixed="top" expand="sm" bg="#036" variant="dark" style={{borderBottom: "2px solid #fcba19"}}>
-      <Container className="foiContainer" style={{maxHeight: "45px"}}>
-        <Nav className="ml-auto">  
-        <div className="col-md-12 col-sm-12">
-          <div className="col-md-3 col-sm-4 foiheaderLogosection">
-          <a href="/foi/dashboard" alt="British Columbia">
-              <img src={logo} alt="Go to the Government of British Columbia website" />
-            </a>
-          </div>
-          <div className="col-md-3 col-sm-4 foiheaderAppNamesection">
-          <h2>FOI</h2>
-          </div>
-            <div className="col-md-6 col-sm-4 foiheaderUserStatusSection">
-          { isAuthenticated &&
-          <>
-            <Navbar.Toggle aria-controls="responsive-navbar-nav" className="foiNavBarToggle" />
-            <Navbar.Collapse id="responsive-navbar-nav">
-              <Nav className="ml-auto">
-                <div className="ml-auto banner-right foihamburgermenu">       
-                  <ul className="navbar-nav foihamburgermenulist">
-                      <li className="nav-item username foinavitem">
-                          <span className="navbar-text">  {user.name || user.preferred_username || ""} </span>
-                      </li>
-                      <li className="bell-icon foinavitem" >
-                      <div onClick={(e) => openModal(e)} className={`drawer-div ${open && 'notification-popup-drawer'}`}>
-                        <Popup className="notification-popup" 
-                        role='tooltip'
-                        open={open} 
-                        onClose={closeModal}
-                        trigger={
-                          triggerPopup
-                        }
-                        nested
-                        closeOnDocumentClick 
-                        contentStyle={{left: `${(screenPosition - 300)}px`}}
-                        position={'bottom right'}
-                        >
-                        <NotificationPopup notifications={messageData} isMinistry ={isMinistry}
-                        ministryCode ={ministryCode} ></NotificationPopup>
-                        </Popup>
-                      </div>
-                      </li>
-                      <li className="nav-item foinavitem">
-                        <button type="button" className="btn btn-primary signout-btn" onClick={signout}>Sign Out</button>
-                      </li>
-                  </ul>
+      <div className="row ">
+        <Navbar
+          collapseOnSelect
+          fixed="top"
+          expand="sm"
+          bg="#036"
+          variant="dark"
+          style={{ borderBottom: "2px solid #fcba19" }}
+        >
+          <Container className="foiContainer" style={{ maxHeight: "45px" }}>
+            <Nav className="ml-auto">
+              <div className="col-md-12 col-sm-12">
+                <div className="col-md-3 col-sm-4 foiheaderLogosection">
+                  <a href="/foi/dashboard" alt="British Columbia">
+                    <img
+                      src={logo}
+                      alt="Go to the Government of British Columbia website"
+                    />
+                  </a>
                 </div>
-              </Nav>
-            </Navbar.Collapse>   
-            </>    
-          }
-          </div>
-          </div>
-      </Nav>      
-    </Container>    
-         </Navbar>   
-         </div>
-         </div>
+                <div className="col-md-3 col-sm-4 foiheaderAppNamesection">
+                  <h2>FOI</h2>
+                </div>
+                <div className="col-md-6 col-sm-4 foiheaderUserStatusSection">
+                  {isAuthenticated && (
+                    <>
+                      <Navbar.Toggle
+                        aria-controls="responsive-navbar-nav"
+                        className="foiNavBarToggle"
+                      />
+                      <Navbar.Collapse id="responsive-navbar-nav">
+                        <Nav className="ml-auto">
+                          <div className="ml-auto banner-right foihamburgermenu">
+                            <ul className="navbar-nav foihamburgermenulist">
+                              <li className="nav-item username foinavitem">
+                                <span className="navbar-text">
+                                  {" "}
+                                  {user.name ||
+                                    user.preferred_username ||
+                                    ""}{" "}
+                                </span>
+                              </li>
+                              <li className="bell-icon foinavitem">
+                                <div
+                                  onClick={(e) => openModal(e)}
+                                  className={`drawer-div ${
+                                    open && "notification-popup-drawer"
+                                  }`}
+                                >
+                                  <Popup
+                                    className="notification-popup"
+                                    role="tooltip"
+                                    open={open}
+                                    onClose={closeModal}
+                                    trigger={triggerPopup}
+                                    nested
+                                    closeOnDocumentClick
+                                    contentStyle={{
+                                      left: `${screenPosition - 300}px`,
+                                    }}
+                                    position={"bottom right"}
+                                  >
+                                    <NotificationPopup
+                                      notifications={messageData}
+                                      isMinistry={isMinistry}
+                                      ministryCode={ministryCode}
+                                    ></NotificationPopup>
+                                  </Popup>
+                                </div>
+                              </li>
+                              <li className="nav-item foinavitem">
+                                <button
+                                  type="button"
+                                  className="btn btn-primary signout-btn"
+                                  onClick={signout}
+                                >
+                                  Sign Out
+                                </button>
+                              </li>
+                            </ul>
+                          </div>
+                        </Nav>
+                      </Navbar.Collapse>
+                    </>
+                  )}
+                </div>
+              </div>
+            </Nav>
+          </Container>
+        </Navbar>
+      </div>
+    </div>
   );
 });
 export default FOIHeader;

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/Header/FOIHeader.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/Header/FOIHeader.js
@@ -9,16 +9,15 @@ import logo from "../../../assets/FOI/images/logo-banner.png";
 import {push} from "connected-react-router";
 import Popup from 'reactjs-popup';
 import NotificationPopup from "./NotificationPopup/NotificationPopup";
-import {
-  fetchFOINotifications
-} from "../../../apiManager/services/FOI/foiNotificationServices";
-import {isMinistryLogin, getMinistryCode} from "../../../helper/FOI/helper";
+import { fetchFOINotifications } from "../../../apiManager/services/FOI/foiNotificationServices";
+import { isMinistryLogin, getMinistryCode } from "../../../helper/FOI/helper";
 import io from "socket.io-client";
 import {
   SOCKETIO_CONNECT_URL,
   SOCKETIO_RECONNECTION_DELAY,
   SOCKETIO_RECONNECTION_DELAY_MAX,
 } from "../../../constants/constants";
+import { fetchFOIFullAssignedToList } from "../../../apiManager/services/FOI/foiMasterDataServices";
 
 const FOIHeader = React.memo(({ unauthorized = false }) => {
   const dispatch = useDispatch();
@@ -46,6 +45,7 @@ const FOIHeader = React.memo(({ unauthorized = false }) => {
 
   useEffect(() => {
     if (!unauthorized && isAuthenticated) {
+      dispatch(fetchFOIFullAssignedToList());
       dispatch(fetchFOINotifications());
       const options = {
         reconnectionDelay: SOCKETIO_RECONNECTION_DELAY


### PR DESCRIPTION
Fixes for :

- Two calls get triggered for /dashboard pagination . Avoid duplicate call.
- There is no need to call the endpoint /intake team with the new approach of dashboard (2 calls)
