### PR TITLE
4929 (Bug fix) Changes to validate user group (before open)

### DIFF
--- a/request-management-api/request_api/models/FOIRawRequests.py
+++ b/request-management-api/request_api/models/FOIRawRequests.py
@@ -629,7 +629,7 @@ class FOIRawRequest(db.Model):
                     return basequery.filter(
                         and_(
                             FOIRawRequest.status.notin_(['Archived']),
-                            or_(and_(FOIRawRequest.isiaorestricted == False, FOIRawRequest.assignedgroup.in_(ProcessingTeamWithKeycloackGroup.list())), and_(FOIRawRequest.isiaorestricted == True, FOIRawRequest.assignedto == userid))))
+                            or_(and_(FOIRawRequest.isiaorestricted == False, FOIRawRequest.assignedgroup.in_(ProcessingTeamWithKeycloackGroup.list()), FOIRawRequest.assignedgroup.in_(tuple(groups))), and_(FOIRawRequest.isiaorestricted == True, FOIRawRequest.assignedto == userid))))
                 return basequery.filter(
                     and_(
                         FOIRawRequest.status.notin_(['Archived']),


### PR DESCRIPTION
This fixes the bug of request being listed in all members of processing team; if the request belongs to processing team.

Unit Testing:

1. Create a request
2. Assign request between different groups & verify the dashboard queue (Before open)
3. Open the request 
4. Verify the ministry queue