### PR TITLE
Avoid full Fetch of AXIS IDs to FE (#2279)

### DIFF
--- a/apps/forms-flow-ai/forms-flow-web/src/apiManager/endpoints/index.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/apiManager/endpoints/index.js
@@ -74,7 +74,7 @@ const API = {
 
   FOI_GET_ADVANCED_SEARCH: `${FOI_BASE_API_URL}/api/advancedsearch`,
 
-  FOI_GET_AXIS_REQUEST_IDS: `${FOI_BASE_API_URL}/api/foirawrequest/axisrequestids`,
+  FOI_CHECK_AXIS_REQUEST_ID: `${FOI_BASE_API_URL}/api/foirawrequest/axisrequestid/<axisrequestid>`,
   
   FOI_GET_AXIS_REQUEST_DATA: `${AXIS_API_URL}/api/RequestSearch/<axisrequestid>`,
 

--- a/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
@@ -388,15 +388,30 @@ export const fetchOpenedMinistriesForNotification = (notification, ...rest) => {
   }
 };
 
-export const fetchExistingAxisRequestIds = (...rest) => {
+export const checkDuplicateAndFetchRequestDataFromAxis = (axisRequestId, isModal,requestDetails, ...rest) => {
   const done = fnDone(rest);
-  const apiUrlgetRequestDetails = replaceUrl(API.FOI_GET_AXIS_REQUEST_IDS);
+  const apiUrlGetExistingAxisRequestIds = replaceUrl(
+    API.FOI_CHECK_AXIS_REQUEST_ID,
+    "<axisrequestid>",
+    axisRequestId
+  );
   return (dispatch) => {
-    httpGETRequest(apiUrlgetRequestDetails, {}, UserService.getToken())
+    httpGETRequest(apiUrlGetExistingAxisRequestIds, {}, UserService.getToken())
       .then((res) => {
         if (res.data) {
-          dispatch(setExistingAxisRequestIds(res.data));
-          done(null, res.data);
+          if(!res.data.ispresent){
+            dispatch(fetchRequestDataFromAxis(axisRequestId, isModal,requestDetails,(err, data) => {
+              if(!err)
+                done(null, data);
+              else {
+                  done(null,"Exception happened while fetching request from AXIS.");
+                  dispatch(serviceActionError(res));
+                  throw new Error(`Error in fetching request from AXIS.`);
+              }
+            }));
+          }
+          else
+            done(null,"Axis Id exists");
         } else {
           dispatch(serviceActionError(res));
           throw new Error(`Error in fetching axis request ids.`);

--- a/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
@@ -390,13 +390,13 @@ export const fetchOpenedMinistriesForNotification = (notification, ...rest) => {
 
 export const checkDuplicateAndFetchRequestDataFromAxis = (axisRequestId, isModal,requestDetails, ...rest) => {
   const done = fnDone(rest);
-  const apiUrlGetExistingAxisRequestIds = replaceUrl(
+  const apiUrlCheckAxisIdExists = replaceUrl(
     API.FOI_CHECK_AXIS_REQUEST_ID,
     "<axisrequestid>",
     axisRequestId
   );
   return (dispatch) => {
-    httpGETRequest(apiUrlGetExistingAxisRequestIds, {}, UserService.getToken())
+    httpGETRequest(apiUrlCheckAxisIdExists, {}, UserService.getToken())
       .then((res) => {
         if (res.data) {
           if(!res.data.ispresent){

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/AxisDetails/AxisDetails.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/AxisDetails/AxisDetails.js
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 import TextField from '@material-ui/core/TextField';
 import FOI_COMPONENT_CONSTANTS from '../../../../constants/FOI/foiComponentConstants';
 import { useDispatch} from "react-redux";
-import { fetchRequestDataFromAxis } from '../../../../apiManager/services/FOI/foiRequestServices';
+import { checkDuplicateAndFetchRequestDataFromAxis } from '../../../../apiManager/services/FOI/foiRequestServices';
 import { makeStyles } from '@material-ui/styles';
 import Accordion from '@material-ui/core/Accordion';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
@@ -53,13 +53,8 @@ const AxisDetails = React.memo(({
     const handleAxisIdChange = (e) => {
         if(e.target.value) {
             let helperText = "";
-            if(/^[A-Za-z]+(?:[-]){0,2}\d+\-\d+$/.test(e.target.value)){
-                helperText =  foiAxisRequestIds?.includes(e.target.value)
-                    ? "AXIS ID Number already exists": "";
-            }
-            else
+            if(!(/^[A-Za-z]+(?:[-]){0,2}\d+\-\d+$/.test(e.target.value)))
                 helperText = "Invalid Axis ID Number";
-                
             axisIdValidation = {field: "AxisId", helperTextValue: helperText};
             setValidation(axisIdValidation);
         }
@@ -74,8 +69,9 @@ const AxisDetails = React.memo(({
     }
 
     const syncWithAxis = () => {
-        dispatch(fetchRequestDataFromAxis(axisRequestId, false, saveRequestObject,(err, data) => {
+        dispatch(checkDuplicateAndFetchRequestDataFromAxis(axisRequestId, false, saveRequestObject,(err, data) => {
             if(!err){
+                console.log(Object.entries(data).length);
                 if(Object.entries(data).length === 0){
                     axisIdValidation = {field: "AxisId", helperTextValue: "Invalid AXIS ID Number"}
                     setValidation(axisIdValidation);  
@@ -85,6 +81,10 @@ const AxisDetails = React.memo(({
                     responseMsg+='';
                     if(responseMsg.indexOf("Exception happened while GET operations of request") >= 0)
                       setAxisMessage("ERROR");
+                    else if(responseMsg.indexOf("Axis Id exists") >= 0){
+                        axisIdValidation = {field: "AxisId", helperTextValue: "AXIS ID Number already exists"};
+                        setValidation(axisIdValidation);
+                    }
                 }
             }
             else

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -26,7 +26,6 @@ import {
 import {
   fetchFOIRequestDetailsWrapper,
   fetchFOIRequestDescriptionList,
-  fetchExistingAxisRequestIds,
   fetchRequestDataFromAxis
 } from "../../../apiManager/services/FOI/foiRequestServices";
 import {
@@ -175,7 +174,6 @@ const FOIRequest = React.memo(({ userDetail }) => {
     if (window.location.href.indexOf("comments") > -1) {
       tabclick("Comments");
     }
-    dispatch(fetchExistingAxisRequestIds());
   }, []);
 
   const dispatch = useDispatch();

--- a/apps/forms-flow-ai/forms-flow-web/src/styles.scss
+++ b/apps/forms-flow-ai/forms-flow-web/src/styles.scss
@@ -560,6 +560,10 @@ body ::-webkit-scrollbar {
   color: #9E2929 !important;
 }
 
+.MuiFormHelperText-root.Mui-error {
+  color: #9E2929 !important;
+}
+
 .btn-link {
   color: #036;
 }

--- a/request-management-api/request_api/resources/request.py
+++ b/request-management-api/request_api/resources/request.py
@@ -100,21 +100,19 @@ def getparams(updaterequest):
         'assigneelastname': updaterequest["assignedToLastName"] if updaterequest.get("assignedToLastName") != None else None
     }
 
-@cors_preflight('GET,POST,OPTIONS')
-@API.route('/foirawrequest/axisrequestids')
+@cors_preflight('GET,OPTIONS')
+@API.route('/foirawrequest/axisrequestid/<axisrequestid>')
 class FOIAXISRequest(Resource):
-    """Consolidates create and retrival of raw request"""
+    """Check if axis request id already exists in db"""
 
     @staticmethod
     @TRACER.trace()
     @cross_origin(origins=allowedorigins())       
     @auth.require
-    def get():
+    def get(axisrequestid=None):
         try : 
-            jsondata = {}
-            axisrequestids = rawrequestservice().getaxisequestids()                                    
-            jsondata = json.dumps(axisrequestids)
-            return jsondata , 200 
+            isaxisrequestidpresent = rawrequestservice().isaxisrequestidpresent(axisrequestid)                                   
+            return {"axisrequestid" : axisrequestid, "ispresent": isaxisrequestidpresent}, 200
         except ValueError:
             return {'status': 500, 'message':INVALID_REQUEST_ID}, 500    
         except BusinessException as exception:            

--- a/request-management-api/request_api/services/rawrequestservice.py
+++ b/request-management-api/request_api/services/rawrequestservice.py
@@ -33,7 +33,7 @@ class rawrequestservice:
         axisrequestid = requestdatajson["axisRequestId"] if 'axisRequestId' in requestdatajson  else None
         isaxisrequestidpresent = False
         if axisrequestid is not None:
-            isaxisrequestidpresent = self.__isaxisrequestidpresent(axisrequestid)
+            isaxisrequestidpresent = self.isaxisrequestidpresent(axisrequestid)
         axissyncdate = requestdatajson["axisSyncDate"] if 'axisSyncDate' in requestdatajson  else None
 
         requirespayment =  rawrequestservice.doesrequirepayment(requestdatajson) if sourceofsubmission == "onlineform"  else False 
@@ -128,7 +128,7 @@ class rawrequestservice:
     def getaxisequestids(self):
         return rawrequestservicegetter().getaxisequestids()
     
-    def __isaxisrequestidpresent(self, axisrequestid):
+    def isaxisrequestidpresent(self, axisrequestid):
         countofaxisrequestid = rawrequestservicegetter().getcountofaxisequestidbyaxisequestid(axisrequestid)
         if countofaxisrequestid > 0:
             return True


### PR DESCRIPTION
**Description:**:
Removed API for fetching all existing AXIS IDs to FE. Now the warning "Axis Id already exists" will be checked on Sync with AXIS button click only.
On the service for fetching the AXIS request, reused an existing method which checks if an axis id already exists in DB.

**ACs: All Passed**

**Sanity Tests Executed:**
Tested #2279 with Add Request and existing requests.