### PR TITLE
PHN Information is getting missed on Personal FOI Request (#2048)

### DIFF
--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/AdditionalApplicantDetails.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/AdditionalApplicantDetails.js
@@ -78,7 +78,7 @@ const AdditionalApplicantDetails = React.memo(({requestDetails, createSaveReques
 
       setPersonalHealthNumber(validateField(
         requestDetails?.additionalPersonalInfo,
-        FOI_COMPONENT_CONSTANTS.IDENTITY_VERIFIED
+        FOI_COMPONENT_CONSTANTS.PERSONAL_HEALTH_NUMBER
       ));
       setIdentityVerified(validateField(
         requestDetails?.additionalPersonalInfo,


### PR DESCRIPTION
**Description :** 
PHN Information is getting missed on Personal FOI Request (#2048).

Test Executed:
Tested creating new request - both personal and general. Made sure PHN value is getting saved and is displaying.