### PR TITLE
Assigning myself to a request and syncing with AXIS (#1903)

### DIFF
--- a/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
@@ -270,7 +270,6 @@ export const saveRequestDetails = (data, urlIndexCreateRequest, requestId, minis
     httpPOSTRequest(apiUrl, data)
       .then((res) => {
         if (res.data) {
-          console.log("Request saved successfully!");
           done(null, res.data);
         } else {
           dispatch(serviceActionError(res));
@@ -291,7 +290,6 @@ export const openRequestDetails = (data, ...rest) => {
       .then((res) => {
         if (res.data) {
           done(null, res.data);
-          console.log("Request opened successfully!");
         } else {
           dispatch(serviceActionError(res));
           throw new Error("Error while opening the request");
@@ -318,7 +316,6 @@ export const saveMinistryRequestDetails = (data, requestId, ministryId, ...rest)
         .then((res) => {
           if (res.data) {
             done(null, res.data);
-            console.log("Request saved successfully!");
           } else {
             dispatch(serviceActionError(res));
             throw new Error(`Error while saving the ministry request (request# ${requestId}, ministry# ${ministryId})`);            
@@ -410,7 +407,7 @@ export const fetchExistingAxisRequestIds = (...rest) => {
   }
 };
 
-export const fetchRequestDataFromAxis = (axisRequestId, isModal, ...rest) => {
+export const fetchRequestDataFromAxis = (axisRequestId, isModal,requestDetails, ...rest) => {
   const done = fnDone(rest);
   const apiUrlgetRequestDetails = replaceUrl(
     API.FOI_GET_AXIS_REQUEST_DATA,
@@ -421,10 +418,18 @@ export const fetchRequestDataFromAxis = (axisRequestId, isModal, ...rest) => {
     httpGETRequest(apiUrlgetRequestDetails, {}, UserService.getToken())
       .then((res) => {
         if (res.data) {
-          if(!isModal && Object.entries(res.data).length !== 0){
-            dispatch(setFOIRequestDetail(res.data));
+          let newRequest = res.data;
+          if(!isModal && Object.entries(newRequest).length !== 0){
+            if(Object.entries(requestDetails).length !== 0){
+              newRequest['assignedGroup'] = requestDetails['assignedGroup'];
+              newRequest['assignedTo'] = requestDetails['assignedTo'];
+              newRequest['assignedToFirstName'] = requestDetails['assignedToFirstName'];
+              newRequest['assignedToLastName'] = requestDetails['assignedToLastName'];
+              newRequest['assignedToName'] = requestDetails['assignedToName'];
+            }
+            dispatch(setFOIRequestDetail(newRequest));
           }
-          done(null, res.data);
+          done(null, newRequest);
         } else {
           done(null,"Exception happened while GET operations of request");
           dispatch(serviceActionError(res));

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/AxisDetails/AxisDetails.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/AxisDetails/AxisDetails.js
@@ -14,7 +14,8 @@ const AxisDetails = React.memo(({
     handleAxisDetailsInitialValue,
     handleAxisDetailsValue,
     handleAxisIdValidation,
-    setAxisMessage
+    setAxisMessage,
+    saveRequestObject
 }) => {
     const dispatch = useDispatch();
     const [axisRequestId, setAxisRequestId] = React.useState("");
@@ -57,7 +58,7 @@ const AxisDetails = React.memo(({
     }
 
     const syncWithAxis = () => {
-        dispatch(fetchRequestDataFromAxis(axisRequestId, false, (err, data) => {
+        dispatch(fetchRequestDataFromAxis(axisRequestId, false, saveRequestObject,(err, data) => {
             if(!err){
                 if(Object.entries(data).length === 0){
                     axisIdValidation = {field: "AxisId", helperTextValue: "Invalid AXIS ID Number"}

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -204,7 +204,7 @@ const FOIRequest = React.memo(({ userDetail }) => {
       settabStatus(requestStateFromId);
       setcurrentrequestStatus(requestStateFromId);
       if(requestDetails.axisRequestId){
-        dispatch(fetchRequestDataFromAxis(requestDetails.axisRequestId, true, (err, data) => {
+        dispatch(fetchRequestDataFromAxis(requestDetails.axisRequestId, saveRequestObject ,true, (err, data) => {
           if(!err){
             if(typeof(data) !== "string" && Object.entries(data).length > 0){
               setAxisSyncedData(data);
@@ -746,6 +746,7 @@ const FOIRequest = React.memo(({ userDetail }) => {
                           handleAxisDetailsValue={handleAxisDetailsValue}
                           handleAxisIdValidation={handleAxisIdValidation}
                           setAxisMessage={setAxisMessage}
+                          saveRequestObject={saveRequestObject}
                         />
                       )}
                       <ApplicantDetails


### PR DESCRIPTION
**Description:** 
 Contains fix for the issue: Currently unable to assign myself as a user to a request before I have synced an AXIS number #1903 .

**ACs: All Passed**

**Sanity Tests Executed:**

Tested creating new request - both personal and general. Made sure all required fields are persisting data and non-mandatory fields are persisting with and with out data.
Tested state transitions and assignments, Watchers - INTAKE IN PROGRESS to CFR.
Tested login with MINISTRY VIEW with Minis. COORDIANTOR l and did state transitions.
Tested submission of  PERSONAL and GENERAL Requests from Angular App. LOCALLY.
Tested attachments, comments, notifications.
Tested Axis Sync and #1903 .