### PR TITLE
Ticket 4426. Adjsutment/FIX

### DIFF
--- a/request-management-api/request_api/services/divisionstageservice.py
+++ b/request-management-api/request_api/services/divisionstageservice.py
@@ -9,7 +9,7 @@ class divisionstageservice:
         divisionstages = []
         programarea = ProgramArea.getprogramarea(bcgovcode)
         divisions = ProgramAreaDivision.getprogramareadivisions(programarea['programareaid'])
-        divisions.sort(key=lambda item: (item["sortorder"] in (None, 0), item["name"]))        
+        divisions.sort(key=lambda item: (item["sortorder"] if item["sortorder"] not in (None,0) else float('inf'), item["name"]))      
         for division in divisions:
             divisionstages.append({"divisionid": division['divisionid'], "name": self.escapestr(division['name'])})
         return {"divisions": divisionstages, "stages": self.getstages()}


### PR DESCRIPTION
While testing in dev found an issue with the sorting (logic would put name over sortorder even if sortorder was present. For example Transportation would be after Services even though Transportation had a sort order of 1 and Services had a sortorder of 20). Fixed. 

Original PR https://github.com/bcgov/foi-flow/pull/4438