### PR TITLE
Ticket 4671/4679. Logic adjustment for oipc review flag (new api endpoint is called when no review is selected) 

### DIFF
--- a/forms-flow-web/src/apiManager/endpoints/index.js
+++ b/forms-flow-web/src/apiManager/endpoints/index.js
@@ -25,6 +25,7 @@ const API = {
   FOI_GET_RECEIVED_MODELIST: `${FOI_BASE_API_URL}/api/foiflow/receivedmodes`,
   FOI_POST_REQUEST_POST: `${FOI_BASE_API_URL}/api/foirequests`,
   FOI_REQUEST_API: `${FOI_BASE_API_URL}/api/foirequests/<requestid>/ministryrequest/<ministryid>`,
+  FOI_REQUEST_SECTION_API: `${FOI_BASE_API_URL}/api/foirequests/<requestid>/ministryrequest/<ministryid>/section`,
   FOI_MINISTRYVIEW_REQUEST_API: `${FOI_BASE_API_URL}/api/foirequests/<requestid>/ministryrequest/<ministryid>/ministry`,
   FOI_RAW_REQUEST_DESCRIPTION: `${FOI_BASE_API_URL}/api/foiaudit/rawrequest/<requestid>/description`,
   FOI_MINISTRY_REQUEST_DESCRIPTION: `${FOI_BASE_API_URL}/api/foiaudit/ministryrequest/<ministryid>/description`,

--- a/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
+++ b/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
@@ -525,3 +525,27 @@ export const fetchRestrictedRequestCommentTagList = (requestid, ministryId, ...r
   }
 };
 
+export const deleteOIPCDetails = (requestId, ministryId, ...rest) => {
+  const done = fnDone(rest);
+  let apiUrl= replaceUrl(replaceUrl(
+    API.FOI_REQUEST_API,
+    "<ministryid>",
+    ministryId),"<requestid>",requestId
+  );
+  const data = {isoipcreview: false, oipcdetails: []}
+  return (dispatch) => {
+    httpPOSTRequest(`${apiUrl}/deleteoipc`, data)
+      .then((res) => {
+        if (res.data) {
+          done(null, res.data);
+        } else {
+          dispatch(serviceActionError(res));
+          throw new Error(`Error while saving the OIPC Details for the (request# ${requestId}, ministry# ${ministryId})`);            
+        }
+      })
+      .catch((error) => {
+        done(error);
+        catchError(error, dispatch);
+      });
+  };
+}

--- a/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
+++ b/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
@@ -528,13 +528,13 @@ export const fetchRestrictedRequestCommentTagList = (requestid, ministryId, ...r
 export const deleteOIPCDetails = (requestId, ministryId, ...rest) => {
   const done = fnDone(rest);
   let apiUrl= replaceUrl(replaceUrl(
-    API.FOI_REQUEST_API,
+    API.FOI_REQUEST_SECTION_API,
     "<ministryid>",
     ministryId),"<requestid>",requestId
   );
   const data = {isoipcreview: false, oipcdetails: []}
   return (dispatch) => {
-    httpPOSTRequest(`${apiUrl}/deleteoipc`, data)
+    httpPOSTRequest(`${apiUrl}/oipc`, data)
       .then((res) => {
         if (res.data) {
           done(null, res.data);

--- a/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -34,6 +34,7 @@ import {
   fetchFOIRequestDescriptionList,
   fetchRequestDataFromAxis,
   fetchRestrictedRequestCommentTagList,
+  deleteOIPCDetails
 } from "../../../apiManager/services/FOI/foiRequestServices";
 import { fetchFOIRequestAttachmentsList } from "../../../apiManager/services/FOI/foiAttachmentServices";
 import { fetchCFRForm } from "../../../apiManager/services/FOI/foiCFRFormServices";
@@ -87,6 +88,7 @@ import DivisionalTracking from "./DivisionalTracking";
 import RedactionSummary from "./RedactionSummary";
 import AxisDetails from "./AxisDetails/AxisDetails";
 import AxisMessageBanner from "./AxisDetails/AxisMessageBanner";
+import { toast } from "react-toastify";
 import HomeIcon from "@mui/icons-material/Home";
 import { RecordsLog } from "../customComponents/Records";
 import { UnsavedModal } from "../customComponents";
@@ -663,16 +665,51 @@ const FOIRequest = React.memo(({ userDetail }) => {
     setAssignedToValue(value);
   };
 
+  const saveOIPCNoReview = () => {
+    removeAllOIPCs();
+    setIsOIPCReview(false);
+    dispatch(
+      deleteOIPCDetails(
+        requestId,
+        ministryId, 
+        (err, _res) => {
+        if(!err) {
+          toast.success("OIPC details have been saved successfully.", {
+            position: "top-right",
+            autoClose: 3000,
+            hideProgressBar: true,
+            closeOnClick: true,
+            pauseOnHover: true,
+            draggable: true,
+            progress: undefined,
+          });
+        } else {
+          toast.error(
+            "Temporarily unable to save the OIPC details. Please try again in a few minutes.",
+            {
+              position: "top-right",
+              autoClose: 3000,
+              hideProgressBar: true,
+              closeOnClick: true,
+              pauseOnHover: true,
+              draggable: true,
+              progress: undefined,
+            }
+          );
+        }
+      })
+    )
+  }
+
   const oipcSectionRef = React.useRef(null);
   const handleOipcReviewFlagChange = (isSelected) => {
     if (!isSelected) {
-      removeAllOIPCs();
-    }
-    setIsOIPCReview(isSelected);
-    requestDetails.isoipcreview = isSelected;
-    oipcSectionRef.current.scrollIntoView();
-    //timeout to allow react state to update after setState call
-    if (isSelected) {
+      saveOIPCNoReview();
+    } else {
+      setIsOIPCReview(isSelected);
+      requestDetails.isoipcreview = isSelected;
+      oipcSectionRef.current.scrollIntoView();
+      //timeout to allow react state to update after setState call
       setTimeout(() => {
         oipcSectionRef.current.scrollIntoView();
       }, (10));
@@ -938,6 +975,8 @@ const FOIRequest = React.memo(({ userDetail }) => {
       requestState !== StateEnum.appfeeowing.name &&
       requestDetails?.requestType === FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_GENERAL)
   }
+
+  console.log(requestDetails)
 
   
   return (!isLoading &&

--- a/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -976,9 +976,6 @@ const FOIRequest = React.memo(({ userDetail }) => {
       requestDetails?.requestType === FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_GENERAL)
   }
 
-  console.log(requestDetails)
-
-  
   return (!isLoading &&
     requestDetails &&
     Object.keys(requestDetails).length !== 0) ||

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -136,7 +136,7 @@ class FOIRequestsById(Resource):
     def post(foirequestid,foiministryrequestid):
         """ POST Method for capturing FOI requests before processing"""
         try:
-            request_json = request.get_json()   
+            request_json = request.get_json() 
             foirequestschema = FOIRequestWrapperSchema().load(request_json)  
             result = requestservice().saverequestversion(foirequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid())
             if result.success == True:
@@ -289,5 +289,34 @@ class FOIRequestByMinistryId(Resource):
             return FOIRequest.get(requestservice().getrequestid(ministryrequestid), ministryrequestid, usertype)
         except ValueError:
             return {'status': 500, 'message':"Invalid Request"}, 500
+        except BusinessException as exception:            
+            return {'status': exception.status_code, 'message':exception.message}, 500
+
+@cors_preflight('POST, DELETE, OPTIONS')
+@API.route('/foirequests/<int:foirequestid>/ministryrequest/<int:foiministryrequestid>/deleteoipc')
+class FOIRequestsById(Resource):
+    """Creates a new version of foi request for iao users deleting all oipc details"""
+    @staticmethod
+    @TRACER.trace()
+    @cross_origin(origins=allowedorigins())
+    @auth.require
+    def post(foirequestid,foiministryrequestid):
+        try:
+            current_foirequest = requestservice().getrequest(foirequestid, foiministryrequestid)
+            current_foirequest['isoipcreview'] = False
+            current_foirequest['oipcdetails'] = []
+            foirequestschema = FOIRequestWrapperSchema().load(current_foirequest)  
+            result = requestservice().saverequestversion(foirequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid())
+            if result.success == True:
+                asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(),AuthHelper.isministrymember()))
+                metadata = json.dumps({"id": result.identifier, "ministries": result.args[0]})
+                requestservice().posteventtoworkflow(foiministryrequestid,  foirequestschema, json.loads(metadata),"iao")
+                return {'status': result.success, 'message':result.message,'id':result.identifier, 'ministryRequests': result.args[0]} , 200
+            else:
+                 return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
+        except ValidationError as err:
+            return {'status': False, 'message': str(err)}, 400
+        except KeyError as error:
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400    
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500 

--- a/request-management-api/request_api/resources/foirequest.py
+++ b/request-management-api/request_api/resources/foirequest.py
@@ -126,7 +126,6 @@ class FOIRequests(Resource):
         
 @cors_preflight('GET,POST,PUT,OPTIONS')
 @API.route('/foirequests/<int:foirequestid>/ministryrequest/<int:foiministryrequestid>')
-@API.route('/foirequests/<int:foirequestid>/ministryrequest/<int:foiministryrequestid>/<string:actiontype>')
 class FOIRequestsById(Resource):
     """Creates a new version of foi request for iao updates"""
 
@@ -134,17 +133,11 @@ class FOIRequestsById(Resource):
     @TRACER.trace()
     @cross_origin(origins=allowedorigins())
     @auth.require
-    def post(foirequestid,foiministryrequestid,actiontype=None):
+    def post(foirequestid,foiministryrequestid):
         """ POST Method for capturing FOI requests before processing"""
         try:
-            if actiontype == "deleteoipc":
-                current_foirequest = requestservice().getrequest(foirequestid, foiministryrequestid)
-                current_foirequest['isoipcreview'] = False
-                current_foirequest['oipcdetails'] = []
-                foirequestschema = FOIRequestWrapperSchema().load(current_foirequest)  
-            else:
-                request_json = request.get_json() 
-                foirequestschema = FOIRequestWrapperSchema().load(request_json)  
+            request_json = request.get_json() 
+            foirequestschema = FOIRequestWrapperSchema().load(request_json)  
             result = requestservice().saverequestversion(foirequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid())
             if result.success == True:
                 asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(),AuthHelper.isministrymember()))
@@ -299,31 +292,33 @@ class FOIRequestByMinistryId(Resource):
         except BusinessException as exception:            
             return {'status': exception.status_code, 'message':exception.message}, 500
 
-# @cors_preflight('POST, DELETE, OPTIONS')
-# @API.route('/foirequests/<int:foirequestid>/ministryrequest/<int:foiministryrequestid>/deleteoipc')
-# class FOIRequestsById(Resource):
-#     """Creates a new version of foi request for iao users deleting all oipc details"""
-#     @staticmethod
-#     @TRACER.trace()
-#     @cross_origin(origins=allowedorigins())
-#     @auth.require
-#     def post(foirequestid,foiministryrequestid):
-#         try:
-#             current_foirequest = requestservice().getrequest(foirequestid, foiministryrequestid)
-#             current_foirequest['isoipcreview'] = False
-#             current_foirequest['oipcdetails'] = []
-#             foirequestschema = FOIRequestWrapperSchema().load(current_foirequest)  
-#             result = requestservice().saverequestversion(foirequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid())
-#             if result.success == True:
-#                 asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(),AuthHelper.isministrymember()))
-#                 metadata = json.dumps({"id": result.identifier, "ministries": result.args[0]})
-#                 requestservice().posteventtoworkflow(foiministryrequestid,  foirequestschema, json.loads(metadata),"iao")
-#                 return {'status': result.success, 'message':result.message,'id':result.identifier, 'ministryRequests': result.args[0]} , 200
-#             else:
-#                  return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
-#         except ValidationError as err:
-#             return {'status': False, 'message': str(err)}, 400
-#         except KeyError as error:
-#             return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400    
-#         except BusinessException as exception:            
-#             return {'status': exception.status_code, 'message':exception.message}, 500 
+@cors_preflight('POST, DELETE, UPDATE, OPTIONS')
+@API.route('/foirequests/<int:foirequestid>/ministryrequest/<int:foiministryrequestid>/section/<string:section>')
+class FOIRequestsById(Resource):
+    """Creates a new version of foi request for iao users adjusting speciifc sections of a FOI Request"""
+    @staticmethod
+    @TRACER.trace()
+    @cross_origin(origins=allowedorigins())
+    @auth.require
+    def post(foirequestid,foiministryrequestid,section):
+        try:
+            request_json = request.get_json()
+            if (section == "oipc"):
+                foirequest = requestservice().getrequest(foirequestid, foiministryrequestid)
+                foirequest['isoipcreview'] = request_json['isoipcreview']
+                foirequest['oipcdetails'] = request_json['oipcdetails']
+            foirequestschema = FOIRequestWrapperSchema().load(foirequest)  
+            result = requestservice().saverequestversion(foirequestschema, foirequestid, foiministryrequestid,AuthHelper.getuserid())
+            if result.success == True:
+                asyncio.ensure_future(eventservice().postevent(foiministryrequestid,"ministryrequest",AuthHelper.getuserid(),AuthHelper.getusername(),AuthHelper.isministrymember()))
+                metadata = json.dumps({"id": result.identifier, "ministries": result.args[0]})
+                requestservice().posteventtoworkflow(foiministryrequestid,  foirequestschema, json.loads(metadata),"iao")
+                return {'status': result.success, 'message':result.message,'id':result.identifier, 'ministryRequests': result.args[0]} , 200
+            else:
+                 return {'status': False, 'message':EXCEPTION_MESSAGE_NOTFOUND_REQUEST,'id':foirequestid} , 404
+        except ValidationError as err:
+            return {'status': False, 'message': str(err)}, 400
+        except KeyError as error:
+            return {'status': False, 'message': CUSTOM_KEYERROR_MESSAGE + str(error)}, 400    
+        except BusinessException as exception:            
+            return {'status': exception.status_code, 'message':exception.message}, 500 


### PR DESCRIPTION
Per Jackies comments in ticket 4679 -> biz would like to save oipc details when no review is selected from the oipc flag. This required an endpoint / backend call to make isoipcreview to false + oipcdetails to empty array + adjust version etc for the coresponding foirequest. 