### PR TITLE
Changes to upgrade keycloak-js to 20.0.2

### DIFF
--- a/forms-flow-web/package.json
+++ b/forms-flow-web/package.json
@@ -73,7 +73,7 @@
     "html-to-pdf-js": "^0.9.3",
     "jquery": "^3.5.1",
     "jsonwebtoken": "^8.5.1",
-    "keycloak-js": "^10.0.2",
+    "keycloak-js": "^20.0.2",
     "popper.js": "^1.16.1",
     "prop-types": "^15.7.2",
     "querystring": "^0.2.1",


### PR DESCRIPTION
Changes to upgrade the keycloak-js to run along with 7.16.x of KC.

Sanity:
Login with IDIR
Logout i.e. Invalidate session successfully