### PR TITLE
PR DEV 2191  - Security restriction to description history

### DIFF
--- a/request-management-api/request_api/auth.py
+++ b/request-management-api/request_api/auth.py
@@ -19,6 +19,7 @@ from flask import g, request
 from flask_jwt_oidc import JwtManager
 from jose import jwt as josejwt
 from request_api.utils.enums import MinistryTeamWithKeycloackGroup, ProcessingTeamWithKeycloackGroup, IAOTeamWithKeycloackGroup
+from request_api.models.FOIMinistryRequests import FOIMinistryRequest
 jwt = (
     JwtManager()
 )  # pylint: disable=invalid-name; lower case name as used by convention in most Flask apps
@@ -45,10 +46,14 @@ class Auth:
     @classmethod
     def belongstosameministry(cls,func):
         @wraps(func)
-        def decorated(type, id, field,*args, **kwargs):
-            usergroups = AuthHelper.getusergroups()
-            
-            print(usergroups)
+        def decorated(type, id, field,*args, **kwargs):           
+            usertype = AuthHelper.getusertype()
+            requestministry = FOIMinistryRequest.getrequestbyministryrequestid(id)
+            ministrygroups = AuthHelper.getministrygroups()
+            expectedministrygroup = MinistryTeamWithKeycloackGroup[requestministry['programarea.bcgovcode']].value
+            retval = "Unauthorized" , 401
+            if(usertype == "ministry" and expectedministrygroup not in ministrygroups):
+                return retval
             return func(type, id, field,*args, **kwargs)            
         return decorated           
            

--- a/request-management-api/request_api/auth.py
+++ b/request-management-api/request_api/auth.py
@@ -47,6 +47,7 @@ class Auth:
         @wraps(func)
         def decorated(type, id, field,*args, **kwargs):
             usergroups = AuthHelper.getusergroups()
+            
             print(usergroups)
             return func(type, id, field,*args, **kwargs)            
         return decorated           

--- a/request-management-api/request_api/auth.py
+++ b/request-management-api/request_api/auth.py
@@ -39,6 +39,19 @@ class Auth:
             return f(*args, **kwargs)
 
         return decorated
+
+
+
+    @classmethod
+    def belongstosameministry(cls,func):
+        @wraps(func)
+        def decorated(type, id, field,*args, **kwargs):
+            usergroups = AuthHelper.getusergroups()
+            print(usergroups)
+            return func(type, id, field,*args, **kwargs)            
+        return decorated           
+           
+             
     
     @classmethod
     def ismemberofgroups(cls, groups):

--- a/request-management-api/request_api/resources/foiaudit.py
+++ b/request-management-api/request_api/resources/foiaudit.py
@@ -39,6 +39,7 @@ class FOIAuditByField(Resource):
     @TRACER.trace()
     @cross_origin(origins=allowedorigins())
     @auth.require
+    @auth.belongstosameministry
     def get(type, id, field):
         """ GET Method for auditing of FOI request field"""
         


### PR DESCRIPTION
- [x] Confirmed Description history listing for IAO - API response**
- [x] Confirmed Description history as ministry user from AEST to an EDU Request - API description history returns 401.
- [x] Confirmed Description history API returns proper response to EDUC ministry user for EDUC request.

Created a decorator "belongstosameministry" (auth.py)  and referred on the API FOIAudit. 