### PR TITLE
dev-MD-4333

### DIFF
--- a/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/MinistryReview.js
+++ b/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/MinistryReview.js
@@ -53,6 +53,7 @@ import Loading from "../../../../containers/Loading";
 import ExtensionDetails from "./ExtensionDetails";
 import clsx from "clsx";
 import { getMinistryBottomTextMap, alertUser, getHeaderText } from "./utils";
+import { isMinistryLogin } from '../../../../helper/FOI/helper';
 import DivisionalTracking from "../DivisionalTracking";
 import HomeIcon from '@mui/icons-material/Home';
 import { RecordsLog } from '../../customComponents/Records';
@@ -106,6 +107,8 @@ const MinistryReview = React.memo(({ userDetail }) => {
 
   const [_currentrequestStatus, setcurrentrequestStatus] = React.useState("");
   const [_tabStatus, settabStatus] = React.useState(requestState);
+  const userGroups = userDetail?.groups?.map(group => group.slice(1));
+  let isMinistryUser = isMinistryLogin(userGroups);
   //gets the request detail from the store
   const IsDivisionalCoordinator = () => {
     return userDetail?.role?.includes("DivisionalCoordinator");
@@ -120,6 +123,7 @@ const MinistryReview = React.memo(({ userDetail }) => {
   let requestAttachments = useSelector(
     (state) => state.foiRequests.foiRequestAttachments.filter(
       attachment => {
+        if (isMinistryUser && attachment.category.toLowerCase() === 'applicant' && requestDetails.requestType.toLowerCase() === 'personal') return false
         return ['feeassessed-onhold', 'fee estimate - payment receipt', 'response-onhold', 'fee balance outstanding - payment receipt']
         .indexOf(attachment.category.toLowerCase()) === -1
       }


### PR DESCRIPTION
I saw another component doing this to get the userDetail

```const user = useSelector((reduxState) => reduxState.user.userDetail)```

In the code here, I used the userDetail prop being passed in instead of the Redux state. Can you please confirm if we are using Redux state as the source of truth in the frontend, or props.

Also, there are quite a few different places where this could be implemented with slightly different effects, I'm not too familiar with the frontend structure yet but it seems like the MinistryReview component makes the most sense. 