### PR TITLE
Previous comments & notifications not getting cleared while syncing extensions from Axis#2759

### DIFF
--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/AxisDetails/AxisSyncModal.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/AxisDetails/AxisSyncModal.js
@@ -51,7 +51,7 @@ const AxisSyncModal = ({ axisSyncModalOpen, setAxisSyncModalOpen, saveRequestObj
     const [axisExtensions, setAxisExtension] = React.useState([]);
     const dispatch = useDispatch();
     const extensions = useSelector((state) => state.foiRequests.foiRequestExtesions);
-    let updateExtensions = false;
+    const [updateExtensions, setUpdateExtensions] = React.useState(false);
 
     useEffect(()=>{
         if(Object.entries(requestDetailsFromAxis).length !== 0){
@@ -114,7 +114,7 @@ const AxisSyncModal = ({ axisSyncModalOpen, setAxisSyncModalOpen, saveRequestObj
       return false;
     }
 
-    const assignDisplayedReqObj = (key,updatedObj, updatedField) => {     
+    const assignDisplayedReqObj = (key,updatedObj, updatedField) => {  
       switch (key) {
         case 'dueDate':
         case 'requestProcessStart':
@@ -144,9 +144,10 @@ const AxisSyncModal = ({ axisSyncModalOpen, setAxisSyncModalOpen, saveRequestObj
         case 'Extensions':
           let extensionsArr = compareExtensions(key);
           if(extensionsArr?.length > 0 || (extensionsArr?.length === 0 && 
-              requestDetailsFromAxis[key].length === 0 && extensions?.length > 0))
+              requestDetailsFromAxis[key].length === 0 && extensions?.length > 0)){
             updatedObj[key] = extensionsArr;
-            updateExtensions = true;
+            setUpdateExtensions(true);
+          }
           break;
         default:
           updatedObj[updatedField] = requestDetailsFromAxis[key];
@@ -154,7 +155,7 @@ const AxisSyncModal = ({ axisSyncModalOpen, setAxisSyncModalOpen, saveRequestObj
       }
       
     }
-
+    
     const compareAdditionalPersonalInfo = (axisKey , reqKey, axisAdditionalPersonalInfo, 
       foiReqAdditionalPersonalInfo, updatedObj) => {
       if(axisKey === reqKey){
@@ -289,8 +290,9 @@ const AxisSyncModal = ({ axisSyncModalOpen, setAxisSyncModalOpen, saveRequestObj
                 draggable: true,
                 progress: undefined,
               });
-              if(updateExtensions)
+              if(updateExtensions){
                 saveExtensions();
+              }
               const _state = getRequestState({
                 currentSelectedStatus,
                 requestState,

--- a/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/apps/forms-flow-ai/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -218,6 +218,7 @@ const FOIRequest = React.memo(({ userDetail }) => {
         setAxisMessage("");
     }
   }, [axisSyncedData, requestExtensions, checkExtension]);
+  
 
   const axisBannerCheck = () =>{
     dispatch(fetchRequestDataFromAxis(requestDetails.axisRequestId, saveRequestObject ,true, (err, data) => {
@@ -229,8 +230,10 @@ const FOIRequest = React.memo(({ userDetail }) => {
             setCheckExtension(false);
             setAxisMessage("WARNING");
           }
-          else
+          else{
+            setCheckExtension(true);
             setAxisMessage("");
+          }
         }
         else if(data){
           let responseMsg = data;

--- a/request-management-api/request_api/models/FOIRequestComments.py
+++ b/request-management-api/request_api/models/FOIRequestComments.py
@@ -35,7 +35,7 @@ class FOIRequestComment(db.Model):
         _createddate = datetime2.now().isoformat() if commentcreatedate is None else commentcreatedate        
         newcomment = FOIRequestComment(commenttypeid=commenttypeid, ministryrequestid=foirequestcomment["ministryrequestid"], version=version, comment=foirequestcomment["comment"], parentcommentid=parentcommentid, isactive=True, created_at=_createddate, createdby=userid,taggedusers=taggedusers)
         db.session.add(newcomment)
-        db.session.commit()               
+        db.session.commit()      
         return DefaultMethodResult(True,'Comment added',newcomment.commentid)    
 
     @classmethod

--- a/request-management-api/request_api/services/events/extension.py
+++ b/request-management-api/request_api/services/events/extension.py
@@ -40,6 +40,15 @@ class extensionevent:
         except BusinessException as exception:
             return DefaultMethodResult(False,'unable to post comment - '+exception.message,extensionid)
 
+    def deleteexistingrelatedevents(self, ministryrequestid):
+        try:
+            notificationids = FOIRequestNotification().getextensionnotificationidsbyministry(ministryrequestid)
+            if notificationids:
+                self.__deleteaxisextensionnotifications(notificationids)
+            FOIRequestComment().deleteextensioncommentsbyministry(ministryrequestid)
+        except BusinessException as exception:
+            return DefaultMethodResult(False,'Issue in deleting previous event related to ministry id - '+exception.message,ministryrequestid)  
+
     def createaxisextensionevent(self, ministryrequestid, extensionid, userid, username, event):
         # get all extension comments and notification of the ministry id
         # delete all comments and notification related to ministry id and extension
@@ -50,14 +59,10 @@ class extensionevent:
         extensionsummaryforcomment = self.__maintained(curextension, prevextension, event)
         message = ""
         try:
-            notificationids = FOIRequestNotification().getextensionnotificationidsbyministry(ministryrequestid)
-            if notificationids:
-                self.__deleteaxisextensionnotifications(notificationids)
             notificationresponse = self.createnotification(ministryrequestid, extensionid, curextension, prevextension, userid, event)
             if extensionsummaryforcomment is None or (extensionsummaryforcomment and len(extensionsummaryforcomment) < 1):
                 return  DefaultMethodResult(True, MSG_NO_CHANGE ,extensionid)
             else:
-                FOIRequestComment().deleteextensioncommentsbyministry(ministryrequestid)
                 commentresponse = self.createcomment(ministryrequestid, userid, username, extensionsummaryforcomment)
                 if commentresponse.success == True:                    
                     message += 'Comment posted' 

--- a/request-management-api/request_api/services/eventservice.py
+++ b/request-management-api/request_api/services/eventservice.py
@@ -40,6 +40,7 @@ class eventservice:
     
     def posteventforaxisextension(self, ministryrequestid, extensionids, userid, username, event):
         try:
+            extensionevent().deleteexistingrelatedevents(ministryrequestid)
             for extensionid in extensionids:
                 extensioneventresponse = extensionevent().createaxisextensionevent(ministryrequestid, extensionid, userid, username, event)
                 if extensioneventresponse.success == False: 


### PR DESCRIPTION
Description:
Fix for Previous comments & notifications not getting cleared while syncing extensions from Axis #2759.
Comments and notifications will be generated for each of the axis approved/denied extensions.
N.B. : Moved the method for deleting previous comments/notifications to outside of the extension loop in B.E.