### PR TITLE
Fix-Query updated

### DIFF
--- a/request-management-api/request_api/models/FOIRequestComments.py
+++ b/request-management-api/request_api/models/FOIRequestComments.py
@@ -40,8 +40,7 @@ class FOIRequestComment(db.Model):
 
     @classmethod
     def deleteextensioncommentsbyministry(cls, ministryid):
-        print("-->Inside deleteextensioncommentsbyministry",ministryid)
-        db.session.query(FOIRequestComment).filter(FOIRequestComment.ministryrequestid.in_(ministryid), FOIRequestComment.commenttypeid == 2).delete(synchronize_session=False)
+        db.session.query(FOIRequestComment).filter(FOIRequestComment.ministryrequestid == ministryid, FOIRequestComment.commenttypeid == 2).delete(synchronize_session=False)
         db.session.commit()  
         return DefaultMethodResult(True,'Extensions comments deleted for the ministry ', ministryid)
 

--- a/request-management-api/request_api/services/events/extension.py
+++ b/request-management-api/request_api/services/events/extension.py
@@ -42,7 +42,6 @@ class extensionevent:
 
     def deleteexistingrelatedevents(self, ministryrequestid):
         try:
-            print("Inside deleteexistingrelatedevents")
             notificationids = FOIRequestNotification().getextensionnotificationidsbyministry(ministryrequestid)
             if notificationids:
                 self.__deleteaxisextensionnotifications(notificationids)

--- a/request-management-api/request_api/services/eventservice.py
+++ b/request-management-api/request_api/services/eventservice.py
@@ -40,7 +40,6 @@ class eventservice:
     
     def posteventforaxisextension(self, ministryrequestid, extensionids, userid, username, event):
         try:
-            print("Inside posteventforaxisextension")
             extensionevent().deleteexistingrelatedevents(ministryrequestid)
             for extensionid in extensionids:
                 extensioneventresponse = extensionevent().createaxisextensionevent(ministryrequestid, extensionid, userid, username, event)


### PR DESCRIPTION
Description : 
Query for deleting existing extension comments wasn't working in DEV but working in local. It was filtering the ministry id of comments using IN which apparently didn't work in DEV,TEST. Updated the filter query with equals.
