### PR TITLE
Ticket 3467 - Incorrect page count (recordspagecount) bug fix

### DIFF
--- a/request-management-api/request_api/schemas/foirequestwrapper.py
+++ b/request-management-api/request_api/schemas/foirequestwrapper.py
@@ -91,7 +91,6 @@ class FOIRequestWrapperSchema(Schema):
     axisSyncDate = fields.Str(data_key="axisSyncDate",allow_none=True)  
     axisRequestId = fields.Str(data_key="axisRequestId",allow_none=True, validate=[validate.Length(max=120, error=MAX_EXCEPTION_MESSAGE)])
     axispagecount = fields.Int(data_key="axispagecount",allow_none=True)
-    recordspagecount = fields.Int(data_key="recordspagecount",allow_none=True)
     description = fields.Str(data_key="description", required=True,validate=[validate.Length(min=1, error=BLANK_EXCEPTION_MESSAGE)])
     category = fields.Str(data_key="category", required=True,validate=[validate.Length(min=1, error=BLANK_EXCEPTION_MESSAGE)])
     requestType = fields.Str(data_key="requestType", required=True,validate=[validate.Length(min=1, error=BLANK_EXCEPTION_MESSAGE)]) 
@@ -160,7 +159,6 @@ class FOIRequestWrapperSchema(Schema):
     estimatedpagecount = fields.Int(data_key="estimatedpagecount",allow_none=True)
     estimatedtaggedpagecount = fields.Int(data_key="estimatedtaggedpagecount",allow_none=True)
 
-    recordspagecount = fields.Int(data_key="recordspagecount",allow_none=True)
     axislanpagecount = fields.Int(data_key="axislanpagecount",allow_none=True)
 
 class EditableFOIMinistryRequestWrapperSchema(Schema):

--- a/request-management-api/request_api/services/foirequest/requestservicebuilder.py
+++ b/request-management-api/request_api/services/foirequest/requestservicebuilder.py
@@ -23,6 +23,7 @@ class requestservicebuilder(requestserviceconfigurator):
     """
 
     def createministry(self, requestschema, ministry, activeversion, userid, filenumber=None, ministryid=None):
+        current_foiministryrequest = FOIMinistryRequest.getrequest(ministryid)
         foiministryrequest = FOIMinistryRequest()
         foiministryrequest.__dict__.update(ministry)
         foiministryrequest.requeststatusid = self.__getrequeststatusid(requestschema.get("requeststatuslabel"))
@@ -32,7 +33,7 @@ class requestservicebuilder(requestserviceconfigurator):
         foiministryrequest.axissyncdate = requestschema.get("axisSyncDate")
         foiministryrequest.axispagecount = requestschema.get("axispagecount")
         foiministryrequest.axislanpagecount = requestschema.get("axislanpagecount")
-        foiministryrequest.recordspagecount = requestschema.get("recordspagecount")
+        foiministryrequest.recordspagecount = current_foiministryrequest["recordspagecount"] if current_foiministryrequest not in (None, {}) else 0
         foiministryrequest.filenumber = self.generatefilenumber(ministry["code"], requestschema.get("foirawrequestid")) if filenumber is None else filenumber
         foiministryrequest.programareaid = self.getvalueof("programArea",ministry["code"])
         foiministryrequest.description = requestschema.get("description")


### PR DESCRIPTION
Adjusted backend cod/logic for iao users making foi request changes (new request ornew versions) in regards to records page count data. Client no longer sends recordspagecount data when requests are updated and created by IAO, instead BE and DB call is done in requestservice to get the latest recordspagecount from the latest ministry request (which was generated by the page count calculator service).

From my understanding, the page count calculator service should solely adjust and update the recordspagecount field in a foi request.