### PR TITLE
Ticket 4245. Ministry Sign Off Approval Feature / Workflow

### DIFF
--- a/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/BottomButtonGroup.js
+++ b/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/BottomButtonGroup.js
@@ -69,25 +69,25 @@ const BottomButtonGroup = React.memo(
 
     //State to manage approval data for Ministry Sign Off
     const [ministryApprovalState, setMinistryApprovalState] = useState({
-      name: "",
-      title: "",
-      date: ""
+      approverName: "",
+      approverTitle: "",
+      approvedDate: ""
     });
 
     const handleApprovalInputs = (event) => {
       if(event.target.name === "name") {
         setMinistryApprovalState((prevState) => {
-          return {...prevState, name: event.target.value}
+          return {...prevState, approverName: event.target.value}
         })
       }
       if(event.target.name === "title") {
         setMinistryApprovalState((prevState) => {
-          return {...prevState, title: event.target.value}
+          return {...prevState, approverTitle: event.target.value}
         })
       }
       if(event.target.name === "datePicker") {
         setMinistryApprovalState((prevState) => {
-          return {...prevState, date: event.target.value}
+          return {...prevState, approvedDate: event.target.value}
         })
       }
     }

--- a/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/BottomButtonGroup.js
+++ b/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/BottomButtonGroup.js
@@ -68,7 +68,7 @@ const BottomButtonGroup = React.memo(
     const disableSave = isValidationError;
 
     //State to manage approval data for Ministry Sign Off
-    const [approvalState, setApprovalState] = useState({
+    const [ministryApprovalState, setMinistryApprovalState] = useState({
       name: "",
       title: "",
       date: ""
@@ -76,17 +76,17 @@ const BottomButtonGroup = React.memo(
 
     const handleApprovalInputs = (event) => {
       if(event.target.name === "name") {
-        setApprovalState((prevState) => {
+        setMinistryApprovalState((prevState) => {
           return {...prevState, name: event.target.value}
         })
       }
       if(event.target.name === "title") {
-        setApprovalState((prevState) => {
+        setMinistryApprovalState((prevState) => {
           return {...prevState, title: event.target.value}
         })
       }
       if(event.target.name === "datePicker") {
-        setApprovalState((prevState) => {
+        setMinistryApprovalState((prevState) => {
           return {...prevState, date: event.target.value}
         })
       }
@@ -208,7 +208,7 @@ const BottomButtonGroup = React.memo(
             saveMinistryRequestObject.requeststatusid = StateEnum.signoff.id;
             break;
           case StateEnum.response.name.toLowerCase():
-            saveMinistryRequestObject.approval = approvalState;
+            saveMinistryRequestObject.ministrysignoffapproval = ministryApprovalState;
             saveMinistryRequestObject.requeststatusid = StateEnum.response.id;
             break;
           case StateEnum.callforrecords.name.toLowerCase():
@@ -281,7 +281,7 @@ const BottomButtonGroup = React.memo(
             openModal={opensaveModal}
             handleModal={handleSaveModal}
             handleApprovalInputs={handleApprovalInputs}
-            approvalState={approvalState}
+            ministryApprovalState={ministryApprovalState}
             state={currentSelectedStatus}
             saveRequestObject={saveMinistryRequestObject}
           />

--- a/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/BottomButtonGroup.js
+++ b/forms-flow-web/src/components/FOI/FOIRequest/MinistryReview/BottomButtonGroup.js
@@ -67,6 +67,32 @@ const BottomButtonGroup = React.memo(
 
     const disableSave = isValidationError;
 
+    //State to manage approval data for Ministry Sign Off
+    const [approvalState, setApprovalState] = useState({
+      name: "",
+      title: "",
+      date: ""
+    });
+
+    const handleApprovalInputs = (event) => {
+      if(event.target.name === "name") {
+        setApprovalState((prevState) => {
+          return {...prevState, name: event.target.value}
+        })
+      }
+      if(event.target.name === "title") {
+        setApprovalState((prevState) => {
+          return {...prevState, title: event.target.value}
+        })
+      }
+      if(event.target.name === "datePicker") {
+        setApprovalState((prevState) => {
+          return {...prevState, date: event.target.value}
+        })
+      }
+    }
+
+
     const returnToQueue = (e) => {
       if (
         (!unSavedRequest && !recordsUploading && !CFRUnsaved) ||
@@ -182,6 +208,7 @@ const BottomButtonGroup = React.memo(
             saveMinistryRequestObject.requeststatusid = StateEnum.signoff.id;
             break;
           case StateEnum.response.name.toLowerCase():
+            saveMinistryRequestObject.approval = approvalState;
             saveMinistryRequestObject.requeststatusid = StateEnum.response.id;
             break;
           case StateEnum.callforrecords.name.toLowerCase():
@@ -253,6 +280,8 @@ const BottomButtonGroup = React.memo(
             attachmentsArray={attachmentsArray}
             openModal={opensaveModal}
             handleModal={handleSaveModal}
+            handleApprovalInputs={handleApprovalInputs}
+            approvalState={approvalState}
             state={currentSelectedStatus}
             saveRequestObject={saveMinistryRequestObject}
           />

--- a/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/MinistryApprovalModal.jsx
+++ b/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/MinistryApprovalModal.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import TextField from '@mui/material/TextField';
+
+const MinistryApprovalModal = (props) => {
+  const {setApprovalState} = props;
+
+  const handleInputs = (event) => {
+    if(event.target.name === "name") {
+      setApprovalState((prevState) => {
+        return {...prevState, name: event.target.value}
+      })
+    }
+    if(event.target.name === "title") {
+      setApprovalState((prevState) => {
+        return {...prevState, title: event.target.value}
+      })
+    }
+    if(event.target.name === "datePicker") {
+      setApprovalState((prevState) => {
+        return {...prevState, date: event.target.value}
+      })
+    }
+  }
+  return (
+    <div className="ministry-approver-main" style={{display: "flex", flexDirection: "row", justifyContent: "center", alignItems: "center", padding: "10px 0px 30px 0px"}}>
+      <TextField 
+        variant="outlined" 
+        name="name" 
+        label="Approver Name"
+        InputLabelProps={{required: true}}
+        style={{paddingRight:"20px"}}
+        size="small"
+        inputProps={{style: {width: "200px",}}}  
+        onChange={handleInputs}/>
+      <TextField 
+        variant="outlined" 
+        name="title" 
+        label="Approver Title"
+        InputLabelProps={{required: true}}
+        style={{paddingRight:"20px"}}
+        size="small"
+        inputProps={{style: {width: "200px",}}}  
+        onChange={handleInputs}/>
+      <TextField 
+        type="date" 
+        name="datePicker"
+        label="Date Approved"  
+        onChange={handleInputs}
+        inputProps={{style: {width: "200px",}}}  
+        InputLabelProps={{ shrink: true, required: true}}
+        size="small"
+        />
+    </div>
+    );
+}
+
+export default MinistryApprovalModal;

--- a/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/MinistryApprovalModal.jsx
+++ b/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/MinistryApprovalModal.jsx
@@ -1,26 +1,8 @@
-import React, { useState } from 'react';
 import TextField from '@mui/material/TextField';
 
 const MinistryApprovalModal = (props) => {
-  const {setApprovalState} = props;
+  const {handleApprovalInputs} = props;
 
-  const handleInputs = (event) => {
-    if(event.target.name === "name") {
-      setApprovalState((prevState) => {
-        return {...prevState, name: event.target.value}
-      })
-    }
-    if(event.target.name === "title") {
-      setApprovalState((prevState) => {
-        return {...prevState, title: event.target.value}
-      })
-    }
-    if(event.target.name === "datePicker") {
-      setApprovalState((prevState) => {
-        return {...prevState, date: event.target.value}
-      })
-    }
-  }
   return (
     <div className="ministry-approver-main" style={{display: "flex", flexDirection: "row", justifyContent: "center", alignItems: "center", padding: "10px 0px 30px 0px"}}>
       <TextField 
@@ -31,7 +13,7 @@ const MinistryApprovalModal = (props) => {
         style={{paddingRight:"20px"}}
         size="small"
         inputProps={{style: {width: "200px",}}}  
-        onChange={handleInputs}/>
+        onChange={(event) => {handleApprovalInputs(event)}}/>
       <TextField 
         variant="outlined" 
         name="title" 
@@ -40,12 +22,12 @@ const MinistryApprovalModal = (props) => {
         style={{paddingRight:"20px"}}
         size="small"
         inputProps={{style: {width: "200px",}}}  
-        onChange={handleInputs}/>
+        onChange={(event) => {handleApprovalInputs(event)}}/>
       <TextField 
         type="date" 
         name="datePicker"
         label="Date Approved"  
-        onChange={handleInputs}
+        onChange={(event) => {handleApprovalInputs(event)}}
         inputProps={{style: {width: "200px",}}}  
         InputLabelProps={{ shrink: true, required: true}}
         size="small"

--- a/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/index.js
+++ b/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/index.js
@@ -123,11 +123,9 @@ export default function ConfirmationModal({requestId, openModal, handleModal, st
             || (state.toLowerCase() === StateEnum.onhold.name.toLowerCase() && amountDue === 0)
             || (state.toLowerCase() === StateEnum.onhold.name.toLowerCase() && cfrStatus !== 'approved')
             || (state.toLowerCase() === StateEnum.onhold.name.toLowerCase() && cfrStatus === 'approved' && !saveRequestObject.email && !mailed)
+            || (state.toLowerCase() === StateEnum.response.name.toLowerCase() && !(ministryApprovalState?.approverName && ministryApprovalState?.approvedDate && ministryApprovalState?.approverTitle))
             || ((state.toLowerCase() === StateEnum.deduplication.name.toLowerCase() || 
                   state.toLowerCase() === StateEnum.review.name.toLowerCase()) && !allowStateChange)) {
-        return true;
-      }
-      else if ((state.toLowerCase() === StateEnum.response.name.toLowerCase() && !(ministryApprovalState?.approverName && ministryApprovalState?.approvedDate && ministryApprovalState?.approverTitle))) {
         return true;
       }
       return files.length === 0 

--- a/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/index.js
+++ b/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/index.js
@@ -127,7 +127,7 @@ export default function ConfirmationModal({requestId, openModal, handleModal, st
                   state.toLowerCase() === StateEnum.review.name.toLowerCase()) && !allowStateChange)) {
         return true;
       }
-      else if ((state.toLowerCase() === StateEnum.response.name.toLowerCase() && !(ministryApprovalState?.name && ministryApprovalState?.date && ministryApprovalState?.title))) {
+      else if ((state.toLowerCase() === StateEnum.response.name.toLowerCase() && !(ministryApprovalState?.approverName && ministryApprovalState?.approvedDate && ministryApprovalState?.approverTitle))) {
         return true;
       }
       return files.length === 0 

--- a/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/index.js
+++ b/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/index.js
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function ConfirmationModal({requestId, openModal, handleModal, state, saveRequestObject,
-  handleClosingDateChange, handleClosingReasonChange, attachmentsArray, handleApprovalInputs, approvalState}) {
+  handleClosingDateChange, handleClosingReasonChange, attachmentsArray, handleApprovalInputs, ministryApprovalState}) {
     const classes = useStyles();
     const processingTeamList = useSelector(reduxstate=> reduxstate.foiRequests.foiProcessingTeamList);
     const selectedMinistries = saveRequestObject?.selectedMinistries?.map(ministry => ministry.code);
@@ -127,7 +127,7 @@ export default function ConfirmationModal({requestId, openModal, handleModal, st
                   state.toLowerCase() === StateEnum.review.name.toLowerCase()) && !allowStateChange)) {
         return true;
       }
-      else if ((state.toLowerCase() === StateEnum.response.name.toLowerCase() && !(approvalState?.name && approvalState?.date && approvalState?.title))) {
+      else if ((state.toLowerCase() === StateEnum.response.name.toLowerCase() && !(ministryApprovalState?.name && ministryApprovalState?.date && ministryApprovalState?.title))) {
         return true;
       }
       return files.length === 0 

--- a/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/index.js
+++ b/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/index.js
@@ -56,7 +56,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function ConfirmationModal({requestId, openModal, handleModal, state, saveRequestObject,
-  handleClosingDateChange, handleClosingReasonChange, attachmentsArray }) {
+  handleClosingDateChange, handleClosingReasonChange, attachmentsArray, handleApprovalInputs, approvalState}) {
     const classes = useStyles();
     const processingTeamList = useSelector(reduxstate=> reduxstate.foiRequests.foiProcessingTeamList);
     const selectedMinistries = saveRequestObject?.selectedMinistries?.map(ministry => ministry.code);
@@ -80,11 +80,6 @@ export default function ConfirmationModal({requestId, openModal, handleModal, st
     const user = useSelector((reduxState) => reduxState.user.userDetail);
     const userGroups = user?.groups?.map(group => group.slice(1));
     let isMinistry = isMinistryLogin(userGroups);
-    const [approvalState, setApprovalState] = useState({
-      name: "",
-      title: "",
-      date: ""
-    });  
     
     const cfrStatus = useSelector((reduxState) => reduxState.foiRequests.foiRequestCFRForm.status);
     const cfrFeeData = useSelector((reduxState) => reduxState.foiRequests.foiRequestCFRForm.feedata);
@@ -113,7 +108,6 @@ export default function ConfirmationModal({requestId, openModal, handleModal, st
       setDisableSaveBtn(!event.target.checked);
       saveRequestObject.isofflinepayment=event.target.checked;
     };
-    
 
     React.useEffect(() => {
       setDisableSaveBtn(state.toLowerCase() === StateEnum.closed.name.toLowerCase());
@@ -133,7 +127,7 @@ export default function ConfirmationModal({requestId, openModal, handleModal, st
                   state.toLowerCase() === StateEnum.review.name.toLowerCase()) && !allowStateChange)) {
         return true;
       }
-      else if ((state.toLowerCase() === StateEnum.response.name.toLowerCase() && !(approvalState.name && approvalState.date && approvalState.title))) {
+      else if ((state.toLowerCase() === StateEnum.response.name.toLowerCase() && !(approvalState?.name && approvalState?.date && approvalState?.title))) {
         return true;
       }
       return files.length === 0 
@@ -237,7 +231,7 @@ export default function ConfirmationModal({requestId, openModal, handleModal, st
       else if (currentState?.toLowerCase() !== StateEnum.closed.name.toLowerCase() && (state.toLowerCase() === StateEnum.response.name.toLowerCase() && saveRequestObject.requeststatusid === StateEnum.signoff.id)) {
         return (
         <div className={classes.fileUploadBox}>
-          <MinistryApprovalModal setApprovalState={setApprovalState} />
+          <MinistryApprovalModal handleApprovalInputs={handleApprovalInputs} />
           <FileUpload
               attchmentFileNameList={attchmentFileNameList}
               multipleFiles={multipleFiles}

--- a/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/util.js
+++ b/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/util.js
@@ -117,7 +117,7 @@ import { getFullnameList } from "../../../../helper/FOI/helper";
             }
       case StateEnum.response.name.toLowerCase():
         if (_saveRequestObject.requeststatusid === StateEnum.signoff.id)
-          return {title: "Ministry Sign Off", body: `Upload E-Approval log or completed sign form (if required) to change the state.`};
+          return {title: "Ministry Sign Off", body: `Upload eApproval Logs to verify Ministry Approval and change the state.`};
         else
           return {title: "Changing the state", body: `Are you sure you want to change Request #${_requestNumber} to ${StateEnum.response.name}?`};
       default:

--- a/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/util.js
+++ b/forms-flow-web/src/components/FOI/customComponents/ConfirmationModal/util.js
@@ -117,7 +117,7 @@ import { getFullnameList } from "../../../../helper/FOI/helper";
             }
       case StateEnum.response.name.toLowerCase():
         if (_saveRequestObject.requeststatusid === StateEnum.signoff.id)
-          return {title: "Ministry Sign Off", body: `Upload eApproval Logs to verify Ministry Approval and change the state.`};
+          return {title: "Ministry Sign Off", body: `Upload eApproval Logs, and enter in required approval fields to verify Ministry Approval and then change the state.`};
         else
           return {title: "Changing the state", body: `Are you sure you want to change Request #${_requestNumber} to ${StateEnum.response.name}?`};
       default:

--- a/request-management-api/migrations/versions/b51a0f2635c1_.py
+++ b/request-management-api/migrations/versions/b51a0f2635c1_.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: b51a0f2635c1
+Revises: d43db71d53e5
+Create Date: 2023-09-06 10:53:17.474765
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b51a0f2635c1'
+down_revision = 'd43db71d53e5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('FOIMinistryRequests', sa.Column('ministrysignoffapproval', sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('FOIMinistryRequests', 'ministrysignoffapproval')

--- a/request-management-api/request_api/models/FOIMinistryRequests.py
+++ b/request-management-api/request_api/models/FOIMinistryRequests.py
@@ -67,6 +67,7 @@ class FOIMinistryRequest(db.Model):
     requestpagecount = db.Column(db.String(20), nullable=True)
     linkedrequests = db.Column(JSON, unique=False, nullable=True)
     identityverified = db.Column(JSON, unique=False, nullable=True)
+    ministrysignoffapproval = db.Column(JSON, unique=False, nullable=True)
     
 
     #ForeignKey References
@@ -1306,5 +1307,5 @@ class FOIMinistryRequestSchema(ma.Schema):
                 'foirequest.receivedmodeid','requeststatus.requeststatusid','requeststatus.name','programarea.bcgovcode',
                 'programarea.name','foirequest_id','foirequestversion_id','created_at','updated_at','createdby','assignedministryperson',
                 'assignedministrygroup','cfrduedate','closedate','closereasonid','closereason.name',
-                'assignee.firstname','assignee.lastname','ministryassignee.firstname','ministryassignee.lastname', 'axisrequestid', 'axissyncdate', 'requestpagecount', 'linkedrequests','identityverified','originalldd')
+                'assignee.firstname','assignee.lastname','ministryassignee.firstname','ministryassignee.lastname', 'axisrequestid', 'axissyncdate', 'requestpagecount', 'linkedrequests', 'ministrysignoffapproval', 'identityverified','originalldd')
     

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -177,7 +177,6 @@ class FOIRequestsByIdAndType(Resource):
                    assigneename = getministryassigneename(ministryrequestschema)               
             else:
                 ministryrequestschema = FOIRequestMinistrySchema().load(request_json)
-                print(ministryrequestschema)
             result = requestservice().saveministryrequestversion(ministryrequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid(), usertype)
             if result.success == True:
                 asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(), AuthHelper.isministrymember(),assigneename, ministryrequestschema))

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -179,7 +179,7 @@ class FOIRequestsByIdAndType(Resource):
                 ministryrequestschema = FOIRequestMinistrySchema().load(request_json)
             result = requestservice().saveministryrequestversion(ministryrequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid(), usertype)
             if result.success == True:
-                asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(), AuthHelper.isministrymember(),assigneename, ministryrequestschema))
+                asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(), AuthHelper.isministrymember(),assigneename))
                 metadata = json.dumps({"id": result.identifier, "ministries": result.args[0]})
                 requestservice().posteventtoworkflow(foiministryrequestid, ministryrequestschema, json.loads(metadata),usertype)
                 return {'status': result.success, 'message':result.message,'id':result.identifier, 'ministryRequests': result.args[0]} , 200

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -168,6 +168,8 @@ class FOIRequestsByIdAndType(Resource):
             if usertype != "ministry" and actiontype != "assignee":
                 return {'status': False, 'message':'Bad Request'}, 400
             request_json = request.get_json()
+            print(request_json)
+            userinput = request_json["approval"] if "approval" in request_json else None
             assigneename =''
             if actiontype == "assignee":
                 ministryrequestschema = FOIRequestAssigneeSchema().load(request_json)                
@@ -179,7 +181,7 @@ class FOIRequestsByIdAndType(Resource):
                 ministryrequestschema = FOIRequestMinistrySchema().load(request_json)
             result = requestservice().saveministryrequestversion(ministryrequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid(), usertype)
             if result.success == True:
-                asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(),AuthHelper.isministrymember(),assigneename))
+                asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(), userinput, AuthHelper.isministrymember(),assigneename))
                 metadata = json.dumps({"id": result.identifier, "ministries": result.args[0]})
                 requestservice().posteventtoworkflow(foiministryrequestid, ministryrequestschema, json.loads(metadata),usertype)
                 return {'status': result.success, 'message':result.message,'id':result.identifier, 'ministryRequests': result.args[0]} , 200

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -139,6 +139,7 @@ class FOIRequestsById(Resource):
             foirequestschema = FOIRequestWrapperSchema().load(request_json)  
             result = requestservice().saverequestversion(foirequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid())
             if result.success == True:
+                ## THIS BREAKS MY TICKET. WITH YOUR METHOD YOU HAVE TO GO EVERY INSTNACE OF EVENTSERVICE.POSTEVENT AND ADD USER INPUT ARG. FIND A FIX! BUGG 
                 asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(),AuthHelper.isministrymember()))
                 metadata = json.dumps({"id": result.identifier, "ministries": result.args[0]})
                 requestservice().posteventtoworkflow(foiministryrequestid,  foirequestschema, json.loads(metadata),"iao")
@@ -168,7 +169,6 @@ class FOIRequestsByIdAndType(Resource):
             if usertype != "ministry" and actiontype != "assignee":
                 return {'status': False, 'message':'Bad Request'}, 400
             request_json = request.get_json()
-            print(request_json)
             userinput = request_json["approval"] if "approval" in request_json else None
             assigneename =''
             if actiontype == "assignee":
@@ -181,7 +181,7 @@ class FOIRequestsByIdAndType(Resource):
                 ministryrequestschema = FOIRequestMinistrySchema().load(request_json)
             result = requestservice().saveministryrequestversion(ministryrequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid(), usertype)
             if result.success == True:
-                asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(), userinput, AuthHelper.isministrymember(),assigneename))
+                asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(), AuthHelper.isministrymember(),assigneename, userinput))
                 metadata = json.dumps({"id": result.identifier, "ministries": result.args[0]})
                 requestservice().posteventtoworkflow(foiministryrequestid, ministryrequestschema, json.loads(metadata),usertype)
                 return {'status': result.success, 'message':result.message,'id':result.identifier, 'ministryRequests': result.args[0]} , 200

--- a/request-management-api/request_api/schemas/foirequestwrapper.py
+++ b/request-management-api/request_api/schemas/foirequestwrapper.py
@@ -154,7 +154,7 @@ class CreateMinistrySignOffApprovalSchema(Schema):
         unknown = EXCLUDE 
     approvername = fields.Str(data_key="approverName", allow_none=False)
     approvertitle = fields.Str(data_key="approverTitle", allow_none=False)
-    approveddate = fields.Date(data_key="approvedDate", allow_none=False)
+    approveddate = fields.Str(data_key="approvedDate", allow_none=False)
 
   
 class FOIRequestMinistrySchema(Schema):

--- a/request-management-api/request_api/schemas/foirequestwrapper.py
+++ b/request-management-api/request_api/schemas/foirequestwrapper.py
@@ -152,9 +152,9 @@ class CreateMinistrySignOffApprovalSchema(Schema):
         """Exclude unknown fields in the deserialized output."""
 
         unknown = EXCLUDE 
-    approvername = fields.Str(data_key="name", allow_none=False)
-    approvertitle = fields.Str(data_key="title", allow_none=False)
-    approveddate = fields.Date(data_key="date", allow_none=False)
+    approvername = fields.Str(data_key="approverName", allow_none=False)
+    approvertitle = fields.Str(data_key="approverTitle", allow_none=False)
+    approveddate = fields.Date(data_key="approvedDate", allow_none=False)
 
   
 class FOIRequestMinistrySchema(Schema):

--- a/request-management-api/request_api/schemas/foirequestwrapper.py
+++ b/request-management-api/request_api/schemas/foirequestwrapper.py
@@ -147,6 +147,15 @@ class FOIMinistryRequestDivisionSchema(Schema):
     eApproval = fields.Str(data_key="eApproval",allow_none=True, validate=[validate.Length(max=12, error=MAX_EXCEPTION_MESSAGE)])
     divisionReceivedDate = fields.Str(data_key="divisionReceivedDate",allow_none=True)
 
+class CreateMinistrySignOffApprovalSchema(Schema):
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Exclude unknown fields in the deserialized output."""
+
+        unknown = EXCLUDE 
+    approvername = fields.Str(data_key="name", allow_none=False)
+    approvertitle = fields.Str(data_key="title", allow_none=False)
+    approveddate = fields.Date(data_key="date", allow_none=False)
+
   
 class FOIRequestMinistrySchema(Schema):
     
@@ -167,3 +176,4 @@ class FOIRequestMinistrySchema(Schema):
     assignedministrypersonFirstName = fields.Str(data_key="assignedministrypersonFirstName",allow_none=True, validate=[validate.Length(max=50, error=MAX_EXCEPTION_MESSAGE)])
     assignedministrypersonMiddleName = fields.Str(data_key="assignedministrypersonMiddleName",allow_none=True, validate=[validate.Length(max=50, error=MAX_EXCEPTION_MESSAGE)])
     assignedministrypersonLastName = fields.Str(data_key="assignedministrypersonLastName",allow_none=True, validate=[validate.Length(max=50, error=MAX_EXCEPTION_MESSAGE)])
+    ministrysignoffapproval = fields.Nested(CreateMinistrySignOffApprovalSchema, data_key="ministrysignoffapproval", allow_none=True)

--- a/request-management-api/request_api/services/events/state.py
+++ b/request-management-api/request_api/services/events/state.py
@@ -102,7 +102,7 @@ class stateevent:
 
     def __commentmessage(self, state, username, ministryrequestschema):
         if state == "Response":
-            return f"{username} changed the state of the request to {self.__formatstate(state)}. Approved by {ministryrequestschema['ministrysignoffapproval']['approvername']}, {ministryrequestschema['approvertitle']} on {ministryrequestschema['ministrysignoffapproval']['approveddate']}"
+            return f"{username} changed the state of the request to {self.__formatstate(state)}. Approved by {ministryrequestschema['ministrysignoffapproval']['approvername']}, {ministryrequestschema['ministrysignoffapproval']['approvertitle']} on {ministryrequestschema['ministrysignoffapproval']['approveddate']}"
         return  username+' changed the state of the request to '+self.__formatstate(state)
 
     def __notificationmessage(self, state, ministryrequestschema):

--- a/request-management-api/request_api/services/eventservice.py
+++ b/request-management-api/request_api/services/eventservice.py
@@ -24,10 +24,10 @@ class eventservice:
 
     """
     
-    async def postevent(self, requestid, requesttype, userid, username, userinput, isministryuser,assigneename=''):
-        self.posteventsync(requestid, requesttype, userid, username, userinput, isministryuser,assigneename)
+    async def postevent(self, requestid, requesttype, userid, username, isministryuser,assigneename='', userinput=None):
+        self.posteventsync(requestid, requesttype, userid, username, isministryuser,assigneename, userinput)
     
-    def posteventsync(self, requestid, requesttype, userid, username, userinput, isministryuser,assigneename=''):
+    def posteventsync(self, requestid, requesttype, userid, username, isministryuser,assigneename='', userinput=None):
         try: 
             stateeventresponse = stateevent().createstatetransitionevent(requestid, requesttype, userid, username, userinput)
             divisioneventresponse = divisionevent().createdivisionevent(requestid, requesttype, userid)

--- a/request-management-api/request_api/services/eventservice.py
+++ b/request-management-api/request_api/services/eventservice.py
@@ -24,12 +24,12 @@ class eventservice:
 
     """
     
-    async def postevent(self, requestid, requesttype, userid, username, isministryuser,assigneename=''):
-        self.posteventsync(requestid, requesttype, userid, username, isministryuser,assigneename)
+    async def postevent(self, requestid, requesttype, userid, username, userinput, isministryuser,assigneename=''):
+        self.posteventsync(requestid, requesttype, userid, username, userinput, isministryuser,assigneename)
     
-    def posteventsync(self, requestid, requesttype, userid, username, isministryuser,assigneename=''):
+    def posteventsync(self, requestid, requesttype, userid, username, userinput, isministryuser,assigneename=''):
         try: 
-            stateeventresponse = stateevent().createstatetransitionevent(requestid, requesttype, userid, username)
+            stateeventresponse = stateevent().createstatetransitionevent(requestid, requesttype, userid, username, userinput)
             divisioneventresponse = divisionevent().createdivisionevent(requestid, requesttype, userid)
             assignmentresponse = assignmentevent().createassignmentevent(requestid, requesttype, userid, isministryuser,assigneename,username)           
             if stateeventresponse.success == False or divisioneventresponse.success == False or assignmentresponse.success == False: 

--- a/request-management-api/request_api/services/eventservice.py
+++ b/request-management-api/request_api/services/eventservice.py
@@ -24,12 +24,12 @@ class eventservice:
 
     """
     
-    async def postevent(self, requestid, requesttype, userid, username, isministryuser,assigneename='', userinput=None):
-        self.posteventsync(requestid, requesttype, userid, username, isministryuser,assigneename, userinput)
+    async def postevent(self, requestid, requesttype, userid, username, isministryuser,assigneename='', ministryrequestschema=None):
+        self.posteventsync(requestid, requesttype, userid, username, isministryuser,assigneename, ministryrequestschema)
     
-    def posteventsync(self, requestid, requesttype, userid, username, isministryuser,assigneename='', userinput=None):
+    def posteventsync(self, requestid, requesttype, userid, username, isministryuser,assigneename='', ministryrequestschema=None):
         try: 
-            stateeventresponse = stateevent().createstatetransitionevent(requestid, requesttype, userid, username, userinput)
+            stateeventresponse = stateevent().createstatetransitionevent(requestid, requesttype, userid, username, ministryrequestschema)
             divisioneventresponse = divisionevent().createdivisionevent(requestid, requesttype, userid)
             assignmentresponse = assignmentevent().createassignmentevent(requestid, requesttype, userid, isministryuser,assigneename,username)           
             if stateeventresponse.success == False or divisioneventresponse.success == False or assignmentresponse.success == False: 

--- a/request-management-api/request_api/services/eventservice.py
+++ b/request-management-api/request_api/services/eventservice.py
@@ -24,12 +24,12 @@ class eventservice:
 
     """
     
-    async def postevent(self, requestid, requesttype, userid, username, isministryuser,assigneename='', ministryrequestschema=None):
-        self.posteventsync(requestid, requesttype, userid, username, isministryuser,assigneename, ministryrequestschema)
+    async def postevent(self, requestid, requesttype, userid, username, isministryuser,assigneename=''):
+        self.posteventsync(requestid, requesttype, userid, username, isministryuser,assigneename)
     
-    def posteventsync(self, requestid, requesttype, userid, username, isministryuser,assigneename='', ministryrequestschema=None):
+    def posteventsync(self, requestid, requesttype, userid, username, isministryuser,assigneename=''):
         try: 
-            stateeventresponse = stateevent().createstatetransitionevent(requestid, requesttype, userid, username, ministryrequestschema)
+            stateeventresponse = stateevent().createstatetransitionevent(requestid, requesttype, userid, username)
             divisioneventresponse = divisionevent().createdivisionevent(requestid, requesttype, userid)
             assignmentresponse = assignmentevent().createassignmentevent(requestid, requesttype, userid, isministryuser,assigneename,username)           
             if stateeventresponse.success == False or divisioneventresponse.success == False or assignmentresponse.success == False: 

--- a/request-management-api/request_api/services/foirequest/requestservicecreate.py
+++ b/request-management-api/request_api/services/foirequest/requestservicecreate.py
@@ -73,7 +73,6 @@ class requestservicecreate:
         _foirequestpersonalattrbs = FOIRequestPersonalAttribute().getrequestpersonalattributes(foirequestid,_foirequest["version"])
         foiministryrequestarr = []     
         foirequest = requestserviceministrybuilder().createfoirequestfromobject(_foirequest, userid)
-        ##IS THERE A BUG IN THE BELOW CODE? FOIMINSTYREQUEST IS PASSED IN IN ARG FIELD OF MINISTRY REQUEST SCHEMA
         foiministryrequest = requestserviceministrybuilder().createfoiministryrequestfromobject(_foiministryrequest, ministryrequestschema, userid, usertype)
         foiministryrequestarr.append(foiministryrequest)
         foirequest.ministryRequests = foiministryrequestarr

--- a/request-management-api/request_api/services/foirequest/requestservicecreate.py
+++ b/request-management-api/request_api/services/foirequest/requestservicecreate.py
@@ -66,13 +66,14 @@ class requestservicecreate:
             return result
     
     def saveministryrequestversion(self,ministryrequestschema, foirequestid , ministryid, userid, usertype = None):        
-        _foirequest = FOIRequest().getrequest(foirequestid) 
+        _foirequest = FOIRequest().getrequest(foirequestid)
         _foiministryrequest = FOIMinistryRequest().getrequestbyministryrequestid(ministryid)
         _foirequestapplicant = FOIRequestApplicantMapping().getrequestapplicants(foirequestid,_foirequest["version"])
         _foirequestcontact = FOIRequestContactInformation().getrequestcontactinformation(foirequestid,_foirequest["version"])
         _foirequestpersonalattrbs = FOIRequestPersonalAttribute().getrequestpersonalattributes(foirequestid,_foirequest["version"])
         foiministryrequestarr = []     
         foirequest = requestserviceministrybuilder().createfoirequestfromobject(_foirequest, userid)
+        ##IS THERE A BUG IN THE BELOW CODE? FOIMINSTYREQUEST IS PASSED IN IN ARG FIELD OF MINISTRY REQUEST SCHEMA
         foiministryrequest = requestserviceministrybuilder().createfoiministryrequestfromobject(_foiministryrequest, ministryrequestschema, userid, usertype)
         foiministryrequestarr.append(foiministryrequest)
         foirequest.ministryRequests = foiministryrequestarr

--- a/request-management-api/request_api/services/foirequest/requestserviceministrybuilder.py
+++ b/request-management-api/request_api/services/foirequest/requestserviceministrybuilder.py
@@ -75,6 +75,7 @@ class requestserviceministrybuilder(requestserviceconfigurator):
         else:
             foiministryrequest.assignedto = None if usertype == "iao" and 'assignedto' in requestschema and requestschema['assignedto'] in (None, '') else ministryschema["assignedto"] 
 
+        foiministryrequest.ministrysignoffapproval = ministryschema["ministrysignoffapproval"]
         foiministryrequest.requeststatusid = requestdict['requeststatusid']
         foiministryrequest.programareaid = requestdict['programareaid']
         foiministryrequest.createdby = userid

--- a/request-management-api/request_api/services/foirequest/requestserviceministrybuilder.py
+++ b/request-management-api/request_api/services/foirequest/requestserviceministrybuilder.py
@@ -36,7 +36,6 @@ class requestserviceministrybuilder(requestserviceconfigurator):
         return foirequest
     
     def createfoiministryrequestfromobject(self, ministryschema, requestschema, userid, usertype = None):
-        #BUG IN THIS CODE? MINISTRY SCHEMA IS ARG 1 BUT WHEN THIS IS USED IN REQUESTSERVICECREATE, FOIMINISTRY REQUEST IS PASSED IN AS ARG 1
         requestdict = self.createfoiministryrequestfromobject1(ministryschema, requestschema)
         foiministryrequest = FOIMinistryRequest()
         foiministryrequest.foiministryrequestid = ministryschema["foiministryrequestid"] 

--- a/request-management-api/request_api/services/foirequest/requestserviceministrybuilder.py
+++ b/request-management-api/request_api/services/foirequest/requestserviceministrybuilder.py
@@ -36,6 +36,7 @@ class requestserviceministrybuilder(requestserviceconfigurator):
         return foirequest
     
     def createfoiministryrequestfromobject(self, ministryschema, requestschema, userid, usertype = None):
+        #BUG IN THIS CODE? MINISTRY SCHEMA IS ARG 1 BUT WHEN THIS IS USED IN REQUESTSERVICECREATE, FOIMINISTRY REQUEST IS PASSED IN AS ARG 1
         requestdict = self.createfoiministryrequestfromobject1(ministryschema, requestschema)
         foiministryrequest = FOIMinistryRequest()
         foiministryrequest.foiministryrequestid = ministryschema["foiministryrequestid"] 
@@ -75,7 +76,7 @@ class requestserviceministrybuilder(requestserviceconfigurator):
         else:
             foiministryrequest.assignedto = None if usertype == "iao" and 'assignedto' in requestschema and requestschema['assignedto'] in (None, '') else ministryschema["assignedto"] 
 
-        foiministryrequest.ministrysignoffapproval = ministryschema["ministrysignoffapproval"]
+        foiministryrequest.ministrysignoffapproval = requestdict["ministrysignoffapproval"]
         foiministryrequest.requeststatusid = requestdict['requeststatusid']
         foiministryrequest.programareaid = requestdict['programareaid']
         foiministryrequest.createdby = userid
@@ -115,7 +116,8 @@ class requestserviceministrybuilder(requestserviceconfigurator):
             'programareaid': ministryschema["programarea.programareaid"] if 'programarea.programareaid' in ministryschema  else None,
             'closedate': requestschema['closedate'] if 'closedate' in requestschema  else None,
             'closereasonid': requestschema['closereasonid'] if 'closereasonid' in requestschema  else None,
-            'linkedrequests': ministryschema['linkedrequests'] if 'linkedrequests' in ministryschema  else None
+            'linkedrequests': requestschema['linkedrequests'] if 'linkedrequests' in requestschema  else None,
+            'ministrysignoffapproval': requestschema['ministrysignoffapproval'] if 'ministrysignoffapproval' in requestschema else None,
         }
     
     def createfoirequestdocuments(self,requestschema, ministryrequestid, activeversion, userid):


### PR DESCRIPTION
Backend:
- created migration to create new JSON column (ministrysignoffapproval) for FOIMinistryRequests table
- Adjusted schemas and models for FOIMinistryRequests in backend to use and consume the new column created
- Adjusted eventservice and state service to use the newly created signoffapproval column to create a comment and notif when state is response and requesttype is ministry request

Frontend:
- Adjusted confirmation model for ministry users to take in user input (approver name, approver title, approved date) and send this data to backend by adjusting saveMinistryRequestObject which is sent to backend via api call. 