### PR TITLE
Changes to generate request history for reason and extension days for approved and denied status.

### DIFF
--- a/request-management-api/request_api/services/events/extension.py
+++ b/request-management-api/request_api/services/events/extension.py
@@ -14,6 +14,8 @@ from enum import Enum
 from request_api.exceptions import BusinessException
 import dateutil.parser
 
+MSG_NO_CHANGE='No change'
+
 class extensionevent:
     """ FOI Event management service
 
@@ -27,7 +29,7 @@ class extensionevent:
         try:
             notificationresponse = self.createnotification(ministryrequestid, extensionid, curextension, prevextension, userid, event)
             if extensionsummaryforcomment is None or (extensionsummaryforcomment and len(extensionsummaryforcomment) < 1):
-                return  DefaultMethodResult(True,'No change',extensionid)
+                return  DefaultMethodResult(True, MSG_NO_CHANGE ,extensionid)
             else:
                 commentresponse = self.createcomment(ministryrequestid, userid, username, extensionsummaryforcomment)
                 if commentresponse.success == True:                    
@@ -53,7 +55,7 @@ class extensionevent:
                 self.__deleteaxisextensionnotifications(notificationids)
             notificationresponse = self.createnotification(ministryrequestid, extensionid, curextension, prevextension, userid, event)
             if extensionsummaryforcomment is None or (extensionsummaryforcomment and len(extensionsummaryforcomment) < 1):
-                return  DefaultMethodResult(True,'No change',extensionid)
+                return  DefaultMethodResult(True, MSG_NO_CHANGE ,extensionid)
             else:
                 FOIRequestComment().deleteextensioncommentsbyministry(ministryrequestid)
                 commentresponse = self.createcomment(ministryrequestid, userid, username, extensionsummaryforcomment)
@@ -66,8 +68,11 @@ class extensionevent:
             return DefaultMethodResult(False,'unable to post comment - '+exception.message,extensionid)  
         
     def createcomment(self, ministryrequestid, userid, username, extensionsummary):        
-        comment = {"ministryrequestid": ministryrequestid, "comment": self.__preparemessage(username, extensionsummary)}
-        return commentservice().createministryrequestcomment(comment, userid, 2)
+        _comment = self.__preparemessage(username, extensionsummary)
+        if _comment not in [None,'']:
+            return commentservice().createministryrequestcomment({"ministryrequestid": ministryrequestid, "comment": _comment}, userid, 2)
+        else:
+             return  DefaultMethodResult(True, MSG_NO_CHANGE ,ministryrequestid)
 
     def createnotification(self, ministryrequestid, extensionid, curextension, prevextension, userid, event):       
         
@@ -99,24 +104,22 @@ class extensionevent:
         return DefaultMethodResult(True,'Extension notifications deleted', extensionid)   
 
     def __preparenotification(self, extensionsummary):
-        ispublicbody = self.__valueexists('ispublicbody', extensionsummary)
-        isdenied = self.__valueexists('isdenied', extensionsummary)
-        isapproved = self.__valueexists('isapproved', extensionsummary)        
-        extension = self.__valueexists('extension', extensionsummary)
-        prevextension = self.__valueexists('prevextension', extensionsummary)
-
-        prevapprovedays =  self.__valueexists('approvednoofdays', prevextension) if prevextension else None
-        approveddays = self.__valueexists('approvednoofdays', extension)
-        prevextendeddays = self.__valueexists('extendedduedays', prevextension) if prevextension else None
-        extendedduedays = self.__valueexists('extendedduedays', extension) 
-        newduedate = self.__formatdate(self.__valueexists('extendedduedate', extension), self.__genericdateformat())
+        ispublicbody = self.__getvalueof('ispublicbody', extensionsummary)
+        isdenied = self.__getvalueof('isdenied', extensionsummary)
+        isapproved = self.__getvalueof('isapproved', extensionsummary)        
+        extension = self.__getvalueof('extension', extensionsummary)
+        prevextension = self.__getvalueof('prevextension', extensionsummary)
+        prevapprovedays =  self.__getvalueof('approvednoofdays', prevextension) if prevextension else None
+        approveddays = self.__getvalueof('approvednoofdays', extension)
+        prevextendeddays = self.__getvalueof('extendedduedays', prevextension) if prevextension else None
+        extendedduedays = self.__getvalueof('extendedduedays', extension) 
+        newduedate = self.__formatdate(self.__getvalueof('extendedduedate', extension), self.__genericdateformat())
 
         approveddayschanged = True if prevapprovedays != approveddays else False
         extendeddayschanged = True if prevextendeddays and prevextendeddays != extendedduedays else False
-
-      
+        
         if isdenied == True:
-            return  "Extension request to OIPC has been denied."
+            return  "Extension request to OIPC has been denied."        
         elif ispublicbody == True and isapproved == True or (extendeddayschanged == True):
             return "Extension taken for " + str(extendedduedays) + " days. The new legislated due date is "+ newduedate + "."
         elif isapproved == True and not ispublicbody or (approveddayschanged == True):
@@ -124,129 +127,145 @@ class extensionevent:
         else:
             return "Extension has been edited."
 
-    # modify any state
-    def __findmodify(self, curextension, prevextension, event):
-        curextensionstatusid = self.__valueexists('extensionstatusid', curextension)
-        prevextensionstatusid = self.__valueexists('extensionstatusid', prevextension) 
-        if (event == EventType.modify.value and curextensionstatusid ==  prevextensionstatusid):           
+    # modified attributes without changing state
+    def __isstatechanged(self, curextension, prevextension, event):
+        if event == EventType.modify.value and self.__getvalueof('extensionstatusid',curextension) != ExtensionStatus.pending.value and self.__getvalueof('extensionstatusid',curextension) ==  self.__getvalueof('extensionstatusid',prevextension):           
+            return False
+        else:
             return True
 
     def __getextensionreason(self, reasonid):
         return extensionreasonservice().getextensionreasonbyid(reasonid)
 
-    def __findpublicbody(self, curextension):
+    def __ispublicbody(self, curextension):
         extnreson = extensionreasonservice().getextensionreasonbyid(curextension['extensionreasonid'])
         extntype = self.__getextensiontype(extnreson)
         if extntype == ExtensionType.publicbody.value:
             return True  
+        return False
 
     # add denied or modify to denied    
-    def __finddenied(self, curextension, prevextension, event):
-        curextensionstatusid = self.__valueexists('extensionstatusid', curextension)
-        prevextensionstatusid = self.__valueexists('extensionstatusid', prevextension)
-        if (event == EventType.modify.value and curextensionstatusid == ExtensionStatus.denied.value and  curextensionstatusid !=  prevextensionstatusid) or (event == EventType.add.value and curextensionstatusid == ExtensionStatus.denied.value ):
-            return True
+    def __isdenied(self, curextension, prevextension, event):
+        return self.__isvalidaction(curextension, prevextension, event, ExtensionStatus.denied.value)
 
     # add approved or modify to approved
-    def __findapproved(self, curextension, prevextension, event):
-        curextensionstatusid = curextension["extensionstatusid"] if 'extensionstatusid' in curextension else None
-        prevextensionstatusid = prevextension["extensionstatusid"] if 'extensionstatusid' in prevextension else None
-        if (event == EventType.modify.value and curextensionstatusid == ExtensionStatus.approved.value and  curextensionstatusid !=  prevextensionstatusid) or (event == EventType.add.value and curextensionstatusid == ExtensionStatus.approved.value):
-            return True
+    def __isapproved(self, curextension, prevextension, event):
+        return self.__isvalidaction(curextension, prevextension, event, ExtensionStatus.approved.value)
+
+    def __isvalidaction(self,curextension, prevextension, event, status):
+        curextensionstatusid = self.__getvalueof('extensionstatusid',curextension)
+        prevextensionstatusid = self.__getvalueof('extensionstatusid',prevextension)
+        if (event == EventType.modify.value and curextensionstatusid !=  prevextensionstatusid) or (event == EventType.add.value):
+            if curextensionstatusid in [ExtensionStatus.denied.value,ExtensionStatus.approved.value] and status == curextensionstatusid:
+                return True
+        return False
 
     def __nonotificationrequired(self, curextension, prevextension, event):
-        curextensionstatusid = self.__valueexists('extensionstatusid', curextension)
-        prevextensionstatusid = self.__valueexists('extensionstatusid', prevextension)
-        curapproveddays = self.__valueexists('approvednoofdays', curextension)
-        prevapproveddays = self.__valueexists('approvednoofdays', prevextension)
+        curextensionstatusid = self.__getvalueof('extensionstatusid',curextension)
+        prevextensionstatusid = self.__getvalueof('extensionstatusid',prevextension)
+        curapproveddays = self.__getvalueof('approvednoofdays',curextension)
+        prevapproveddays = self.__getvalueof('approvednoofdays',prevextension)
         if (event == EventType.add.value and curextensionstatusid == 1) or (event == EventType.modify.value and curextensionstatusid ==  prevextensionstatusid and curapproveddays == prevapproveddays):
             return True
         return False
     
     def __onlycleanuprequired(self, curextension, prevextension, event):
-        curextensionstatusid = self.__valueexists('extensionstatusid', curextension)
-        prevextensionstatusid = self.__valueexists('extensionstatusid', prevextension)
+        curextensionstatusid = self.__getvalueof('extensionstatusid',curextension)
+        prevextensionstatusid = self.__getvalueof('extensionstatusid',prevextension)
         if event == EventType.delete.value or (event == EventType.modify.value and str(prevextensionstatusid)  in [str(ExtensionStatus.denied.value), str(ExtensionStatus.approved.value)] and curextensionstatusid == 1):
             return True
         return False
 
     def __onlynotificationrequired(self, curextension, prevextension, event):
-        isdenied = self.__finddenied(curextension, prevextension, event)
-        ispublicbody = self.__findpublicbody(curextension)
-        isapproved = self.__findapproved(curextension, prevextension, event)
-        if isdenied == True or isapproved == True or ispublicbody == True:
+        if self.__isdenied(curextension, prevextension, event) == True or self.__isapproved(curextension, prevextension, event) == True or self.__ispublicbody(curextension) == True:
             return True
         return False
 
     def __bothnotificationandcleanup(self, curextension, prevextension, event):
-        curextensionstatusid = self.__valueexists('extensionstatusid', curextension)
-        prevextensionstatusid = self.__valueexists('extensionstatusid', prevextension)
-        curapproveddays = self.__valueexists('approvednoofdays', curextension)
-        prevapproveddays = self.__valueexists('approvednoofdays', prevextension)
+        curextensionstatusid = self.__getvalueof('extensionstatusid',curextension)
+        prevextensionstatusid = self.__getvalueof('extensionstatusid',prevextension)
+        curapproveddays = self.__getvalueof('approvednoofdays',curextension)
+        prevapproveddays = self.__getvalueof('approvednoofdays',prevextension)
         if (event == EventType.modify.value and curextensionstatusid in [ExtensionStatus.approved.value, ExtensionStatus.denied.value] and prevextensionstatusid in [ExtensionStatus.approved.value, ExtensionStatus.denied.value]) or (event == EventType.modify.value and curextensionstatusid == ExtensionStatus.approved.value and curextensionstatusid == prevextensionstatusid and prevapproveddays != curapproveddays):
             return True
         return False
 
-    def __maintained(self, curextension, prevextension, event):        
+    def __maintained(self, curextension, prevextension, event):   
         return self.__createextensionsummary(curextension, prevextension, event)
     
     def __createextensionsummary(self, curextension, prevextension, event):
-        isdenied = self.__finddenied(curextension, prevextension, event)
-        ispublicbody = self.__findpublicbody(curextension)
-        isapproved = self.__findapproved(curextension, prevextension, event)
-        ismodified = self.__findmodify(curextension, prevextension, event)        
-        curreasonid = self.__valueexists("extensionreasonid", curextension)        
-        curreason = self.__getextensionreasonvalue(self.__getextensionreason(curreasonid))        
+        _extensionsummary = {'extension': curextension, 'prevextension':prevextension, 'reason': self.__getreasonfromid(self.__getvalueof("extensionreasonid", curextension)), 'action': event} 
         if event == EventType.delete.value:
-            return {'extension': curextension, 'reason': curreason, 'isdelete': True}
-        elif event == EventType.modify.value and not ismodified and curextension["extensionstatusid"] != ExtensionStatus.pending.value:
-            return {'extension': curextension, 'ispublicbody': ispublicbody, 'isdenied': isdenied, 'isapproved': isapproved, 'reason': self.__getextensionreasonvalue(self.__getextensionreason(curreasonid)), 'isdelete': False}   
-        elif event == EventType.add.value and curextension["extensionstatusid"] != ExtensionStatus.pending.value:
-            return {'extension': curextension, 'ispublicbody': ispublicbody, 'isdenied': isdenied, 'isapproved': isapproved, 'reason': self.__getextensionreasonvalue(self.__getextensionreason(curreasonid)), 'isdelete': False}
+            _extensionsummary['isdelete'] = True
+        elif curextension["extensionstatusid"] != ExtensionStatus.pending.value and (event == EventType.modify.value or event == EventType.add.value):
+            _extensionsummary['isdelete'] = False
+            _extensionsummary['isdenied'] = self.__isdenied(curextension, prevextension, event)
+            _extensionsummary['ispublicbody'] =  self.__ispublicbody(curextension)
+            _extensionsummary['isapproved'] = self.__isapproved(curextension, prevextension, event)
+        return _extensionsummary
     
     def __createnotificationsummary(self, curextension, prevextension, event):
-        isdenied = self.__finddenied(curextension, prevextension, event)
-        ispublicbody = self.__findpublicbody(curextension)
-        isapproved = self.__findapproved(curextension, prevextension, event)
+        isdenied = self.__isdenied(curextension, prevextension, event)
+        ispublicbody = self.__ispublicbody(curextension)
+        isapproved = self.__isapproved(curextension, prevextension, event)
     
         if event == EventType.modify.value:
             return {'extension': curextension, 'prevextension': prevextension, 'ispublicbody': ispublicbody, 'isdenied': isdenied, 'isapproved': isapproved}
         elif event == EventType.add.value and curextension["extensionstatusid"] != ExtensionStatus.pending.value:
             return {'extension': curextension, 'ispublicbody': ispublicbody, 'isdenied': isdenied, 'isapproved': isapproved}
 
+    def __preparemessage(self, username, extensionsummary):
+        action =  self.__getvalueof('action', extensionsummary)     
+        extension = self.__getvalueof('extension', extensionsummary) 
+        prevextension = self.__getvalueof('prevextension', extensionsummary) 
+        ispublicbody = self.__getvalueof('ispublicbody', extensionsummary)
+        isapproved = self.__getvalueof('isapproved', extensionsummary)
+        message = ""
+        if action == EventType.delete.value:
+            message = "Extension for " + self.__getvalueof('reason',extensionsummary) + " has been deleted."   
+        elif action in [EventType.modify.value, EventType.add.value]:
+            if self.__isstatechanged(extension, prevextension, action) == False:
+                message = self.__preparemodifycomment(extensionsummary)
+            else:
+                if self.__getvalueof('isdenied', extensionsummary) == True:
+                    message =  "The OIPC has denied a "+ str(self.__getvalueof('extendedduedays',extension)) +" day extension."
+                elif isapproved == True:
+                    if ispublicbody == True:
+                        message = username + " has taken a "+ str(self.__getvalueof('extendedduedays',extension)) +" day Public Body extension." 
+                    else:
+                        message = "The OIPC has granted a "+ str(self.__getvalueof('approvednoofdays',extension) ) +" day extension." 
+                    message += " The new legislated due date is "+ self.__formatdate(self.__getvalueof('extendedduedate',extension), self.__genericdateformat())
+        else:
+            message = "Extension for " + self.__getvalueof('reason',extensionsummary) + " has been edited."
+        return message
+
+    def __preparemodifycomment(self,extensionsummary):
+        extension = self.__getvalueof('extension', extensionsummary) 
+        prevextension = self.__getvalueof('prevextension', extensionsummary)
+        isapproved = True if self.__getvalueof('extensionstatusid', extension)  == ExtensionStatus.approved.value else False
+        comment = ""
+        if self.__getvalueof('extensionreasonid', extension) != self.__getvalueof('extensionreasonid', prevextension):
+            comment = "Extension reason has been updated to " + self.__getvalueof('reason', extensionsummary)   
+        
+        if self.__getvalueof('extendedduedays', extension) != self.__getvalueof('extendedduedays', prevextension):
+            comment += " AND " if comment not in [None,""] else ""
+            comment += "Approved" if isapproved is True else "Denied"   
+            comment +=" number of days for extension has changed to " + str(self.__getvalueof('extendedduedays', extension))+ "."
+            if isapproved == True:
+                comment +=  " The new legislated due date is "+ self.__formatdate(self.__getvalueof('extendedduedate', extension), self.__genericdateformat())
+        return comment
+
+    def __getreasonfromid(self, curreasonid):
+        return self.__getextensionreasonvalue(self.__getextensionreason(curreasonid))
+    
     def __getextensionreasonvalue(self, extnreson):       
        return extnreson["reason"]
 
     def __getextensiontype(self, extnreson):       
        return extnreson["extensiontype"]
 
-    def __valueexists(self, key, extensionsummary):
+    def __getvalueof(self, key, extensionsummary):
         return extensionsummary[key] if key in extensionsummary else None
-
-    def __preparemessage(self, username, extensionsummary):        
-        isdelete = self.__valueexists('isdelete', extensionsummary)
-        ispublicbody = self.__valueexists('ispublicbody', extensionsummary)
-        isdenied = self.__valueexists('isdenied', extensionsummary)
-        isapproved = self.__valueexists('isapproved', extensionsummary)
-        
-        extension = self.__valueexists('extension', extensionsummary)       
-        extensionreason = self.__valueexists('reason', extensionsummary)       
-        
-        approveddays = self.__valueexists('approvednoofdays', extension) 
-        extendedduedays = self.__valueexists('extendedduedays', extension) 
-        newduedate = self.__valueexists('extendedduedate', extension)
-
-        if isdelete == True:
-            return "Extension for " + extensionreason + " has been deleted."       
-        elif isdenied == True:
-            return  "The OIPC has denied a "+ str(extendedduedays) +" day extension."
-        elif ispublicbody == True and isapproved == True:
-            return  username + " has taken a "+ str(extendedduedays) +" day Public Body extension. The new legislated due date is "+ self.__formatdate(newduedate, self.__genericdateformat()) + "."
-        elif isapproved == True and not ispublicbody:
-            return  "The OIPC has granted a "+ str(approveddays) +" day extension. The new legislated due date is "+ self.__formatdate(newduedate, self.__genericdateformat())
-        else:
-            return "Extension for " + extensionreason + " has been edited."
-   
 
     def __formatdate(self, datevalue, format):
         return dateutil.parser.parse(datevalue).strftime(format) if datevalue is not None else None


### PR DESCRIPTION
Use case: Generate request history for a reason and extension days changes for states approved or denied.

Sanity Test:
1. Create request using "Sync with Axis"
2.  Create extension
3. Delete extension
4. Update extension
5. Validate notifications for extensions
6.  State transition 
7. Watch/Unwatch changes

Additional Changes:
Code reusability and naming conventions applied.