### PR TITLE
4434-Add 'Consult' attachment tag

### DIFF
--- a/forms-flow-web/src/constants/FOI/statusEnum.js
+++ b/forms-flow-web/src/constants/FOI/statusEnum.js
@@ -228,6 +228,13 @@ const AttachmentCategories = Object.freeze({
       bgcolor: "#4B296B",
       type: ["tag"],
     },
+    {
+      name: "consult",
+      tags: ["consult"],
+      display: "Consult",
+      bgcolor: "#7A3A9C",
+      type: ["tag"],
+    },
     { // transition: Response -> On hold
       name: "response-onhold",
       tags: ["response-onhold"],


### PR DESCRIPTION
It looks like there isn't anything else that needs to be updated (eg. no corresponding enums on the backend) - please double check this.