### PR TITLE
Minor fix on axis sync modal when all linked requests are removed from axis

### DIFF
--- a/forms-flow-web/src/components/FOI/FOIRequest/AxisDetails/AxisSyncModal.js
+++ b/forms-flow-web/src/components/FOI/FOIRequest/AxisDetails/AxisSyncModal.js
@@ -129,8 +129,7 @@ const AxisSyncModal = ({ axisSyncModalOpen, setAxisSyncModalOpen, saveRequestObj
         }
         case 'linkedRequests':
           let linkedRequestsDiff= comparelinkedRequests(key);
-          if(linkedRequestsDiff.length > 0)
-            updatedObj[updatedField] =linkedRequestsDiff.toString()?.split(',')?.join(', ');
+          updatedObj[updatedField] = linkedRequestsDiff.length > 0 ? linkedRequestsDiff.toString()?.split(',')?.join(', '): [];
           break;
         case 'compareReceivedDate':
           updatedObj[updatedField] =formatDate(requestDetailsFromAxis['receivedDate'], "MMM dd yyyy");


### PR DESCRIPTION
**Description:**

Minor fix on axis sync modal when all linked requests are removed from axis. 
Issue : When all linked requests in axis are removed from an already synced request. Now the banner is showing up but the Modal is not shown. Instead show the modal and show Linked requests as empty.