### PR TITLE
Axis Sync warning is still showing after the Sync (#2034)

### DIFF
--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -207,30 +207,8 @@ const FOIRequest = React.memo(({ userDetail }) => {
       settabStatus(requestStateFromId);
       setcurrentrequestStatus(requestStateFromId);
       setHeaderText(getHeaderText({requestDetails, ministryId, requestState}))
-      if(requestDetails.axisRequestId){
-        dispatch(fetchRequestDataFromAxis(requestDetails.axisRequestId, saveRequestObject ,true, (err, data) => {
-          if(!err){
-            if(typeof(data) !== "string" && Object.entries(data).length > 0){
-              setAxisSyncedData(data);
-              var axisDataUpdated = checkIfAxisDataUpdated(data);
-              if(axisDataUpdated){
-                setCheckExtension(false);
-                setAxisMessage("WARNING");
-              }
-            }
-            else if(data){
-              let responseMsg = data;
-              responseMsg+='';
-              if(responseMsg.indexOf("Exception happened while GET operations of request") >= 0)
-                setAxisMessage("ERROR");
-            }
-            
-          }
-          else
-            setAxisMessage("ERROR");
-
-        }));
-      }
+      if(requestDetails.axisRequestId)
+        axisBannerCheck();
     }
   }, [requestDetails]);
 
@@ -244,6 +222,31 @@ const FOIRequest = React.memo(({ userDetail }) => {
         setAxisMessage("");
     }
   }, [axisSyncedData, requestExtensions, checkExtension]);
+
+  const axisBannerCheck = () =>{
+    dispatch(fetchRequestDataFromAxis(requestDetails.axisRequestId, saveRequestObject ,true, (err, data) => {
+      if(!err){
+        if(typeof(data) !== "string" && Object.entries(data).length > 0){
+          setAxisSyncedData(data);
+          var axisDataUpdated = checkIfAxisDataUpdated(data);
+          if(axisDataUpdated){
+            setCheckExtension(false);
+            setAxisMessage("WARNING");
+          }
+          else
+            setAxisMessage("");
+        }
+        else if(data){
+          let responseMsg = data;
+          responseMsg+='';
+          if(responseMsg.indexOf("Exception happened while GET operations of request") >= 0)
+            setAxisMessage("ERROR");
+        }
+      }
+      else
+        setAxisMessage("ERROR");
+    }));
+  }
 
   const checkIfAxisDataUpdated = (axisData) => {
     var updateNeeded= false;


### PR DESCRIPTION
**Description:** 
Axis Sync warning is still showing after the Sync.(#2034)

**ACs: Passed**

**Tests Executed:**

Tested syncing a new request with AXIS Id.
Tried Editing the fields and syncing again and the banner disappears if nothing to sync.