### PR TITLE
1398 - Zap Scan - Scheduling only works when merged into main branch

### DIFF
--- a/.github/workflows/zap-scan-dev.yml
+++ b/.github/workflows/zap-scan-dev.yml
@@ -1,6 +1,8 @@
 name: Zap Scanning
 
 on:
+  schedule:
+    - cron: "0 11 * * *" # 3am pst
   push:
     branches:
       - dev

--- a/.github/workflows/zap-scan-dev.yml
+++ b/.github/workflows/zap-scan-dev.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   zap_scan_frontend:
     runs-on: ubuntu-latest
-    name: Scan the epd-Frontend 
+    name: Scan the frontend
     steps:
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.4.0
@@ -37,7 +37,7 @@ jobs:
 
   zap_scan_request_management:
     runs-on: ubuntu-latest
-    name: Scan the epd-backend-applications
+    name: Scan the request management api
     steps:
       - name: ZAP Scan
         uses: zaproxy/action-api-scan@v0.2.0

--- a/.github/workflows/zap-scan-dev.yml
+++ b/.github/workflows/zap-scan-dev.yml
@@ -33,7 +33,7 @@ jobs:
           allow_issue_writing: false
           token: ${{ secrets.GITHUB_TOKEN }}
           issue_title: 'ZAP Scan Report'
-          target: 'https://dev.foirequests.gov.bc.ca/'
+          target: 'https://dev-marshal-foirequest.apps.silver.devops.gov.bc.ca/'
 
   zap_scan_request_management:
     runs-on: ubuntu-latest
@@ -45,4 +45,4 @@ jobs:
           allow_issue_writing: false
           token: ${{ secrets.GITHUB_TOKEN }}
           issue_title: 'ZAP Scan Report'
-          target: 'https://request-management-api-dev.apps.silver.devops.gov.bc.ca/'
+          target: 'https://request-management-api-002-dev.apps.silver.devops.gov.bc.ca/'

--- a/.github/workflows/zap-scan-dev.yml
+++ b/.github/workflows/zap-scan-dev.yml
@@ -33,7 +33,8 @@ jobs:
           allow_issue_writing: false
           token: ${{ secrets.GITHUB_TOKEN }}
           issue_title: 'ZAP Scan Report'
-          target: 'https://dev-marshal-foirequest.apps.silver.devops.gov.bc.ca/'
+          target: ${{ secrets.ZAP_URL_DEV_MARSHALL_FRONTEND }}
+          
 
   zap_scan_request_management:
     runs-on: ubuntu-latest
@@ -45,4 +46,4 @@ jobs:
           allow_issue_writing: false
           token: ${{ secrets.GITHUB_TOKEN }}
           issue_title: 'ZAP Scan Report'
-          target: 'https://request-management-api-002-dev.apps.silver.devops.gov.bc.ca/'
+          target: ${{ secrets.ZAP_URL_DEV_REQ_MGMT }}

--- a/.github/workflows/zap-scan-dev.yml
+++ b/.github/workflows/zap-scan-dev.yml
@@ -1,0 +1,48 @@
+name: Zap Scanning
+
+on:
+  push:
+    branches:
+      - dev
+      - dev-ac-1398 #testing purpose
+    
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Target environment to deploy latest changes
+        default: "dev"
+        required: true
+        # options:
+        # - dev
+        # - test
+        # - prod
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zap_scan_frontend:
+    runs-on: ubuntu-latest
+    name: Scan the epd-Frontend 
+    steps:
+      - name: ZAP Scan
+        uses: zaproxy/action-full-scan@v0.4.0
+        with:
+          allow_issue_writing: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue_title: 'ZAP Scan Report'
+          target: 'https://dev.foirequests.gov.bc.ca/'
+
+  zap_scan_request_management:
+    runs-on: ubuntu-latest
+    name: Scan the epd-backend-applications
+    steps:
+      - name: ZAP Scan
+        uses: zaproxy/action-api-scan@v0.2.0
+        with:
+          allow_issue_writing: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue_title: 'ZAP Scan Report'
+          target: 'https://request-management-api-dev.apps.silver.devops.gov.bc.ca/'


### PR DESCRIPTION
For #1398 we want to schedule this on an early-morning cron.  GitHub action cron jobs only are properly scheduled if in the main/default branch.   **Because of this, I am attempting to merge directly into `main`, not `dev`, as the scheduling will only work if we get it into `main`**.  This is just a GitHub action, nothing deployed to OCP.

The secrets currently point to dev marshal, but we can change it to test marshal if we want.  The job takes around 30 minutes to run and triggers at 3am PST.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

> Scheduled workflows run on the latest commit on the default or base branch. 

