### PR TITLE
update token refresh and values and set using constants

### DIFF
--- a/apps/forms-flow-ai/forms-flow-web/src/services/UserService.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/services/UserService.js
@@ -20,6 +20,8 @@ import {
 } from "../helper/FOI/helper";
 
 const jwt = require("jsonwebtoken");
+const tokenRefreshInterval = 180000; // how often we should check for token expiry --> 180000 = 3 mins
+const tokenUpdateThreshold = 600; // if token expires in less than 10 minutes (600 seconds), refresh token
 
 /**
  * Initializes Keycloak instance and calls the provided callback function if successfully authenticated.
@@ -70,7 +72,7 @@ let refreshInterval;
 const refreshToken = (store) => {
   refreshInterval = setInterval(() => {
     KeycloakData &&
-      KeycloakData.updateToken(5)
+      KeycloakData.updateToken(tokenUpdateThreshold)
         .then((refreshed) => {
           if (refreshed) {
             store.dispatch(setUserToken(KeycloakData.token));
@@ -80,7 +82,7 @@ const refreshToken = (store) => {
           console.log(error);
           userLogout();
         });
-  }, 6000);
+  }, tokenRefreshInterval);
 };
 
 /**


### PR DESCRIPTION
externalizing these values is not needed since it should be much shorter than either access or refresh token lifespan
keycloak will automatically check if access token is expiring before requesting new token
access token lifespan has been updated in dev to 1 hour
refresh token lifespan remains at 12 hours
this means user will still be logged in for 12 hours, while getting new access token every hour