### PR TITLE
Ticket 4539. Fix/Adjustment to exception handling in request-management api

### DIFF
--- a/request-management-api/request_api/resources/foiadmin.py
+++ b/request-management-api/request_api/resources/foiadmin.py
@@ -51,7 +51,7 @@ class FOIProgramAreaDivisions(Resource):
             result = programareadivisionservice().getallprogramareadivisonsandsections()
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500     
 
@@ -72,7 +72,7 @@ class CreateFOIProgramAreaDivision(Resource):
             result = programareadivisionservice().createprogramareadivision(programareadivisionschema)
             return {'status': result.success, 'message':result.message, 'id':result.identifier}, 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400      
+            return {'status': False, 'message': str(type(error).__name__)}, 400      
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500             
 
@@ -94,7 +94,7 @@ class UpdateFOIProgramAreaDivision(Resource):
             result = programareadivisionservice().updateprogramareadivision(divisionid, programareadivisionschema, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message, 'id':result.identifier}, 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500  
 
@@ -115,7 +115,7 @@ class DisableFOIProgramAreaDivision(Resource):
                 return {'status': result.success, 'message': result.message, 'id':result.identifier}, 400  
             return {'status': result.success, 'message':result.message, 'id':result.identifier}, 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400      
+            return {'status': False, 'message': str(type(error).__name__)}, 400      
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
 

--- a/request-management-api/request_api/resources/foiadmin.py
+++ b/request-management-api/request_api/resources/foiadmin.py
@@ -30,6 +30,7 @@ from request_api.utils.cache import cache_filter, response_filter
 
 API = Namespace('FOIAdmin', description='Endpoints for FOI admin management')
 TRACER = Tracer.get_instance()
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
 
 """Custom exception messages
 """
@@ -51,7 +52,7 @@ class FOIProgramAreaDivisions(Resource):
             result = programareadivisionservice().getallprogramareadivisonsandsections()
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500     
 
@@ -72,7 +73,7 @@ class CreateFOIProgramAreaDivision(Resource):
             result = programareadivisionservice().createprogramareadivision(programareadivisionschema)
             return {'status': result.success, 'message':result.message, 'id':result.identifier}, 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400      
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400      
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500             
 
@@ -94,7 +95,7 @@ class UpdateFOIProgramAreaDivision(Resource):
             result = programareadivisionservice().updateprogramareadivision(divisionid, programareadivisionschema, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message, 'id':result.identifier}, 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500  
 
@@ -115,7 +116,7 @@ class DisableFOIProgramAreaDivision(Resource):
                 return {'status': result.success, 'message': result.message, 'id':result.identifier}, 400  
             return {'status': result.success, 'message':result.message, 'id':result.identifier}, 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400      
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400      
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
 

--- a/request-management-api/request_api/resources/foiadmin.py
+++ b/request-management-api/request_api/resources/foiadmin.py
@@ -50,9 +50,9 @@ class FOIProgramAreaDivisions(Resource):
         try:
             result = programareadivisionservice().getallprogramareadivisonsandsections()
             return json.dumps(result), 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
-        except BusinessException as exception:            
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
+        except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500     
 
 @cors_preflight('POST,OPTIONS')
@@ -71,8 +71,8 @@ class CreateFOIProgramAreaDivision(Resource):
             programareadivisionschema = FOIProgramAreaDivisionSchema().load(requestjson)
             result = programareadivisionservice().createprogramareadivision(programareadivisionschema)
             return {'status': result.success, 'message':result.message, 'id':result.identifier}, 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400      
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500             
 
@@ -93,8 +93,8 @@ class UpdateFOIProgramAreaDivision(Resource):
             programareadivisionschema = FOIProgramAreaDivisionSchema().load(requestjson)
             result = programareadivisionservice().updateprogramareadivision(divisionid, programareadivisionschema, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message, 'id':result.identifier}, 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500  
 
@@ -114,8 +114,8 @@ class DisableFOIProgramAreaDivision(Resource):
             if result.success != True:
                 return {'status': result.success, 'message': result.message, 'id':result.identifier}, 400  
             return {'status': result.success, 'message':result.message, 'id':result.identifier}, 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400      
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
 

--- a/request-management-api/request_api/resources/foicfrfee.py
+++ b/request-management-api/request_api/resources/foicfrfee.py
@@ -110,6 +110,6 @@ class FOICFRFee(Resource):
             result = {"current": cfrfeeservice().getcfrfee(requestid), "history": cfrfeeservice().getcfrfeehistory(requestid)}
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   

--- a/request-management-api/request_api/resources/foicfrfee.py
+++ b/request-management-api/request_api/resources/foicfrfee.py
@@ -36,6 +36,7 @@ TRACER = Tracer.get_instance()
 """Custom exception messages
 """
 EXCEPTION_MESSAGE_BAD_REQUEST='Bad Request'
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
         
 @cors_preflight('POST,OPTIONS')
 @API.route('/foicfrfee/foirequest/<requestid>/ministryrequest/<ministryrequestid>')
@@ -58,9 +59,9 @@ class CreateFOICFRFee(Resource):
         except ValidationError as verr:
             logging.error(verr)
             return {'status': False, 'message': str(verr)}, 400     
-        except KeyError as err:
-            logging.error(str(type(err).__name__))
-            return {'status': False, 'message': EXCEPTION_MESSAGE_BAD_REQUEST}, 400        
+        except KeyError as error:
+            logging.error(CUSTOM_KEYERROR_MESSAGE + str(error))
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400     
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -88,9 +89,9 @@ class SanctionFOICFRFee(Resource):
         except ValidationError as verr:
             logging.error(verr)
             return {'status': False, 'message': str(verr)}, 400     
-        except KeyError as err:
-            logging.error(str(type(err).__name__))
-            return {'status': False, 'message': EXCEPTION_MESSAGE_BAD_REQUEST}, 400        
+        except KeyError as error:
+            logging.error(CUSTOM_KEYERROR_MESSAGE + str(error))
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400       
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -110,6 +111,6 @@ class FOICFRFee(Resource):
             result = {"current": cfrfeeservice().getcfrfee(requestid), "history": cfrfeeservice().getcfrfeehistory(requestid)}
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   

--- a/request-management-api/request_api/resources/foicfrfee.py
+++ b/request-management-api/request_api/resources/foicfrfee.py
@@ -59,7 +59,7 @@ class CreateFOICFRFee(Resource):
             logging.error(verr)
             return {'status': False, 'message':verr.messages}, 400     
         except KeyError as err:
-            logging.error(err)
+            logging.error(type(err))
             return {'status': False, 'message': EXCEPTION_MESSAGE_BAD_REQUEST}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
@@ -89,7 +89,7 @@ class SanctionFOICFRFee(Resource):
             logging.error(verr)
             return {'status': False, 'message':verr.messages}, 400     
         except KeyError as err:
-            logging.error(err)
+            logging.error(type(err))
             return {'status': False, 'message': EXCEPTION_MESSAGE_BAD_REQUEST}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
@@ -109,7 +109,7 @@ class FOICFRFee(Resource):
         try:
             result = {"current": cfrfeeservice().getcfrfee(requestid), "history": cfrfeeservice().getcfrfeehistory(requestid)}
             return json.dumps(result), 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   

--- a/request-management-api/request_api/resources/foicfrfee.py
+++ b/request-management-api/request_api/resources/foicfrfee.py
@@ -57,9 +57,9 @@ class CreateFOICFRFee(Resource):
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as verr:
             logging.error(verr)
-            return {'status': False, 'message': verr}, 400     
+            return {'status': False, 'message': str(verr)}, 400     
         except KeyError as err:
-            logging.error(type(err))
+            logging.error(str(type(err).__name__))
             return {'status': False, 'message': EXCEPTION_MESSAGE_BAD_REQUEST}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
@@ -87,9 +87,9 @@ class SanctionFOICFRFee(Resource):
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as verr:
             logging.error(verr)
-            return {'status': False, 'message': verr}, 400     
+            return {'status': False, 'message': str(verr)}, 400     
         except KeyError as err:
-            logging.error(type(err))
+            logging.error(str(type(err).__name__))
             return {'status': False, 'message': EXCEPTION_MESSAGE_BAD_REQUEST}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 

--- a/request-management-api/request_api/resources/foicfrfee.py
+++ b/request-management-api/request_api/resources/foicfrfee.py
@@ -57,7 +57,7 @@ class CreateFOICFRFee(Resource):
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as verr:
             logging.error(verr)
-            return {'status': False, 'message':verr.messages}, 400     
+            return {'status': False, 'message': verr}, 400     
         except KeyError as err:
             logging.error(type(err))
             return {'status': False, 'message': EXCEPTION_MESSAGE_BAD_REQUEST}, 400        
@@ -87,7 +87,7 @@ class SanctionFOICFRFee(Resource):
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as verr:
             logging.error(verr)
-            return {'status': False, 'message':verr.messages}, 400     
+            return {'status': False, 'message': verr}, 400     
         except KeyError as err:
             logging.error(type(err))
             return {'status': False, 'message': EXCEPTION_MESSAGE_BAD_REQUEST}, 400        

--- a/request-management-api/request_api/resources/foicomment.py
+++ b/request-management-api/request_api/resources/foicomment.py
@@ -54,8 +54,8 @@ class CreateFOIRequestComment(Resource):
             if result.success == True:
                 asyncio.ensure_future(eventservice().postcommentevent(result.identifier, "ministryrequest", AuthHelper.getuserid()))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -77,8 +77,8 @@ class CreateFOIRawRequestComment(Resource):
             if result.success == True:
                 asyncio.ensure_future(eventservice().postcommentevent(result.identifier, "rawrequest", AuthHelper.getuserid()))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -108,8 +108,8 @@ class FOIComment(Resource):
                 return json.dumps(result), 200
             else:
                 return {'status': 401, 'message':'Restricted Request'} , 401
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
         
@@ -136,8 +136,8 @@ class FOIDisableComment(Resource):
             if result.success == True:
                 asyncio.ensure_future(eventservice().postcommentevent(result.identifier, requesttype, AuthHelper.getuserid(), True))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -166,8 +166,8 @@ class FOIUpdateComment(Resource):
             if result.success == True:
                 asyncio.ensure_future(eventservice().postcommentevent(commentid, requesttype, AuthHelper.getuserid(), existingtaggedusers=result.args[0]))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foicomment.py
+++ b/request-management-api/request_api/resources/foicomment.py
@@ -184,7 +184,7 @@ class FOIRestrictedRequestTagList(Resource):
             result = commentservice().createcommenttagginguserlist("rawrequest",requestid)
             return json.dumps(result), 200
         except ValueError:
-            return {'status': 500, 'message':"Invalid Request"}, 400    
+            return {'status': 500, 'message':"Invalid Request"}, 500    
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -200,6 +200,6 @@ class FOIRestrictedRequestTagList(Resource):
              result = commentservice().createcommenttagginguserlist("ministryrequest",ministryrequestid)
              return json.dumps(result), 200
         except ValueError:
-            return {'status': 500, 'message':"Invalid Request"}, 400    
+            return {'status': 500, 'message':"Invalid Request"}, 500    
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 

--- a/request-management-api/request_api/resources/foicomment.py
+++ b/request-management-api/request_api/resources/foicomment.py
@@ -55,7 +55,7 @@ class CreateFOIRequestComment(Resource):
                 asyncio.ensure_future(eventservice().postcommentevent(result.identifier, "ministryrequest", AuthHelper.getuserid()))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -78,7 +78,7 @@ class CreateFOIRawRequestComment(Resource):
                 asyncio.ensure_future(eventservice().postcommentevent(result.identifier, "rawrequest", AuthHelper.getuserid()))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -109,7 +109,7 @@ class FOIComment(Resource):
             else:
                 return {'status': 401, 'message':'Restricted Request'} , 401
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
         
@@ -137,7 +137,7 @@ class FOIDisableComment(Resource):
                 asyncio.ensure_future(eventservice().postcommentevent(result.identifier, requesttype, AuthHelper.getuserid(), True))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -167,7 +167,7 @@ class FOIUpdateComment(Resource):
                 asyncio.ensure_future(eventservice().postcommentevent(commentid, requesttype, AuthHelper.getuserid(), existingtaggedusers=result.args[0]))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foicomment.py
+++ b/request-management-api/request_api/resources/foicomment.py
@@ -35,6 +35,7 @@ TRACER = Tracer.get_instance()
 """Custom exception messages
 """
 EXCEPTION_MESSAGE_BAD_REQUEST='Bad Request'
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
         
 @cors_preflight('POST,OPTIONS')
 @API.route('/foicomment/ministryrequest')
@@ -55,7 +56,7 @@ class CreateFOIRequestComment(Resource):
                 asyncio.ensure_future(eventservice().postcommentevent(result.identifier, "ministryrequest", AuthHelper.getuserid()))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -78,7 +79,7 @@ class CreateFOIRawRequestComment(Resource):
                 asyncio.ensure_future(eventservice().postcommentevent(result.identifier, "rawrequest", AuthHelper.getuserid()))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -109,7 +110,7 @@ class FOIComment(Resource):
             else:
                 return {'status': 401, 'message':'Restricted Request'} , 401
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400       
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
         
@@ -137,7 +138,7 @@ class FOIDisableComment(Resource):
                 asyncio.ensure_future(eventservice().postcommentevent(result.identifier, requesttype, AuthHelper.getuserid(), True))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -167,7 +168,7 @@ class FOIUpdateComment(Resource):
                 asyncio.ensure_future(eventservice().postcommentevent(commentid, requesttype, AuthHelper.getuserid(), existingtaggedusers=result.args[0]))
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foidocument.py
+++ b/request-management-api/request_api/resources/foidocument.py
@@ -50,8 +50,8 @@ class GetFOIDocument(Resource):
         try:
             result = documentservice().getrequestdocumentsbyrole(requestid, requesttype, AuthHelper.isministrymember())
             return json.dumps(result), 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
 
@@ -75,8 +75,8 @@ class CreateFOIDocument(Resource):
             return {'status': result.success, 'message':result.message} , 200 
         except ValidationError as err:
                     return {'status': False, 'message':err.messages}, 400
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -99,8 +99,8 @@ class RenameFOIDocument(Resource):
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as err:
                     return {'status': False, 'message':err.messages}, 400
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -137,8 +137,8 @@ class ReclassifyFOIDocument(Resource):
             return {'status': False, 'message': "Something went wrong moving the document's location" }, 500
         except ValidationError as err:
                     return {'status': False, 'message':err.messages}, 400
-        except KeyError as err:
-            return {'status': False, 'message': err.messages}, 400
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -160,8 +160,8 @@ class ReplaceFOIDocument(Resource):
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as err:
                     return {'status': False, 'message':err.messages}, 400
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -180,7 +180,7 @@ class DeleteFOIDocument(Resource):
         try:
             result = documentservice().deleterequestdocument(requestid, documentid, AuthHelper.getuserid(), requesttype)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 

--- a/request-management-api/request_api/resources/foidocument.py
+++ b/request-management-api/request_api/resources/foidocument.py
@@ -74,7 +74,7 @@ class CreateFOIDocument(Resource):
             result = documentservice().createrequestdocument(requestid, documentschema, AuthHelper.getuserid(), requesttype)
             return {'status': result.success, 'message':result.message} , 200 
         except ValidationError as err:
-                    return {'status': False, 'message':err.messages}, 400
+             return {'status': False, 'message': err}, 400
         except KeyError as error:
             return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
@@ -98,7 +98,7 @@ class RenameFOIDocument(Resource):
             result = documentservice().createrequestdocumentversion(requestid, documentid, documentschema, AuthHelper.getuserid(), requesttype)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as err:
-                    return {'status': False, 'message':err.messages}, 400
+            return {'status': False, 'message': err}, 400
         except KeyError as error:
             return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
@@ -136,7 +136,7 @@ class ReclassifyFOIDocument(Resource):
                  return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
             return {'status': False, 'message': "Something went wrong moving the document's location" }, 500
         except ValidationError as err:
-                    return {'status': False, 'message':err.messages}, 400
+            return {'status': False, 'message': err}, 400
         except KeyError as error:
             return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:
@@ -159,7 +159,7 @@ class ReplaceFOIDocument(Resource):
             result = documentservice().createrequestdocumentversion(requestid, documentid, documentschema, AuthHelper.getuserid(), requesttype)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as err:
-                    return {'status': False, 'message':err.messages}, 400
+            return {'status': False, 'message': err}, 400
         except KeyError as error:
             return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            

--- a/request-management-api/request_api/resources/foidocument.py
+++ b/request-management-api/request_api/resources/foidocument.py
@@ -51,7 +51,7 @@ class GetFOIDocument(Resource):
             result = documentservice().getrequestdocumentsbyrole(requestid, requesttype, AuthHelper.isministrymember())
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
 
@@ -76,7 +76,7 @@ class CreateFOIDocument(Resource):
         except ValidationError as err:
              return {'status': False, 'message': err}, 400
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -100,7 +100,7 @@ class RenameFOIDocument(Resource):
         except ValidationError as err:
             return {'status': False, 'message': err}, 400
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -138,7 +138,7 @@ class ReclassifyFOIDocument(Resource):
         except ValidationError as err:
             return {'status': False, 'message': err}, 400
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -161,7 +161,7 @@ class ReplaceFOIDocument(Resource):
         except ValidationError as err:
             return {'status': False, 'message': err}, 400
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -181,6 +181,6 @@ class DeleteFOIDocument(Resource):
             result = documentservice().deleterequestdocument(requestid, documentid, AuthHelper.getuserid(), requesttype)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 

--- a/request-management-api/request_api/resources/foidocument.py
+++ b/request-management-api/request_api/resources/foidocument.py
@@ -74,7 +74,7 @@ class CreateFOIDocument(Resource):
             result = documentservice().createrequestdocument(requestid, documentschema, AuthHelper.getuserid(), requesttype)
             return {'status': result.success, 'message':result.message} , 200 
         except ValidationError as err:
-             return {'status': False, 'message': err}, 400
+             return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
@@ -98,7 +98,7 @@ class RenameFOIDocument(Resource):
             result = documentservice().createrequestdocumentversion(requestid, documentid, documentschema, AuthHelper.getuserid(), requesttype)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as err:
-            return {'status': False, 'message': err}, 400
+            return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
@@ -136,7 +136,7 @@ class ReclassifyFOIDocument(Resource):
                  return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
             return {'status': False, 'message': "Something went wrong moving the document's location" }, 500
         except ValidationError as err:
-            return {'status': False, 'message': err}, 400
+            return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:
@@ -159,7 +159,7 @@ class ReplaceFOIDocument(Resource):
             result = documentservice().createrequestdocumentversion(requestid, documentid, documentschema, AuthHelper.getuserid(), requesttype)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except ValidationError as err:
-            return {'status': False, 'message': err}, 400
+            return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            

--- a/request-management-api/request_api/resources/foidocument.py
+++ b/request-management-api/request_api/resources/foidocument.py
@@ -31,7 +31,8 @@ import boto3
 
 
 API = Namespace('FOIDocument', description='Endpoints for FOI Document management')
-TRACER = Tracer.get_instance()  
+TRACER = Tracer.get_instance()
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "  
         
     
 @cors_preflight('GET,OPTIONS')
@@ -51,7 +52,7 @@ class GetFOIDocument(Resource):
             result = documentservice().getrequestdocumentsbyrole(requestid, requesttype, AuthHelper.isministrymember())
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
 
@@ -76,7 +77,7 @@ class CreateFOIDocument(Resource):
         except ValidationError as err:
              return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -100,7 +101,7 @@ class RenameFOIDocument(Resource):
         except ValidationError as err:
             return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400       
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -138,7 +139,7 @@ class ReclassifyFOIDocument(Resource):
         except ValidationError as err:
             return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -161,7 +162,7 @@ class ReplaceFOIDocument(Resource):
         except ValidationError as err:
             return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -181,6 +182,6 @@ class DeleteFOIDocument(Resource):
             result = documentservice().deleterequestdocument(requestid, documentid, AuthHelper.getuserid(), requesttype)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 

--- a/request-management-api/request_api/resources/foiemail.py
+++ b/request-management-api/request_api/resources/foiemail.py
@@ -50,7 +50,7 @@ class FOISendEmail(Resource):
             result = emailservice().send(servicename.upper(), requestid, ministryrequestid, emailschema)
             return json.dumps(result), 200 if result["success"] == True else 500
         except ValueError as err:
-            return {'status': 500, 'message':err.messages}, 500
+            return {'status': 500, 'message': str(err)}, 500
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
@@ -71,7 +71,7 @@ class FOIAcknowledgeSendEmail(Resource):
             result = emailservice().acknowledge(servicename.upper(), requestid, ministryrequestid)
             return json.dumps(result), 200 if result["success"] == True else 500
         except ValueError as err:
-            return {'status': 500, 'message':err.messages}, 500
+            return {'status': 500, 'message': str(err)}, 500
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            

--- a/request-management-api/request_api/resources/foiemail.py
+++ b/request-management-api/request_api/resources/foiemail.py
@@ -52,7 +52,7 @@ class FOISendEmail(Resource):
         except ValueError as err:
             return {'status': 500, 'message':err.messages}, 500
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -73,7 +73,7 @@ class FOIAcknowledgeSendEmail(Resource):
         except ValueError as err:
             return {'status': 500, 'message':err.messages}, 500
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         

--- a/request-management-api/request_api/resources/foiemail.py
+++ b/request-management-api/request_api/resources/foiemail.py
@@ -32,6 +32,7 @@ from flask_cors import cross_origin
 
 API = Namespace('FOIEmail', description='Endpoints for FOI EMAIL management')
 TRACER = Tracer.get_instance()
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
 
 @cors_preflight('POST,OPTIONS')
 @API.route('/foiemail/<requestid>/ministryrequest/<ministryrequestid>/<servicename>')
@@ -52,7 +53,7 @@ class FOISendEmail(Resource):
         except ValueError as err:
             return {'status': 500, 'message': str(err)}, 500
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -73,7 +74,7 @@ class FOIAcknowledgeSendEmail(Resource):
         except ValueError as err:
             return {'status': 500, 'message': str(err)}, 500
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         

--- a/request-management-api/request_api/resources/foiemail.py
+++ b/request-management-api/request_api/resources/foiemail.py
@@ -51,8 +51,8 @@ class FOISendEmail(Resource):
             return json.dumps(result), 200 if result["success"] == True else 500
         except ValueError as err:
             return {'status': 500, 'message':err.messages}, 500
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -72,8 +72,8 @@ class FOIAcknowledgeSendEmail(Resource):
             return json.dumps(result), 200 if result["success"] == True else 500
         except ValueError as err:
             return {'status': 500, 'message':err.messages}, 500
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         

--- a/request-management-api/request_api/resources/foiextension.py
+++ b/request-management-api/request_api/resources/foiextension.py
@@ -37,6 +37,7 @@ TRACER = Tracer.get_instance()
 """Custom exception messages
 """
 EXCEPTION_MESSAGE_BAD_REQUEST='Bad Request'
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
 
 @cors_preflight('GET,OPTIONS')
 @API.route('/foiextension/ministryrequest/<requestid>')
@@ -53,7 +54,7 @@ class GetFOIExtensions(Resource):
             extensionrecords = extensionservice().getrequestextensions(requestid)            
             return json.dumps(extensionrecords), 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -72,7 +73,7 @@ class GetFOIExtension(Resource):
             extensionrecord = extensionservice().getrequestextension(extensionid)            
             return json.dumps(extensionrecord), 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -97,7 +98,7 @@ class CreateFOIRequestExtension(Resource):
                     newduedate, = result.args
                     return {'status': result.success, 'message':result.message,'id':result.identifier, 'newduedate': newduedate or None} , 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -122,7 +123,7 @@ class SaveAXISRequestExtension(Resource):
                         eventservice().posteventforaxisextension(ministryrequestid, result.args[0], AuthHelper.getuserid(), AuthHelper.getusername(), "add")
                     return {'status': result.success, 'message':result.message} , 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -146,7 +147,7 @@ class EditFOIRequestExtension(Resource):
                     newduedate = result.args[-1] if len(result.args) > 0 else None
                     return {'status': result.success, 'message':result.message,'id':result.identifier, 'newduedate': newduedate or None} , 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400       
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
 
@@ -168,6 +169,6 @@ class DeleteFOIRequestExtension(Resource):
                     newduedate = result.args[-1] if len(result.args) > 0 else None
                     return {'status': result.success, 'message':result.message,'id':result.identifier, 'newduedate': newduedate or None} , 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500    

--- a/request-management-api/request_api/resources/foiextension.py
+++ b/request-management-api/request_api/resources/foiextension.py
@@ -53,7 +53,7 @@ class GetFOIExtensions(Resource):
             extensionrecords = extensionservice().getrequestextensions(requestid)            
             return json.dumps(extensionrecords), 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -72,7 +72,7 @@ class GetFOIExtension(Resource):
             extensionrecord = extensionservice().getrequestextension(extensionid)            
             return json.dumps(extensionrecord), 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -97,7 +97,7 @@ class CreateFOIRequestExtension(Resource):
                     newduedate, = result.args
                     return {'status': result.success, 'message':result.message,'id':result.identifier, 'newduedate': newduedate or None} , 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -122,7 +122,7 @@ class SaveAXISRequestExtension(Resource):
                         eventservice().posteventforaxisextension(ministryrequestid, result.args[0], AuthHelper.getuserid(), AuthHelper.getusername(), "add")
                     return {'status': result.success, 'message':result.message} , 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -146,7 +146,7 @@ class EditFOIRequestExtension(Resource):
                     newduedate = result.args[-1] if len(result.args) > 0 else None
                     return {'status': result.success, 'message':result.message,'id':result.identifier, 'newduedate': newduedate or None} , 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
 
@@ -168,6 +168,6 @@ class DeleteFOIRequestExtension(Resource):
                     newduedate = result.args[-1] if len(result.args) > 0 else None
                     return {'status': result.success, 'message':result.message,'id':result.identifier, 'newduedate': newduedate or None} , 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500    

--- a/request-management-api/request_api/resources/foiextension.py
+++ b/request-management-api/request_api/resources/foiextension.py
@@ -52,8 +52,8 @@ class GetFOIExtensions(Resource):
         try:
             extensionrecords = extensionservice().getrequestextensions(requestid)            
             return json.dumps(extensionrecords), 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -71,8 +71,8 @@ class GetFOIExtension(Resource):
         try:
             extensionrecord = extensionservice().getrequestextension(extensionid)            
             return json.dumps(extensionrecord), 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -96,8 +96,8 @@ class CreateFOIRequestExtension(Resource):
                     eventservice().posteventforextension(ministryrequestid, result.identifier, AuthHelper.getuserid(), AuthHelper.getusername(), "add")
                     newduedate, = result.args
                     return {'status': result.success, 'message':result.message,'id':result.identifier, 'newduedate': newduedate or None} , 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -121,8 +121,8 @@ class SaveAXISRequestExtension(Resource):
                     if len(result.args) > 0:
                         eventservice().posteventforaxisextension(ministryrequestid, result.args[0], AuthHelper.getuserid(), AuthHelper.getusername(), "add")
                     return {'status': result.success, 'message':result.message} , 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
 
@@ -145,8 +145,8 @@ class EditFOIRequestExtension(Resource):
                     # posteventforextension moved to createrequestextensionversion to generate the comments before updating the ministry table with new due date
                     newduedate = result.args[-1] if len(result.args) > 0 else None
                     return {'status': result.success, 'message':result.message,'id':result.identifier, 'newduedate': newduedate or None} , 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500   
 
@@ -167,7 +167,7 @@ class DeleteFOIRequestExtension(Resource):
                     eventservice().posteventforextension(ministryrequestid, extensionid, AuthHelper.getuserid(), AuthHelper.getusername(), "delete")
                     newduedate = result.args[-1] if len(result.args) > 0 else None
                     return {'status': result.success, 'message':result.message,'id':result.identifier, 'newduedate': newduedate or None} , 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500    

--- a/request-management-api/request_api/resources/foinotification.py
+++ b/request-management-api/request_api/resources/foinotification.py
@@ -47,8 +47,8 @@ class FOINotification(Resource):
             return json.dumps(result), 200
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -72,8 +72,8 @@ class FOIDismissNotification(Resource):
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 500
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -92,8 +92,8 @@ class FOIReminderNotification(Resource):
             reminderresponse = eventservice().postreminderevent()
             respcode = 200 if reminderresponse.success == True else 500
             return {'status': reminderresponse.success, 'message':reminderresponse.message,'id': reminderresponse.identifier} , respcode
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -113,7 +113,7 @@ class FOIReminderNotification(Resource):
             reminderresponse = eventservice().postpaymentexpiryevent(ministry_request_id)
             respcode = 200 if reminderresponse.success == True else 500
             return {'status': reminderresponse.success, 'message':reminderresponse.message,'id': reminderresponse.identifier} , respcode
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500

--- a/request-management-api/request_api/resources/foinotification.py
+++ b/request-management-api/request_api/resources/foinotification.py
@@ -48,7 +48,7 @@ class FOINotification(Resource):
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -73,7 +73,7 @@ class FOIDismissNotification(Resource):
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -93,7 +93,7 @@ class FOIReminderNotification(Resource):
             respcode = 200 if reminderresponse.success == True else 500
             return {'status': reminderresponse.success, 'message':reminderresponse.message,'id': reminderresponse.identifier} , respcode
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -114,6 +114,6 @@ class FOIReminderNotification(Resource):
             respcode = 200 if reminderresponse.success == True else 500
             return {'status': reminderresponse.success, 'message':reminderresponse.message,'id': reminderresponse.identifier} , respcode
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500

--- a/request-management-api/request_api/resources/foinotification.py
+++ b/request-management-api/request_api/resources/foinotification.py
@@ -30,6 +30,7 @@ from flask_cors import cross_origin
 
 API = Namespace('FOINotification', description='Endpoints for FOI notification management')
 TRACER = Tracer.get_instance()
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
 
 @cors_preflight('GET,OPTIONS')
 @API.route('/foinotifications')
@@ -48,7 +49,7 @@ class FOINotification(Resource):
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -73,7 +74,7 @@ class FOIDismissNotification(Resource):
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400       
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -93,7 +94,7 @@ class FOIReminderNotification(Resource):
             respcode = 200 if reminderresponse.success == True else 500
             return {'status': reminderresponse.success, 'message':reminderresponse.message,'id': reminderresponse.identifier} , respcode
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -114,6 +115,6 @@ class FOIReminderNotification(Resource):
             respcode = 200 if reminderresponse.success == True else 500
             return {'status': reminderresponse.success, 'message':reminderresponse.message,'id': reminderresponse.identifier} , respcode
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500

--- a/request-management-api/request_api/resources/foipayment.py
+++ b/request-management-api/request_api/resources/foipayment.py
@@ -31,6 +31,7 @@ from flask_cors import cross_origin
 
 API = Namespace('FOIPayment', description='Endpoints for FOI Payment management')
 TRACER = Tracer.get_instance()
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
 
 @cors_preflight('POST,OPTIONS')
 @API.route('/foipayment/<requestid>/ministryrequest/<ministryrequestid>')
@@ -49,7 +50,7 @@ class CreateFOIPayment(Resource):
             result = paymentservice().createpayment(requestid, ministryrequestid, paymentschema)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -70,7 +71,7 @@ class CreateFOIPayment(Resource):
             result = paymentservice().cancelpayment(requestid, ministryrequestid, paymentschema)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -89,7 +90,7 @@ class GetFOIPayment(Resource):
             result = paymentservice().getpayment(requestid, ministryrequestid)
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foipayment.py
+++ b/request-management-api/request_api/resources/foipayment.py
@@ -49,7 +49,7 @@ class CreateFOIPayment(Resource):
             result = paymentservice().createpayment(requestid, ministryrequestid, paymentschema)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -70,7 +70,7 @@ class CreateFOIPayment(Resource):
             result = paymentservice().cancelpayment(requestid, ministryrequestid, paymentschema)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -89,7 +89,7 @@ class GetFOIPayment(Resource):
             result = paymentservice().getpayment(requestid, ministryrequestid)
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foipayment.py
+++ b/request-management-api/request_api/resources/foipayment.py
@@ -48,8 +48,8 @@ class CreateFOIPayment(Resource):
             paymentschema = FOIRequestPaymentSchema().load(requestjson)  
             result = paymentservice().createpayment(requestid, ministryrequestid, paymentschema)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -69,8 +69,8 @@ class CreateFOIPayment(Resource):
             paymentschema = FOIRequestPaymentSchema().load(requestjson)
             result = paymentservice().cancelpayment(requestid, ministryrequestid, paymentschema)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -88,8 +88,8 @@ class GetFOIPayment(Resource):
         try:
             result = paymentservice().getpayment(requestid, ministryrequestid)
             return json.dumps(result), 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foirecord.py
+++ b/request-management-api/request_api/resources/foirecord.py
@@ -47,7 +47,7 @@ class FOIRequestGetRecord(Resource):
             result = recordservice().fetch(requestid, ministryrequestid)
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except Exception as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -70,7 +70,7 @@ class FOIRequestBulkCreateRecord(Resource):
             respcode = 200 if response.success == True else 500
             return {'status': response.success, 'message':response.message,'data': response.args[0]} , respcode
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -92,7 +92,7 @@ class UpdateFOIDocument(Resource):
             result = recordservice().update(requestid, ministryrequestid, data, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -113,7 +113,7 @@ class RetryFOIDocument(Resource):
             result = recordservice().retry(requestid, ministryrequestid, recordschema)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -135,7 +135,7 @@ class ReplaceFOIDocument(Resource):
 
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -158,7 +158,7 @@ class FOIRequestDownloadRecord(Resource):
             respcode = 200 if response.success == True else 500
             return {'status': response.success, 'message':response.message,'id':response.identifier}, respcode
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -178,7 +178,7 @@ class FOIRequestDownloadRecord(Resource):
             result = recordservice().getpdfstitchpackagetodownload(ministryrequestid, recordstype.lower())
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -199,8 +199,8 @@ class FOIRequestPDFStitchStatus(Resource):
             #("getpdfstichstatus result == ", result)
             return result, 200
         except KeyError as error:
-            print("KeyError")
-            return {'status': False, 'message': f"{error=}"}, 400  
+            print(str(type(error).__name__))
+            return {'status': False, 'message': str(type(error).__name__)}, 400  
         except BusinessException as exception:
             print("BusinessException == ", exception.message)
             return {'status': exception.status_code, 'message':exception.message}, 500
@@ -225,8 +225,8 @@ class FOIRequestRecordsChanged(Resource):
             #print("records changed == ", result)
             return result, 200
         except KeyError as error:
-            print("KeyError")
-            return {'status': False, 'message': f"{error=}"}, 400
+            print(str(type(error).__name__))
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:
             print("BusinessException == ", exception.message)
             return {'status': exception.status_code, 'message':exception.message}, 500

--- a/request-management-api/request_api/resources/foirecord.py
+++ b/request-management-api/request_api/resources/foirecord.py
@@ -30,6 +30,7 @@ from flask_cors import cross_origin
 
 API = Namespace('FOIWatcher', description='Endpoints for FOI record management')
 TRACER = Tracer.get_instance()
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
 
 @cors_preflight('GET,OPTIONS')
 @API.route('/foirecord/<requestid>/ministryrequest/<ministryrequestid>')
@@ -47,7 +48,7 @@ class FOIRequestGetRecord(Resource):
             result = recordservice().fetch(requestid, ministryrequestid)
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except Exception as exception:
             return {'status': False, 'message': str(exception)}, 500
 
@@ -70,7 +71,7 @@ class FOIRequestBulkCreateRecord(Resource):
             respcode = 200 if response.success == True else 500
             return {'status': response.success, 'message':response.message,'data': response.args[0]} , respcode
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -92,7 +93,7 @@ class UpdateFOIDocument(Resource):
             result = recordservice().update(requestid, ministryrequestid, data, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -113,7 +114,7 @@ class RetryFOIDocument(Resource):
             result = recordservice().retry(requestid, ministryrequestid, recordschema)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -135,7 +136,7 @@ class ReplaceFOIDocument(Resource):
 
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -158,7 +159,7 @@ class FOIRequestDownloadRecord(Resource):
             respcode = 200 if response.success == True else 500
             return {'status': response.success, 'message':response.message,'id':response.identifier}, respcode
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -178,7 +179,7 @@ class FOIRequestDownloadRecord(Resource):
             result = recordservice().getpdfstitchpackagetodownload(ministryrequestid, recordstype.lower())
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -199,8 +200,8 @@ class FOIRequestPDFStitchStatus(Resource):
             #("getpdfstichstatus result == ", result)
             return result, 200
         except KeyError as error:
-            print(str(type(error).__name__))
-            return {'status': False, 'message': str(type(error).__name__)}, 400  
+            print(CUSTOM_KEYERROR_MESSAGE + str(error))
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400  
         except BusinessException as exception:
             print("BusinessException == ", exception.message)
             return {'status': exception.status_code, 'message':exception.message}, 500
@@ -225,8 +226,8 @@ class FOIRequestRecordsChanged(Resource):
             #print("records changed == ", result)
             return result, 200
         except KeyError as error:
-            print(str(type(error).__name__))
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            print(CUSTOM_KEYERROR_MESSAGE + str(error))
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:
             print("BusinessException == ", exception.message)
             return {'status': exception.status_code, 'message':exception.message}, 500

--- a/request-management-api/request_api/resources/foirecord.py
+++ b/request-management-api/request_api/resources/foirecord.py
@@ -46,8 +46,8 @@ class FOIRequestGetRecord(Resource):
         try:
             result = recordservice().fetch(requestid, ministryrequestid)
             return json.dumps(result), 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except Exception as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -69,8 +69,8 @@ class FOIRequestBulkCreateRecord(Resource):
             response = recordservice().create(requestid, ministryrequestid, recordschema, AuthHelper.getuserid())
             respcode = 200 if response.success == True else 500
             return {'status': response.success, 'message':response.message,'data': response.args[0]} , respcode
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -91,8 +91,8 @@ class UpdateFOIDocument(Resource):
             data = FOIRequestRecordUpdateSchema().load(requestjson)
             result = recordservice().update(requestid, ministryrequestid, data, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
-        except KeyError as err:
-            return {'status': False, 'message':err['messages']}, 400
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -112,8 +112,8 @@ class RetryFOIDocument(Resource):
             recordschema = FOIRequestBulkRetryRecordSchema().load(requestjson, unknown=INCLUDE)
             result = recordservice().retry(requestid, ministryrequestid, recordschema)
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -134,8 +134,8 @@ class ReplaceFOIDocument(Resource):
             result = recordservice().replace(requestid, ministryrequestid,recordid, recordschema,AuthHelper.getuserid())
 
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -157,8 +157,8 @@ class FOIRequestDownloadRecord(Resource):
             response = recordservice().triggerpdfstitchservice(requestid, ministryrequestid, recordschema, AuthHelper.getuserid())
             respcode = 200 if response.success == True else 500
             return {'status': response.success, 'message':response.message,'id':response.identifier}, respcode
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -177,8 +177,8 @@ class FOIRequestDownloadRecord(Resource):
         try:
             result = recordservice().getpdfstitchpackagetodownload(ministryrequestid, recordstype.lower())
             return json.dumps(result), 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -198,15 +198,15 @@ class FOIRequestPDFStitchStatus(Resource):
             result = recordservice().getpdfstichstatus(ministryrequestid, recordstype.lower())
             #("getpdfstichstatus result == ", result)
             return result, 200
-        except KeyError as err:
-            print("KeyError == ", err.messages)
-            return {'status': False, 'message':err.messages}, 400
+        except KeyError as error:
+            print("KeyError")
+            return {'status': False, 'message': f"{error=}"}, 400  
         except BusinessException as exception:
             print("BusinessException == ", exception.message)
             return {'status': exception.status_code, 'message':exception.message}, 500
         except Exception as error:
             print("Exception error == ", error)
-            return {'status': False, 'message':error.message}, 500
+            return {'status': False, 'message': f"{error=}"}, 500
     
 @cors_preflight('GET,OPTIONS')
 @API.route('/foirecord/<requestid>/ministryrequest/<ministryrequestid>/<recordstype>/recrodschanged')
@@ -224,12 +224,12 @@ class FOIRequestRecordsChanged(Resource):
             result = recordservice().isrecordschanged(ministryrequestid, recordstype.lower())
             #print("records changed == ", result)
             return result, 200
-        except KeyError as err:
-            print("KeyError == ", err.messages)
-            return {'status': False, 'message':err.messages}, 400
+        except KeyError as error:
+            print("KeyError")
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:
             print("BusinessException == ", exception.message)
             return {'status': exception.status_code, 'message':exception.message}, 500
         except Exception as error:
             print("Exception error == ", error)
-            return {'status': False, 'message':error.message}, 500
+            return {'status': False, 'message': f"{error=}"}, 500

--- a/request-management-api/request_api/resources/foirecord.py
+++ b/request-management-api/request_api/resources/foirecord.py
@@ -49,7 +49,7 @@ class FOIRequestGetRecord(Resource):
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400
         except Exception as exception:
-            return {'status': exception.status_code, 'message':exception.message}, 500
+            return {'status': False, 'message': str(exception)}, 500
 
 @cors_preflight('POST,OPTIONS')
 @API.route('/foirecord/<requestid>/ministryrequest/<ministryrequestid>')
@@ -206,7 +206,7 @@ class FOIRequestPDFStitchStatus(Resource):
             return {'status': exception.status_code, 'message':exception.message}, 500
         except Exception as error:
             print("Exception error == ", error)
-            return {'status': False, 'message': f"{error=}"}, 500
+            return {'status': False, 'message': str(error)}, 500
     
 @cors_preflight('GET,OPTIONS')
 @API.route('/foirecord/<requestid>/ministryrequest/<ministryrequestid>/<recordstype>/recrodschanged')
@@ -232,4 +232,4 @@ class FOIRequestRecordsChanged(Resource):
             return {'status': exception.status_code, 'message':exception.message}, 500
         except Exception as error:
             print("Exception error == ", error)
-            return {'status': False, 'message': f"{error=}"}, 500
+            return {'status': False, 'message': str(error)}, 500

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -36,6 +36,7 @@ import asyncio
 API = Namespace('FOIRequests', description='Endpoints for FOI request management')
 TRACER = Tracer.get_instance()
 EXCEPTION_MESSAGE_NOTFOUND_REQUEST='Record not found'
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
 
 
 @cors_preflight('GET,OPTIONS')
@@ -73,7 +74,7 @@ class FOIRequest(Resource):
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -119,7 +120,7 @@ class FOIRequests(Resource):
         except ValidationError as err:
             return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400                    
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400                    
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -148,7 +149,7 @@ class FOIRequestsById(Resource):
         except ValidationError as err:
             return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400    
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400    
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
     
@@ -188,7 +189,7 @@ class FOIRequestsByIdAndType(Resource):
         except ValidationError as err:
             return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -247,7 +248,7 @@ class FOIRequestDetailsByMinistryId(Resource):
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -117,7 +117,7 @@ class FOIRequests(Resource):
 
             return {'status': result.success, 'message':result.message,'id':result.identifier, 'ministryRequests': result.args[0]} , 200
         except ValidationError as err:
-                    return {'status': False, 'message':err.messages}, 400
+            return {'status': False, 'message': err}, 400
         except KeyError as error:
             return {'status': False, 'message': f"{error=}"}, 400                    
         except BusinessException as exception:            
@@ -146,7 +146,7 @@ class FOIRequestsById(Resource):
             else:
                  return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
         except ValidationError as err:
-            return {'status': False, 'message':err.messages}, 400
+            return {'status': False, 'message': err}, 400
         except KeyError as error:
             return {'status': False, 'message': f"{error=}"}, 400    
         except BusinessException as exception:            
@@ -186,7 +186,7 @@ class FOIRequestsByIdAndType(Resource):
             else:
                  return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
         except ValidationError as err:
-            return {'status': False, 'message':err.messages}, 400
+            return {'status': False, 'message': err}, 400
         except KeyError as error:
             return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:            
@@ -224,7 +224,7 @@ class FOIRequestUpdateById(Resource):
             else:
                  return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
         except ValidationError as err:
-            return {'status': False, 'message':err.messages}, 40
+            return {'status': False, 'message': err}, 40
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -72,8 +72,8 @@ class FOIRequest(Resource):
             return jsondata , statuscode 
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -118,8 +118,8 @@ class FOIRequests(Resource):
             return {'status': result.success, 'message':result.message,'id':result.identifier, 'ministryRequests': result.args[0]} , 200
         except ValidationError as err:
                     return {'status': False, 'message':err.messages}, 400
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400                    
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400                    
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -147,8 +147,8 @@ class FOIRequestsById(Resource):
                  return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
         except ValidationError as err:
             return {'status': False, 'message':err.messages}, 400
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400    
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400    
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
     
@@ -187,8 +187,8 @@ class FOIRequestsByIdAndType(Resource):
                  return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
         except ValidationError as err:
             return {'status': False, 'message':err.messages}, 400
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -246,8 +246,8 @@ class FOIRequestDetailsByMinistryId(Resource):
             return jsondata , statuscode 
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -73,7 +73,7 @@ class FOIRequest(Resource):
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -119,7 +119,7 @@ class FOIRequests(Resource):
         except ValidationError as err:
             return {'status': False, 'message': err}, 400
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400                    
+            return {'status': False, 'message': str(type(error).__name__)}, 400                    
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -148,7 +148,7 @@ class FOIRequestsById(Resource):
         except ValidationError as err:
             return {'status': False, 'message': err}, 400
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400    
+            return {'status': False, 'message': str(type(error).__name__)}, 400    
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
     
@@ -188,7 +188,7 @@ class FOIRequestsByIdAndType(Resource):
         except ValidationError as err:
             return {'status': False, 'message': err}, 400
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400
+            return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -247,7 +247,7 @@ class FOIRequestDetailsByMinistryId(Resource):
         except ValueError:
             return {'status': 500, 'message':"Invalid Request Id"}, 500
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -117,7 +117,7 @@ class FOIRequests(Resource):
 
             return {'status': result.success, 'message':result.message,'id':result.identifier, 'ministryRequests': result.args[0]} , 200
         except ValidationError as err:
-            return {'status': False, 'message': err}, 400
+            return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400                    
         except BusinessException as exception:            
@@ -146,7 +146,7 @@ class FOIRequestsById(Resource):
             else:
                  return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
         except ValidationError as err:
-            return {'status': False, 'message': err}, 400
+            return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400    
         except BusinessException as exception:            
@@ -186,7 +186,7 @@ class FOIRequestsByIdAndType(Resource):
             else:
                  return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
         except ValidationError as err:
-            return {'status': False, 'message': err}, 400
+            return {'status': False, 'message': str(err)}, 400
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400
         except BusinessException as exception:            
@@ -224,7 +224,7 @@ class FOIRequestUpdateById(Resource):
             else:
                  return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
         except ValidationError as err:
-            return {'status': False, 'message': err}, 40
+            return {'status': False, 'message': str(err)}, 400
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -271,7 +271,7 @@ class FOIRestrictedMinistryRequest(Resource):
                 else:
                   return {'status': result.success, 'message':result.message,'id':result.identifier} , 500  
         except ValueError:
-            return {'status': 500, 'message':"Invalid Request"}, 400    
+            return {'status': 500, 'message':"Invalid Request"}, 500    
         except BusinessException as exception:
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -287,6 +287,6 @@ class FOIRequestByMinistryId(Resource):
         try :
             return FOIRequest.get(requestservice().getrequestid(ministryrequestid), ministryrequestid, usertype)
         except ValueError:
-            return {'status': 500, 'message':"Invalid Request"}, 400
+            return {'status': 500, 'message':"Invalid Request"}, 500
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 

--- a/request-management-api/request_api/resources/foiwatcher.py
+++ b/request-management-api/request_api/resources/foiwatcher.py
@@ -50,7 +50,7 @@ class FOIRawRequestWatcher(Resource):
         except ValueError as err:
             return {'status': 500, 'message':err.messages}, 500
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -73,7 +73,7 @@ class CreateFOIRawRequestWatcher(Resource):
                 eventservice().posteventforwatcher(requestjson["requestid"], requestjson, "rawrequest",AuthHelper.getuserid(), AuthHelper.getusername())
             return {'status': result.success, 'message':result.message} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -92,7 +92,7 @@ class DisableFOIRawRequestWatcher(Resource):
             result = watcherservice().disablerawrequestwatchers(requestid, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
                   
@@ -111,7 +111,7 @@ class FOIRequestWatcher(Resource):
             result = watcherservice().getministryrequestwatchers(ministryrequestid,AuthHelper.isministrymember())
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500         
         
@@ -134,7 +134,7 @@ class CreateFOIRequestWatcher(Resource):
                 eventservice().posteventforwatcher(requestjson["ministryrequestid"], requestjson, "ministryrequest", AuthHelper.getuserid(), AuthHelper.getusername())
             return {'status': result.success, 'message':result.message} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -153,6 +153,6 @@ class DisableFOIRequestWatcher(Resource):
             result = watcherservice().disableministryrequestwatchers(ministryrequestid, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500

--- a/request-management-api/request_api/resources/foiwatcher.py
+++ b/request-management-api/request_api/resources/foiwatcher.py
@@ -49,8 +49,8 @@ class FOIRawRequestWatcher(Resource):
             return json.dumps(result), 200
         except ValueError as err:
             return {'status': 500, 'message':err.messages}, 500
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -72,8 +72,8 @@ class CreateFOIRawRequestWatcher(Resource):
             if result.success == True:
                 eventservice().posteventforwatcher(requestjson["requestid"], requestjson, "rawrequest",AuthHelper.getuserid(), AuthHelper.getusername())
             return {'status': result.success, 'message':result.message} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -91,8 +91,8 @@ class DisableFOIRawRequestWatcher(Resource):
         try:
             result = watcherservice().disablerawrequestwatchers(requestid, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
                   
@@ -110,8 +110,8 @@ class FOIRequestWatcher(Resource):
         try:
             result = watcherservice().getministryrequestwatchers(ministryrequestid,AuthHelper.isministrymember())
             return json.dumps(result), 200
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500         
         
@@ -133,8 +133,8 @@ class CreateFOIRequestWatcher(Resource):
             if result.success == True:
                 eventservice().posteventforwatcher(requestjson["ministryrequestid"], requestjson, "ministryrequest", AuthHelper.getuserid(), AuthHelper.getusername())
             return {'status': result.success, 'message':result.message} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -152,7 +152,7 @@ class DisableFOIRequestWatcher(Resource):
         try:
             result = watcherservice().disableministryrequestwatchers(ministryrequestid, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500

--- a/request-management-api/request_api/resources/foiwatcher.py
+++ b/request-management-api/request_api/resources/foiwatcher.py
@@ -48,7 +48,7 @@ class FOIRawRequestWatcher(Resource):
             result = watcherservice().getrawrequestwatchers(requestid)
             return json.dumps(result), 200
         except ValueError as err:
-            return {'status': 500, 'message':err.messages}, 500
+            return {'status': 500, 'message': str(err)}, 500
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            

--- a/request-management-api/request_api/resources/foiwatcher.py
+++ b/request-management-api/request_api/resources/foiwatcher.py
@@ -32,6 +32,7 @@ from flask_cors import cross_origin
 
 API = Namespace('FOIWatcher', description='Endpoints for FOI watcher management')
 TRACER = Tracer.get_instance()
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
 
 @cors_preflight('GET,OPTIONS')
 @API.route('/foiwatcher/rawrequest/<requestid>')
@@ -50,7 +51,7 @@ class FOIRawRequestWatcher(Resource):
         except ValueError as err:
             return {'status': 500, 'message': str(err)}, 500
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
@@ -73,7 +74,7 @@ class CreateFOIRawRequestWatcher(Resource):
                 eventservice().posteventforwatcher(requestjson["requestid"], requestjson, "rawrequest",AuthHelper.getuserid(), AuthHelper.getusername())
             return {'status': result.success, 'message':result.message} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
         
@@ -92,7 +93,7 @@ class DisableFOIRawRequestWatcher(Resource):
             result = watcherservice().disablerawrequestwatchers(requestid, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
                   
@@ -111,7 +112,7 @@ class FOIRequestWatcher(Resource):
             result = watcherservice().getministryrequestwatchers(ministryrequestid,AuthHelper.isministrymember())
             return json.dumps(result), 200
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400       
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500         
         
@@ -134,7 +135,7 @@ class CreateFOIRequestWatcher(Resource):
                 eventservice().posteventforwatcher(requestjson["ministryrequestid"], requestjson, "ministryrequest", AuthHelper.getuserid(), AuthHelper.getusername())
             return {'status': result.success, 'message':result.message} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 
         
@@ -153,6 +154,6 @@ class DisableFOIRequestWatcher(Resource):
             result = watcherservice().disableministryrequestwatchers(ministryrequestid, AuthHelper.getuserid())
             return {'status': result.success, 'message':result.message,'id':result.identifier} , 200 
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500

--- a/request-management-api/request_api/resources/foiworkflow.py
+++ b/request-management-api/request_api/resources/foiworkflow.py
@@ -46,7 +46,7 @@ class FOIWorkflow(Resource):
             response = workflowservice().syncwfinstance(requesttype, requestid, True)
             return json.dumps({"message": str(response)}), 200
         except ValueError as err:
-            return {'status': 500, 'message':err.messages}, 500
+            return {'status': 500, 'message': str(err)}, 500
         except KeyError as error:
             return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            

--- a/request-management-api/request_api/resources/foiworkflow.py
+++ b/request-management-api/request_api/resources/foiworkflow.py
@@ -29,6 +29,7 @@ import logging
 
 API = Namespace('FOIWorkflow', description='Endpoints for FOI workflow management')
 TRACER = Tracer.get_instance()
+CUSTOM_KEYERROR_MESSAGE = "Key error has occured: "
 
 @cors_preflight('POST,OPTIONS')
 @API.route('/foiworkflow/<requesttype>/<requestid>/sync')
@@ -48,7 +49,7 @@ class FOIWorkflow(Resource):
         except ValueError as err:
             return {'status': 500, 'message': str(err)}, 500
         except KeyError as error:
-            return {'status': False, 'message': str(type(error).__name__)}, 400        
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foiworkflow.py
+++ b/request-management-api/request_api/resources/foiworkflow.py
@@ -48,7 +48,7 @@ class FOIWorkflow(Resource):
         except ValueError as err:
             return {'status': 500, 'message':err.messages}, 500
         except KeyError as error:
-            return {'status': False, 'message': f"{error=}"}, 400        
+            return {'status': False, 'message': str(type(error).__name__)}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/resources/foiworkflow.py
+++ b/request-management-api/request_api/resources/foiworkflow.py
@@ -47,8 +47,8 @@ class FOIWorkflow(Resource):
             return json.dumps({"message": str(response)}), 200
         except ValueError as err:
             return {'status': 500, 'message':err.messages}, 500
-        except KeyError as err:
-            return {'status': False, 'message':err.messages}, 400        
+        except KeyError as error:
+            return {'status': False, 'message': f"{error=}"}, 400        
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 

--- a/request-management-api/request_api/services/rawrequestservice.py
+++ b/request-management-api/request_api/services/rawrequestservice.py
@@ -68,7 +68,7 @@ class rawrequestservice:
             try:
                 workflowservice().createinstance(redispubservice.foirequestqueueredischannel, json_data)
             except Exception as ex:
-                logging.error("Unable to create instance")
+                logging.error(ex)
                 asyncio.ensure_future(redispubservice.publishrequest(json_data))
         return result
 

--- a/request-management-api/request_api/services/rawrequestservice.py
+++ b/request-management-api/request_api/services/rawrequestservice.py
@@ -68,7 +68,7 @@ class rawrequestservice:
             try:
                 workflowservice().createinstance(redispubservice.foirequestqueueredischannel, json_data)
             except Exception as ex:
-                logging.error("Unable to create instance", ex)
+                logging.error("Unable to create instance")
                 asyncio.ensure_future(redispubservice.publishrequest(json_data))
         return result
 

--- a/request-management-api/request_api/services/workflowservice.py
+++ b/request-management-api/request_api/services/workflowservice.py
@@ -26,7 +26,7 @@ class workflowservice:
     def createinstance(self, definitionkey, message):
         response = bpmservice().createinstance(definitionkey, json.loads(message))
         if response is None:
-            raise BusinessException(Error.INVALID_INPUT)
+            raise Exception("Unable to create instance for key"+ definitionkey)
         return response
 
     def postunopenedevent(self, id, wfinstanceid, requestsschema, status, ministries=None):        

--- a/request-management-api/request_api/services/workflowservice.py
+++ b/request-management-api/request_api/services/workflowservice.py
@@ -2,7 +2,7 @@ import requests
 import os
 import json
 from enum import Enum
-from request_api.exceptions import BusinessException
+from request_api.exceptions import BusinessException, Error
 from request_api.utils.redispublisher import RedisPublisherService
 from request_api.services.external.bpmservice import MessageType, bpmservice, ProcessDefinitionKey
 from request_api.services.cfrfeeservice import cfrfeeservice
@@ -26,7 +26,7 @@ class workflowservice:
     def createinstance(self, definitionkey, message):
         response = bpmservice().createinstance(definitionkey, json.loads(message))
         if response is None:
-            raise BusinessException("Unable to create instance for key"+ definitionkey)
+            raise BusinessException(Error.INVALID_INPUT)
         return response
 
     def postunopenedevent(self, id, wfinstanceid, requestsschema, status, ministries=None):        

--- a/request-management-api/request_api/tracer.py
+++ b/request-management-api/request_api/tracer.py
@@ -34,7 +34,7 @@ class Tracer():  # pylint: disable=too-few-public-methods
     def __init__(self):
         """Virtually private constructor."""
         if Tracer.__instance is not None:
-            raise BusinessException('Attempt made to create multiple tracing instances')
+            raise Exception('Attempt made to create multiple tracing instances')
 
         api_tracer = ApiTracer()
         Tracer.__instance = ApiTracing(api_tracer.tracer)

--- a/request-management-api/request_api/utils/redispublisher.py
+++ b/request-management-api/request_api/utils/redispublisher.py
@@ -22,7 +22,7 @@ class RedisPublisherService:
             logging.info(message)
             self.publishtoredischannel(self.foicommentqueueredischannel, message)
         except Exception as ex:
-            current_app.logger.error("%s,%s" % ('Unable to get user details', ex.message)) 
+            current_app.logger.error("%s,%s" % ('Unable to get user details', ex)) 
             raise ex
               
     def publishtoredischannel(self, channel , message):  


### PR DESCRIPTION
Python 3 exceptions do not have a message attributes. See [PEP 352](https://www.python.org/dev/peps/pep-0352/) for more details.

Please see corresponding docreviewer PR here: https://github.com/bcgov/foi-docreviewer/pull/560