### PR TITLE
FOIMOD-2982- Comments Tab - Type of Comments (Peer Review, Internal, General) - Observation 9 fix

### DIFF
--- a/forms-flow-web/src/components/FOI/customComponents/Comments/InputField.js
+++ b/forms-flow-web/src/components/FOI/customComponents/Comments/InputField.js
@@ -301,7 +301,7 @@ const InputField = ({ cancellor, parentId, child, inputvalue, edit, main, add, f
             ) : null}
           </div>
         </div>
-        {edit == true &&
+        {edit &&
           <Grid item xs={12} lg={6}>
             <FormControl component="fieldset">
               <RadioGroup

--- a/forms-flow-web/src/components/FOI/customComponents/Comments/InputField.js
+++ b/forms-flow-web/src/components/FOI/customComponents/Comments/InputField.js
@@ -301,35 +301,37 @@ const InputField = ({ cancellor, parentId, child, inputvalue, edit, main, add, f
             ) : null}
           </div>
         </div>
-        <Grid item xs={12} lg={6}>
-          <FormControl component="fieldset">
-            <RadioGroup
-              id="status-options"
-              row
-              name="controlled-radio-buttons-group"
-              value={editCommentTypeId}
-              onChange={(e) => {
-                setEditCommentTypeId(Number(e.target.value));
-              }}
-            >
-            <FormControlLabel 
-              value={getCommentTypeIdByName(commentTypes, "User submitted")}
-              control={<Radio color="default" id="rbextpending" />}
-              label="General"
-            />
-            <FormControlLabel
-              value={isMinistry ? getCommentTypeIdByName(commentTypes, "Ministry Internal"):getCommentTypeIdByName(commentTypes, "IAO Internal") }
-              control={<Radio color="default" id="rbextapproved" />}
-              label="Internal"
-            />
-            <FormControlLabel
-              value={isMinistry ? getCommentTypeIdByName(commentTypes,"Ministry Peer Review"): getCommentTypeIdByName(commentTypes, "IAO Peer Review")}
-              control={<Radio color="default" id="rbextdenied" />}
-              label="Peer Review"
-            />
-            </RadioGroup>
-          </FormControl>
-        </Grid>
+        {edit == true &&
+          <Grid item xs={12} lg={6}>
+            <FormControl component="fieldset">
+              <RadioGroup
+                id="status-options"
+                row
+                name="controlled-radio-buttons-group"
+                value={editCommentTypeId}
+                onChange={(e) => {
+                  setEditCommentTypeId(Number(e.target.value));
+                }}
+              >
+              <FormControlLabel 
+                value={getCommentTypeIdByName(commentTypes, "User submitted")}
+                control={<Radio color="default" id="rbextpending" />}
+                label="General"
+              />
+              <FormControlLabel
+                value={isMinistry ? getCommentTypeIdByName(commentTypes, "Ministry Internal"):getCommentTypeIdByName(commentTypes, "IAO Internal") }
+                control={<Radio color="default" id="rbextapproved" />}
+                label="Internal"
+              />
+              <FormControlLabel
+                value={isMinistry ? getCommentTypeIdByName(commentTypes,"Ministry Peer Review"): getCommentTypeIdByName(commentTypes, "IAO Peer Review")}
+                control={<Radio color="default" id="rbextdenied" />}
+                label="Peer Review"
+              />
+              </RadioGroup>
+            </FormControl>
+          </Grid>
+        }
         <Editor
           editorState={editorState}
           onChange={_handleChange}

--- a/request-management-api/request_api/schemas/foicomment.py
+++ b/request-management-api/request_api/schemas/foicomment.py
@@ -39,6 +39,8 @@ class EditFOIRawRequestCommentSchema(Schema):
         unknown = EXCLUDE    
     comment = fields.Str(data_key="comment")
     taggedusers = fields.Str(data_key="taggedusers")
+    commenttypeid= fields.Int(data_key="commenttypeid",allow_none=True)
+
 
 
 


### PR DESCRIPTION
**Description:**
Update on Observation 9 - Comment replies should have the same type as the parent comment and if the parent comment type is edited it should update reply comment types as well