### PR TITLE
fix(foi-request): preserve BCPS AssignedTo value after state transition

### DIFF
--- a/forms-flow-web/src/apiManager/services/FOI/foiMasterDataServices.js
+++ b/forms-flow-web/src/apiManager/services/FOI/foiMasterDataServices.js
@@ -1,524 +1,363 @@
 import {
-    httpGETRequest,
-    httpPOSTRequest,
-    httpOpenGETRequest
-  } from "../../httpRequestHandler";
-  import API from "../../endpoints";
-  import {
-    serviceActionError,
-    setFOILoader,
-    setFOIAssignedToListLoader,
-    setFOICategoryList,
-    setFOIProgramAreaList,
-    setFOIAssignedToList,
-    setFOIProcessingTeamList,
-    setFOIFullAssignedToList,
-    setFOIMinistryAssignedToList,
-    setFOIDeliveryModeList,
-    setFOIReceivedModeList,
-    setFOIMinistryDivisionalStages,
-    setFOIPersonalDivisionsAndSections,
-    setFOIPersonalPeople,
-    setFOIPersonalFiletypes,
-    setFOIPersonalVolumes,
-    setFOIPersonalSections,
-    setClosingReasons,
-    setFOISubjectCodeList,  
-    setCommentTagListLoader, 
-    setFOIAdminProgramAreaList,
-    setOIPCOutcomes,
-    setOIPCStatuses,
-    setOIPCReviewtypes,
-    setOIPCInquiryoutcomes,
-    setOIExemptions,
-    setOIPublicationStatuses,
-    setOIStatuses,
-    setFOICommentTypes,
-    setFOIEmailTemplates
-  } from "../../../actions/FOI/foiRequestActions";
-  import { fnDone, catchError } from "./foiServicesUtil";
-  import UserService from "../../../services/UserService";
-  import { replaceUrl, addToFullnameList, getAssignToList, getFullnameTeamList } from "../../../helper/FOI/helper";
-  
-  export const fetchFOICategoryList = () => {
-    const firstCategory = { "applicantcategoryid": 0, "name": "Select Category" };
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_CATEGORIES_API, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const foiRequestCategoryList = res.data;
-            let data = foiRequestCategoryList.map((category) => {
-              return { ...category };
-            });
-            data.unshift(firstCategory);
-            dispatch(setFOICategoryList(data));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching category master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching category master data", error);
-          dispatch(serviceActionError(error));
+  httpGETRequest,
+  httpPOSTRequest,
+  httpOpenGETRequest
+} from "../../httpRequestHandler";
+import API from "../../endpoints";
+import {
+  serviceActionError,
+  setFOILoader,
+  setFOIAssignedToListLoader,
+  setFOICategoryList,
+  setFOIProgramAreaList,
+  setFOIAssignedToList,
+  setFOIProcessingTeamList,
+  setFOIFullAssignedToList,
+  setFOIMinistryAssignedToList,
+  setFOIDeliveryModeList,
+  setFOIReceivedModeList,
+  setFOIMinistryDivisionalStages,
+  setFOIPersonalDivisionsAndSections,
+  setFOIPersonalPeople,
+  setFOIPersonalFiletypes,
+  setFOIPersonalVolumes,
+  setFOIPersonalSections,
+  setClosingReasons,
+  setFOISubjectCodeList,
+  setCommentTagListLoader,
+  setFOIAdminProgramAreaList,
+  setOIPCOutcomes,
+  setOIPCStatuses,
+  setOIPCReviewtypes,
+  setOIPCInquiryoutcomes,
+  setOIExemptions,
+  setOIPublicationStatuses,
+  setOIStatuses,
+  setFOICommentTypes,
+  setFOIEmailTemplates
+} from "../../../actions/FOI/foiRequestActions";
+import { fnDone, catchError } from "./foiServicesUtil";
+import UserService from "../../../services/UserService";
+import { replaceUrl, addToFullnameList, getAssignToList, getFullnameTeamList } from "../../../helper/FOI/helper";
+
+export const fetchFOICategoryList = () => {
+  const firstCategory = { "applicantcategoryid": 0, "name": "Select Category" };
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_CATEGORIES_API, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const foiRequestCategoryList = res.data;
+          let data = foiRequestCategoryList.map((category) => {
+            return { ...category };
+          });
+          data.unshift(firstCategory);
+          dispatch(setFOICategoryList(data));
           dispatch(setFOILoader(false));
-        });
-    };
-  };
-  
-  export const fetchFOIProgramAreaList = () => {    
-    return (dispatch) => {
-      httpGETRequest(
-        API.FOI_GET_PROGRAMAREAS_FORUSER_API,
-        {},
-        UserService.getToken()
-      )
-        .then((res) => {
-          if (res.data) {
-            const foiProgramAreaList = res.data;
-            let data = foiProgramAreaList.map((programArea) => {
-              return { ...programArea, isChecked: false };
-            });
-            dispatch(setFOIProgramAreaList(data));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching program area master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching program area master data", error);
-          dispatch(serviceActionError(error));
+        } else {
+          console.log("Error while fetching category master data", res);
+          dispatch(serviceActionError(res));
           dispatch(setFOILoader(false));
-        });
-    };
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching category master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
   };
-  
-  
-  export const fetchFOIAssignedToList = (requestType, status, bcgovcode, isagbcpsteam = false) => {
-    let apiUrlGETAssignedToList = API.FOI_GET_ASSIGNEDTO_INTAKEGROUP_LIST_API;
-    if (isagbcpsteam) apiUrlGETAssignedToList = API.FOI_GET_ASSIGNEDTO_BCPSWITHINTAKEGROUP_LIST_API
-    if (requestType && status) {
-      if (bcgovcode) {
+};
+
+export const fetchFOIProgramAreaList = () => {
+  return (dispatch) => {
+    httpGETRequest(
+      API.FOI_GET_PROGRAMAREAS_FORUSER_API,
+      {},
+      UserService.getToken()
+    )
+      .then((res) => {
+        if (res.data) {
+          const foiProgramAreaList = res.data;
+          let data = foiProgramAreaList.map((programArea) => {
+            return { ...programArea, isChecked: false };
+          });
+          dispatch(setFOIProgramAreaList(data));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching program area master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching program area master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+
+
+export const fetchFOIAssignedToList = (requestType, status, bcgovcode, isagbcpsteam = false) => {
+  let apiUrlGETAssignedToList = API.FOI_GET_ASSIGNEDTO_INTAKEGROUP_LIST_API;
+  if (isagbcpsteam) {
+    apiUrlGETAssignedToList = API.FOI_GET_ASSIGNEDTO_BCPSWITHINTAKEGROUP_LIST_API;
+  } else if (requestType && status) {
+    if (bcgovcode) {
       apiUrlGETAssignedToList = replaceUrl(replaceUrl(replaceUrl(
         API.FOI_GET_ASSIGNEDTOGROUPLIST_WITHGOVCODE_API,
         "<requesttype>",
         requestType
       ), "<curentstate>", status), "<bcgovcode>", bcgovcode);
-      }     
     }
-    return (dispatch) => {
-      httpGETRequest(apiUrlGETAssignedToList, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const foiAssignedToList = res.data;
-            let data = foiAssignedToList.map((assignedTo) => {
-              return { ...assignedTo };
-            });
-            dispatch(setFOIAssignedToList(data));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log(`Error while fetching assigned to master data based on requestType ${requestType} and state ${status} `, res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching assigned to master data based on requestType ${requestType} and state ${status}", error);
-          dispatch(serviceActionError(error));
+  }
+  return (dispatch) => {
+    httpGETRequest(apiUrlGETAssignedToList, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const foiAssignedToList = res.data;
+          let data = foiAssignedToList.map((assignedTo) => {
+            return { ...assignedTo };
+          });
+          dispatch(setFOIAssignedToList(data));
           dispatch(setFOILoader(false));
-        });
-    };
+        } else {
+          console.log(`Error while fetching assigned to master data based on requestType ${requestType} and state ${status} `, res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching assigned to master data based on requestType ${requestType} and state ${status}", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
   };
+};
 
-  export const fetchFOIProcessingTeamList = (requestType) => {
-    let apiUrlGETAssignedToList = API.FOI_GET_ASSIGNEDTO_ALLGROUP_LIST_API;
-    if (requestType) {
-      apiUrlGETAssignedToList = replaceUrl(
-        API.FOI_GET_PROCESSINGTEAMLIST_API,
-        "<requesttype>",
-        requestType
-      );
-    }
+export const fetchFOIProcessingTeamList = (requestType) => {
+  let apiUrlGETAssignedToList = API.FOI_GET_ASSIGNEDTO_ALLGROUP_LIST_API;
+  if (requestType) {
+    apiUrlGETAssignedToList = replaceUrl(
+      API.FOI_GET_PROCESSINGTEAMLIST_API,
+      "<requesttype>",
+      requestType
+    );
+  }
+  return (dispatch) => {
+    httpGETRequest(apiUrlGETAssignedToList, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const foiAssignedToList = res.data;
+          let data = foiAssignedToList.map((assignedTo) => {
+            return { ...assignedTo };
+          });
+          dispatch(setFOIProcessingTeamList(data));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log(
+            `Error while fetching assigned to master data based on requestType ${requestType} `,
+            res
+          );
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log(
+          `Error while fetching assigned to master data based on requestType ${requestType}`,
+          error
+        );
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+
+export const fetchFOIFullAssignedToList = (...rest) => {
+  let fullnameTeamArray = getFullnameTeamList();
+  if (!fullnameTeamArray || !Array.isArray(fullnameTeamArray)) {
+    fullnameTeamArray = [];
+  }
+
+  if (fullnameTeamArray.includes("iao")) {
     return (dispatch) => {
-      httpGETRequest(apiUrlGETAssignedToList, {}, UserService.getToken())
+      dispatch(setFOIFullAssignedToList(getAssignToList("iao")));
+      dispatch(setFOIAssignedToListLoader(false));
+      dispatch(setCommentTagListLoader(false));
+    };
+  } else {
+    const done = fnDone(rest);
+    return (dispatch) => {
+      httpGETRequest(
+        API.FOI_GET_ASSIGNEDTO_ALLGROUP_LIST_API,
+        {},
+        UserService.getToken()
+      )
         .then((res) => {
           if (res.data) {
-            const foiAssignedToList = res.data;
-            let data = foiAssignedToList.map((assignedTo) => {
+            const foiFullAssignedToList = res.data;
+            let data = foiFullAssignedToList.map((assignedTo) => {
               return { ...assignedTo };
             });
-            dispatch(setFOIProcessingTeamList(data));
-            dispatch(setFOILoader(false));
+            addToFullnameList(data, "iao");
+            dispatch(setFOIFullAssignedToList(data));
+            dispatch(setFOIAssignedToListLoader(false));
+            done(null, res.data);
           } else {
             console.log(
-              `Error while fetching assigned to master data based on requestType ${requestType} `,
+              "Error while fetching FOI Ops assigned to master data",
               res
             );
             dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
+            dispatch(setFOIAssignedToListLoader(false));
           }
+          dispatch(setCommentTagListLoader(false));
         })
         .catch((error) => {
           console.log(
-            `Error while fetching assigned to master data based on requestType ${requestType}`,
+            "Error while fetching FOI Ops assigned to master data",
             error
           );
           dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
+          dispatch(setFOIAssignedToListLoader(false));
+          dispatch(setCommentTagListLoader(false));
+          done(error);
         });
     };
-  };
+  }
+};
 
-  export const fetchFOIFullAssignedToList = (...rest) => {
-    let fullnameTeamArray = getFullnameTeamList();
-    if (!fullnameTeamArray || !Array.isArray(fullnameTeamArray)) {
-      fullnameTeamArray = [];
-    }
+export const fetchFOIMinistryAssignedToList = (govCode, ...rest) => {
 
-    if (fullnameTeamArray.includes("iao")) {
-      return (dispatch) => {
-        dispatch(setFOIFullAssignedToList(getAssignToList("iao")));
-        dispatch(setFOIAssignedToListLoader(false));
-        dispatch(setCommentTagListLoader(false));
-      };
-    } else {
-      const done = fnDone(rest);
-      return (dispatch) => {
-        httpGETRequest(
-          API.FOI_GET_ASSIGNEDTO_ALLGROUP_LIST_API,
-          {},
-          UserService.getToken()
-        )
-          .then((res) => {
-            if (res.data) {
-              const foiFullAssignedToList = res.data;
-              let data = foiFullAssignedToList.map((assignedTo) => {
-                return { ...assignedTo };
-              });
-              addToFullnameList(data, "iao");
-              dispatch(setFOIFullAssignedToList(data));
-              dispatch(setFOIAssignedToListLoader(false));
-              done(null, res.data);
-            } else {
-              console.log(
-                "Error while fetching FOI Ops assigned to master data",
-                res
-              );
-              dispatch(serviceActionError(res));
-              dispatch(setFOIAssignedToListLoader(false));
-            }
-            dispatch(setCommentTagListLoader(false));
-          })
-          .catch((error) => {
-            console.log(
-              "Error while fetching FOI Ops assigned to master data",
-              error
-            );
-            dispatch(serviceActionError(error));
-            dispatch(setFOIAssignedToListLoader(false));
-            dispatch(setCommentTagListLoader(false));
-            done(error);
+  let fullnameTeamArray = getFullnameTeamList();
+  if (!fullnameTeamArray || !Array.isArray(fullnameTeamArray)) {
+    fullnameTeamArray = [];
+  }
+
+  if (fullnameTeamArray.includes(govCode.toLowerCase())) {
+    return (dispatch) => {
+      dispatch(setFOIMinistryAssignedToList(getAssignToList(govCode)));
+      dispatch(setFOILoader(false));
+    };
+
+  } else {
+    const done = fnDone(rest);
+
+    const apiUrlGETAssignedToList = replaceUrl(
+      API.FOI_GET_ASSIGNEDTO_MINISTRYGROUP_LIST_API,
+      "<govcode>",
+      govCode
+    );
+
+    return (dispatch) => {
+      httpGETRequest(apiUrlGETAssignedToList, {}, UserService.getToken())
+        .then((res) => {
+          if (res.data) {
+            const foiAssignedToList = res.data;
+            let data = foiAssignedToList.map((assignedTo) => {
+              return { ...assignedTo };
+            });
+            addToFullnameList(data, govCode);
+            dispatch(setFOIMinistryAssignedToList(data));
+            dispatch(setFOILoader(false));
+            done(null, res.data);
+          } else {
+            console.log(`Error while fetching Ministry(${govCode}) assigned to master data`, res);
+            dispatch(serviceActionError(res));
+            dispatch(setFOILoader(false));
+          }
+        })
+        .catch((error) => {
+          console.log(`Error while fetching Ministry(${govCode}) assigned to master data`, error);
+          dispatch(serviceActionError(error));
+          dispatch(setFOILoader(false));
+          done(error);
+        });
+    };
+  }
+};
+
+export const fetchFOIDeliveryModeList = () => {
+  const firstDeliveryMode = { "deliverymodeid": 0, "name": "Select Delivery Mode" };
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_DELIVERY_MODELIST, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const foiDeliveryModeList = res.data;
+          let data = foiDeliveryModeList.map((deliveryMode) => {
+            return { ...deliveryMode };
           });
-      };
-    }
-  };
-  
-  export const fetchFOIMinistryAssignedToList = (govCode, ...rest) => {
-  
-    let fullnameTeamArray = getFullnameTeamList();
-    if(!fullnameTeamArray || !Array.isArray(fullnameTeamArray)) {
-      fullnameTeamArray = [];
-    }
-  
-    if(fullnameTeamArray.includes(govCode.toLowerCase())) {
-      return (dispatch) => {
-        dispatch(setFOIMinistryAssignedToList(getAssignToList(govCode)));
+          //data.unshift(firstDeliveryMode);
+          dispatch(setFOIDeliveryModeList(data));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching delivery mode master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching delivery mode master data", error);
+        dispatch(serviceActionError(error));
         dispatch(setFOILoader(false));
-      };
-  
-    } else {
-      const done =fnDone(rest);
-  
-      const apiUrlGETAssignedToList = replaceUrl(
-        API.FOI_GET_ASSIGNEDTO_MINISTRYGROUP_LIST_API,
-        "<govcode>",
-        govCode
-      );
-    
-      return (dispatch) => {
-        httpGETRequest(apiUrlGETAssignedToList, {}, UserService.getToken())
-          .then((res) => {
-            if (res.data) {
-              const foiAssignedToList = res.data;
-              let data = foiAssignedToList.map((assignedTo) => {
-                return { ...assignedTo };
-              });
-              addToFullnameList(data, govCode);
-              dispatch(setFOIMinistryAssignedToList(data));
-              dispatch(setFOILoader(false));
-              done(null, res.data);
-            } else {
-              console.log(`Error while fetching Ministry(${govCode}) assigned to master data`, res);
-              dispatch(serviceActionError(res));
-              dispatch(setFOILoader(false));
-            }
-          })
-          .catch((error) => {
-            console.log(`Error while fetching Ministry(${govCode}) assigned to master data`, error);
-            dispatch(serviceActionError(error));
-            dispatch(setFOILoader(false));
-            done(error);
+      });
+  };
+};
+
+export const fetchFOIReceivedModeList = () => {
+  const firstReceivedMode = { "receivedmodeid": 0, "name": "Select Received Mode" };
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_RECEIVED_MODELIST, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const foiReceivedModeList = res.data;
+          let data = foiReceivedModeList.map((receivedMode) => {
+            return { ...receivedMode };
           });
-      };
-    }
-  };
-  
-  export const fetchFOIDeliveryModeList = () => {
-    const firstDeliveryMode = { "deliverymodeid": 0, "name": "Select Delivery Mode" };
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_DELIVERY_MODELIST, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const foiDeliveryModeList = res.data;
-            let data = foiDeliveryModeList.map((deliveryMode) => {
-              return { ...deliveryMode };
-            });
-            //data.unshift(firstDeliveryMode);
-            dispatch(setFOIDeliveryModeList(data));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching delivery mode master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching delivery mode master data", error);
-          dispatch(serviceActionError(error));
+          data.unshift(firstReceivedMode);
+
+          dispatch(setFOIReceivedModeList(data));
           dispatch(setFOILoader(false));
-        });
-    };
-  };
-  
-  export const fetchFOIReceivedModeList = () => {
-    const firstReceivedMode = { "receivedmodeid": 0, "name": "Select Received Mode" };
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_RECEIVED_MODELIST, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const foiReceivedModeList = res.data;
-            let data = foiReceivedModeList.map((receivedMode) => {
-              return { ...receivedMode };
-            });
-            data.unshift(firstReceivedMode);
-  
-            dispatch(setFOIReceivedModeList(data));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching received mode master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching received mode master data", error);
-          dispatch(serviceActionError(error));
+        } else {
+          console.log("Error while fetching received mode master data", res);
+          dispatch(serviceActionError(res));
           dispatch(setFOILoader(false));
-        });
-    };
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching received mode master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
   };
+};
 
-  export const fetchClosingReasonList = () => {    
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_CLOSING_REASONS, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const closingReasons = res.data;
-            dispatch(setClosingReasons(closingReasons));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching close request reason master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching close request reason master data", error);
-          dispatch(serviceActionError(error));
+export const fetchClosingReasonList = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_CLOSING_REASONS, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const closingReasons = res.data;
+          dispatch(setClosingReasons(closingReasons));
           dispatch(setFOILoader(false));
-        });
-    };
-  };
-
-  export const fetchFOIMinistryDivisionalStages = (bcgovcode) => {
-    const apiUrlgetdivisionalstages = replaceUrl(API.FOI_MINISTRY_DIVISIONALSTAGES, "<bcgovcode>", bcgovcode);
-    return (dispatch) => {
-      httpGETRequest(apiUrlgetdivisionalstages, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const foiMinistryDivisionalStages = res.data;
-            dispatch(setFOIMinistryDivisionalStages({}));
-            dispatch(setFOIMinistryDivisionalStages(foiMinistryDivisionalStages));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, error);
-          dispatch(serviceActionError(error));
+        } else {
+          console.log("Error while fetching close request reason master data", res);
+          dispatch(serviceActionError(res));
           dispatch(setFOILoader(false));
-        });
-    };
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching close request reason master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
   };
+};
 
-  export const fetchFOIPersonalDivisionsAndSections = (bcgovcode) => {
-    switch(bcgovcode) {
-      case "MCF":
-        const apiUrlMCF = replaceUrl(API.FOI_PERSONAL_SECTIONS, "<bcgovcode>", bcgovcode);
-        return (dispatch) => {
-          httpGETRequest(apiUrlMCF, {}, UserService.getToken())
-            .then((res) => {
-              if (res.data) {
-                const foiPersonalSections = res.data;
-                dispatch(setFOIPersonalSections({}));
-                dispatch(setFOIPersonalSections(foiPersonalSections));
-                dispatch(setFOILoader(false));
-              } else {
-                console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, res);
-                dispatch(serviceActionError(res));
-                dispatch(setFOILoader(false));
-              }
-            })
-            .catch((error) => {
-              console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, error);
-              dispatch(serviceActionError(error));
-              dispatch(setFOILoader(false));
-            });
-        };
-      case "MSD":
-        const apiUrlMSD = replaceUrl(API.FOI_PERSONAL_DIVISIONS_SECTIONS, "<bcgovcode>", bcgovcode);
-        return (dispatch) => {
-          httpGETRequest(apiUrlMSD, {}, UserService.getToken())
-            .then((res) => {
-              if (res.data) {
-                const foiPersonalDivisionsAndSections = res.data;
-                dispatch(setFOIPersonalDivisionsAndSections({}));
-                dispatch(setFOIPersonalDivisionsAndSections(foiPersonalDivisionsAndSections));
-                dispatch(setFOILoader(false));
-              } else {
-                console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, res);
-                dispatch(serviceActionError(res));
-                dispatch(setFOILoader(false));
-              }
-            })
-            .catch((error) => {
-              console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, error);
-              dispatch(serviceActionError(error));
-              dispatch(setFOILoader(false));
-            });
-        };
-      default:
-        break;
-    }
-  };
-
-  export const fetchFOIPersonalPeople = (bcgovcode) => {
-    switch(bcgovcode) {
-      case "MCF":
-        const apiUrlMCF = replaceUrl(API.FOI_PERSONAL_PEOPLE, "<bcgovcode>", bcgovcode);
-        return (dispatch) => {
-          httpGETRequest(apiUrlMCF, {}, UserService.getToken())
-            .then((res) => {
-              if (res.data) {
-                const foiPersonalSections = res.data;
-                dispatch(setFOIPersonalPeople({}));
-                dispatch(setFOIPersonalPeople(foiPersonalSections));
-                dispatch(setFOILoader(false));
-              } else {
-                console.log(`Error while fetching (${bcgovcode}) FOI records people`, res);
-                dispatch(serviceActionError(res));
-                dispatch(setFOILoader(false));
-              }
-            })
-            .catch((error) => {
-              console.log(`Error while fetching (${bcgovcode}) FOI records people`, error);
-              dispatch(serviceActionError(error));
-              dispatch(setFOILoader(false));
-            });
-        };
-      default:
-        break;
-    }
-  };
-
-  export const fetchFOIPersonalFiletypes = (bcgovcode) => {
-    switch(bcgovcode) {
-      case "MCF":
-        const apiUrlMCF = replaceUrl(API.FOI_PERSONAL_FILETYPES, "<bcgovcode>", bcgovcode);
-        return (dispatch) => {
-          httpGETRequest(apiUrlMCF, {}, UserService.getToken())
-            .then((res) => {
-              if (res.data) {
-                const foiPersonalSections = res.data;
-                dispatch(setFOIPersonalFiletypes({}));
-                dispatch(setFOIPersonalFiletypes(foiPersonalSections));
-                dispatch(setFOILoader(false));
-              } else {
-                console.log(`Error while fetching (${bcgovcode}) FOI records people`, res);
-                dispatch(serviceActionError(res));
-                dispatch(setFOILoader(false));
-              }
-            })
-            .catch((error) => {
-              console.log(`Error while fetching (${bcgovcode}) FOI records people`, error);
-              dispatch(serviceActionError(error));
-              dispatch(setFOILoader(false));
-            });
-        };
-      default:
-        break;
-    }
-  };
-
-  export const fetchFOIPersonalVolumes = (bcgovcode) => {
-    switch(bcgovcode) {
-      case "MCF":
-        const apiUrlMCF = replaceUrl(API.FOI_PERSONAL_VOLUMES, "<bcgovcode>", bcgovcode);
-        return (dispatch) => {
-          httpGETRequest(apiUrlMCF, {}, UserService.getToken())
-            .then((res) => {
-              if (res.data) {
-                const foiPersonalSections = res.data;
-                dispatch(setFOIPersonalVolumes({}));
-                dispatch(setFOIPersonalVolumes(foiPersonalSections));
-                dispatch(setFOILoader(false));
-              } else {
-                console.log(`Error while fetching (${bcgovcode}) FOI records people`, res);
-                dispatch(serviceActionError(res));
-                dispatch(setFOILoader(false));
-              }
-            })
-            .catch((error) => {
-              console.log(`Error while fetching (${bcgovcode}) FOI records people`, error);
-              dispatch(serviceActionError(error));
-              dispatch(setFOILoader(false));
-            });
-        };
-      default:
-        break;
-    }
-  };
-
-  export const fetchFOIPersonalDivisions = (bcgovcode) => {
-    const apiUrl = replaceUrl(API.FOI_PERSONAL_DIVISIONS, "<bcgovcode>", bcgovcode);
-    return (dispatch) => {
-      httpGETRequest(apiUrl, {}, UserService.getToken())
+export const fetchFOIMinistryDivisionalStages = (bcgovcode) => {
+  const apiUrlgetdivisionalstages = replaceUrl(API.FOI_MINISTRY_DIVISIONALSTAGES, "<bcgovcode>", bcgovcode);
+  return (dispatch) => {
+    httpGETRequest(apiUrlgetdivisionalstages, {}, UserService.getToken())
       .then((res) => {
         if (res.data) {
           const foiMinistryDivisionalStages = res.data;
@@ -536,297 +375,459 @@ import {
         dispatch(serviceActionError(error));
         dispatch(setFOILoader(false));
       });
-    };
   };
+};
 
-  export const fetchFOISubjectCodeList = () => {
-    const firstSubjectCode = { "subjectcodeid": 0, "name": "No Subject Code" };
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_SUBJECT_CODELIST, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const foiSubjectCodeList = res.data;
-            let data = foiSubjectCodeList.map((subjectCode) => {
-              return { ...subjectCode };
-            });
-            data.unshift(firstSubjectCode);
-            dispatch(setFOISubjectCodeList(data));
+export const fetchFOIPersonalDivisionsAndSections = (bcgovcode) => {
+  switch (bcgovcode) {
+    case "MCF":
+      const apiUrlMCF = replaceUrl(API.FOI_PERSONAL_SECTIONS, "<bcgovcode>", bcgovcode);
+      return (dispatch) => {
+        httpGETRequest(apiUrlMCF, {}, UserService.getToken())
+          .then((res) => {
+            if (res.data) {
+              const foiPersonalSections = res.data;
+              dispatch(setFOIPersonalSections({}));
+              dispatch(setFOIPersonalSections(foiPersonalSections));
+              dispatch(setFOILoader(false));
+            } else {
+              console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, res);
+              dispatch(serviceActionError(res));
+              dispatch(setFOILoader(false));
+            }
+          })
+          .catch((error) => {
+            console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, error);
+            dispatch(serviceActionError(error));
             dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching subject code master data", res);
-            dispatch(serviceActionError(res));
+          });
+      };
+    case "MSD":
+      const apiUrlMSD = replaceUrl(API.FOI_PERSONAL_DIVISIONS_SECTIONS, "<bcgovcode>", bcgovcode);
+      return (dispatch) => {
+        httpGETRequest(apiUrlMSD, {}, UserService.getToken())
+          .then((res) => {
+            if (res.data) {
+              const foiPersonalDivisionsAndSections = res.data;
+              dispatch(setFOIPersonalDivisionsAndSections({}));
+              dispatch(setFOIPersonalDivisionsAndSections(foiPersonalDivisionsAndSections));
+              dispatch(setFOILoader(false));
+            } else {
+              console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, res);
+              dispatch(serviceActionError(res));
+              dispatch(setFOILoader(false));
+            }
+          })
+          .catch((error) => {
+            console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, error);
+            dispatch(serviceActionError(error));
             dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching delivery mode master data", error);
-          dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
-        });
-    };
-  };
-
-  export const fetchAllProgramAreasForAdmin = () => {    
-    return (dispatch) => {
-      httpGETRequest(
-        API.FOI_GET_PROGRAMAREAS_API,
-        {},
-        UserService.getToken()
-      )
-        .then((res) => {
-          if (res.data) {
-            dispatch(setFOIAdminProgramAreaList(res.data));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching program area master data for admin dashboard", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching program area master data for admin dashboard", error);
-          dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
-        });
-    };
-  };
-
-  export const refreshRedisCacheForAdmin = (...rest) => {
-    const done = fnDone(rest);
-    return (dispatch) => {
-      httpPOSTRequest(API.FOI_REFRESH_REDIS_CACHE,{}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            done(null, res.data);
-          } else {
-            dispatch(serviceActionError(res));
-            throw new Error("Error Refreshing Cache");
-          }
-        })
-        .catch((error) => {
-          done(error);
-          catchError(error, dispatch);
-        });
-    };
-  };
-
-  export const refreshRedisCacheForTemplate = (...rest) => {
-    const done = fnDone(rest);
-    return (dispatch) => {
-      httpPOSTRequest(API.FOI_REFRESH_REDIS_CACHE_TEMPLATE,{}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            done(null, res.data);
-          } else {
-            dispatch(serviceActionError(res));
-            throw new Error("Error Refreshing Cache");
-          }
-        })
-        .catch((error) => {
-          done(error);
-          catchError(error, dispatch);
-        });
-    };
-  };
-
-  export const fetchOIPCOutcomes = () => {    
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_OIPC_OUTCOMES, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const oipcOutcomes = res.data;
-            dispatch(setOIPCOutcomes(oipcOutcomes));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching OIPC outcomes master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching OIPC outcomes master data", error);
-          dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
-        });
-    };
-  };
-
-  export const fetchOIPCStatuses = () => {    
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_OIPC_STATUSES, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const oipcStatuses = res.data;
-            dispatch(setOIPCStatuses(oipcStatuses));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching OIPC statuses master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching OIPC statuses master data", error);
-          dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
-        });
-    };
-  };
-
-  export const fetchOIPCReviewtypes = () => {    
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_OIPC_REVIEWTYPES, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const oipcReviewtypes = res.data;
-            dispatch(setOIPCReviewtypes(oipcReviewtypes));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching OIPC reviewtypes master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching OIPC reviewtypes master data", error);
-          dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
-        });
-    };
-  };
-
-  export const fetchOIPCInquiryoutcomes = () => {    
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_OIPC_INQUIRYOUTCOMES, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const oipcInquiryoutcomes = res.data;
-            dispatch(setOIPCInquiryoutcomes(oipcInquiryoutcomes));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching OIPC inqiuryoutcomes master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching OIPC inqiuryoutcomes master data", error);
-          dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
-        });
-    };
-  };
-
-  export const fetchOpenInfoPublicationStatuses = () => {
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_OI_PUBLICATIONSTATUSES, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const oiPublicationStatuses = res.data;
-            dispatch(setOIPublicationStatuses(oiPublicationStatuses));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching OI publication statuses master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching OI publication statuses master data", error);
-          dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
-        });
-    };
+          });
+      };
+    default:
+      break;
   }
+};
 
-  export const fetchOpenInfoExemptions = () => {
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_OI_EXEMPTIONS, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const oiExemptions = res.data;
-            oiExemptions.unshift({name: "Select Reason", oiexemptionid: 0, isactive: true})
-            dispatch(setOIExemptions(oiExemptions));
+export const fetchFOIPersonalPeople = (bcgovcode) => {
+  switch (bcgovcode) {
+    case "MCF":
+      const apiUrlMCF = replaceUrl(API.FOI_PERSONAL_PEOPLE, "<bcgovcode>", bcgovcode);
+      return (dispatch) => {
+        httpGETRequest(apiUrlMCF, {}, UserService.getToken())
+          .then((res) => {
+            if (res.data) {
+              const foiPersonalSections = res.data;
+              dispatch(setFOIPersonalPeople({}));
+              dispatch(setFOIPersonalPeople(foiPersonalSections));
+              dispatch(setFOILoader(false));
+            } else {
+              console.log(`Error while fetching (${bcgovcode}) FOI records people`, res);
+              dispatch(serviceActionError(res));
+              dispatch(setFOILoader(false));
+            }
+          })
+          .catch((error) => {
+            console.log(`Error while fetching (${bcgovcode}) FOI records people`, error);
+            dispatch(serviceActionError(error));
             dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching OI exemptions master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching OI exemptions master data", error);
-          dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
-        });
-    };
+          });
+      };
+    default:
+      break;
   }
+};
 
-  export const fetchOpenInfoStatuses = () => {
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_OI_STATUSES, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const oiStatuses = res.data;
-            dispatch(setOIStatuses(oiStatuses));
+export const fetchFOIPersonalFiletypes = (bcgovcode) => {
+  switch (bcgovcode) {
+    case "MCF":
+      const apiUrlMCF = replaceUrl(API.FOI_PERSONAL_FILETYPES, "<bcgovcode>", bcgovcode);
+      return (dispatch) => {
+        httpGETRequest(apiUrlMCF, {}, UserService.getToken())
+          .then((res) => {
+            if (res.data) {
+              const foiPersonalSections = res.data;
+              dispatch(setFOIPersonalFiletypes({}));
+              dispatch(setFOIPersonalFiletypes(foiPersonalSections));
+              dispatch(setFOILoader(false));
+            } else {
+              console.log(`Error while fetching (${bcgovcode}) FOI records people`, res);
+              dispatch(serviceActionError(res));
+              dispatch(setFOILoader(false));
+            }
+          })
+          .catch((error) => {
+            console.log(`Error while fetching (${bcgovcode}) FOI records people`, error);
+            dispatch(serviceActionError(error));
             dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching OI statuses master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching OI statuses master data", error);
-          dispatch(serviceActionError(error));
-          dispatch(setFOILoader(false));
-        });
-    };
+          });
+      };
+    default:
+      break;
   }
-  export const fetchFOICommentTypes = () => {
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_COMMENT_TYPES, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const foiCommentTypes = res.data;
-            let data = foiCommentTypes?.map((type) => {
-              return { ...type };
-            });
-            dispatch(setFOICommentTypes(data));
+};
+
+export const fetchFOIPersonalVolumes = (bcgovcode) => {
+  switch (bcgovcode) {
+    case "MCF":
+      const apiUrlMCF = replaceUrl(API.FOI_PERSONAL_VOLUMES, "<bcgovcode>", bcgovcode);
+      return (dispatch) => {
+        httpGETRequest(apiUrlMCF, {}, UserService.getToken())
+          .then((res) => {
+            if (res.data) {
+              const foiPersonalSections = res.data;
+              dispatch(setFOIPersonalVolumes({}));
+              dispatch(setFOIPersonalVolumes(foiPersonalSections));
+              dispatch(setFOILoader(false));
+            } else {
+              console.log(`Error while fetching (${bcgovcode}) FOI records people`, res);
+              dispatch(serviceActionError(res));
+              dispatch(setFOILoader(false));
+            }
+          })
+          .catch((error) => {
+            console.log(`Error while fetching (${bcgovcode}) FOI records people`, error);
+            dispatch(serviceActionError(error));
             dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching comment types master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching comment types master data", error);
-          dispatch(serviceActionError(error));
+          });
+      };
+    default:
+      break;
+  }
+};
+
+export const fetchFOIPersonalDivisions = (bcgovcode) => {
+  const apiUrl = replaceUrl(API.FOI_PERSONAL_DIVISIONS, "<bcgovcode>", bcgovcode);
+  return (dispatch) => {
+    httpGETRequest(apiUrl, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const foiMinistryDivisionalStages = res.data;
+          dispatch(setFOIMinistryDivisionalStages({}));
+          dispatch(setFOIMinistryDivisionalStages(foiMinistryDivisionalStages));
           dispatch(setFOILoader(false));
-        });
-    };
-  };
-  
-  export const fetchFOIEmailTemplates = () => {
-    return (dispatch) => {
-      httpGETRequest(API.FOI_GET_EMAIL_TEMPLATES, {}, UserService.getToken())
-        .then((res) => {
-          if (res.data) {
-            const foiEmailTemplates = res.data;
-            dispatch(setFOIEmailTemplates(foiEmailTemplates));
-            dispatch(setFOILoader(false));
-          } else {
-            console.log("Error while fetching email templates master data", res);
-            dispatch(serviceActionError(res));
-            dispatch(setFOILoader(false));
-          }
-        })
-        .catch((error) => {
-          console.log("Error while fetching email templates master data", error);
-          dispatch(serviceActionError(error));
+        } else {
+          console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, res);
+          dispatch(serviceActionError(res));
           dispatch(setFOILoader(false));
-        });
-    };
+        }
+      })
+      .catch((error) => {
+        console.log(`Error while fetching ministry(${bcgovcode}) divisional stage master data`, error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
   };
-  
+};
+
+export const fetchFOISubjectCodeList = () => {
+  const firstSubjectCode = { "subjectcodeid": 0, "name": "No Subject Code" };
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_SUBJECT_CODELIST, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const foiSubjectCodeList = res.data;
+          let data = foiSubjectCodeList.map((subjectCode) => {
+            return { ...subjectCode };
+          });
+          data.unshift(firstSubjectCode);
+          dispatch(setFOISubjectCodeList(data));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching subject code master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching delivery mode master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+
+export const fetchAllProgramAreasForAdmin = () => {
+  return (dispatch) => {
+    httpGETRequest(
+      API.FOI_GET_PROGRAMAREAS_API,
+      {},
+      UserService.getToken()
+    )
+      .then((res) => {
+        if (res.data) {
+          dispatch(setFOIAdminProgramAreaList(res.data));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching program area master data for admin dashboard", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching program area master data for admin dashboard", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+
+export const refreshRedisCacheForAdmin = (...rest) => {
+  const done = fnDone(rest);
+  return (dispatch) => {
+    httpPOSTRequest(API.FOI_REFRESH_REDIS_CACHE, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          done(null, res.data);
+        } else {
+          dispatch(serviceActionError(res));
+          throw new Error("Error Refreshing Cache");
+        }
+      })
+      .catch((error) => {
+        done(error);
+        catchError(error, dispatch);
+      });
+  };
+};
+
+export const refreshRedisCacheForTemplate = (...rest) => {
+  const done = fnDone(rest);
+  return (dispatch) => {
+    httpPOSTRequest(API.FOI_REFRESH_REDIS_CACHE_TEMPLATE, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          done(null, res.data);
+        } else {
+          dispatch(serviceActionError(res));
+          throw new Error("Error Refreshing Cache");
+        }
+      })
+      .catch((error) => {
+        done(error);
+        catchError(error, dispatch);
+      });
+  };
+};
+
+export const fetchOIPCOutcomes = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_OIPC_OUTCOMES, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const oipcOutcomes = res.data;
+          dispatch(setOIPCOutcomes(oipcOutcomes));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching OIPC outcomes master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching OIPC outcomes master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+
+export const fetchOIPCStatuses = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_OIPC_STATUSES, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const oipcStatuses = res.data;
+          dispatch(setOIPCStatuses(oipcStatuses));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching OIPC statuses master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching OIPC statuses master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+
+export const fetchOIPCReviewtypes = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_OIPC_REVIEWTYPES, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const oipcReviewtypes = res.data;
+          dispatch(setOIPCReviewtypes(oipcReviewtypes));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching OIPC reviewtypes master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching OIPC reviewtypes master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+
+export const fetchOIPCInquiryoutcomes = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_OIPC_INQUIRYOUTCOMES, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const oipcInquiryoutcomes = res.data;
+          dispatch(setOIPCInquiryoutcomes(oipcInquiryoutcomes));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching OIPC inqiuryoutcomes master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching OIPC inqiuryoutcomes master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+
+export const fetchOpenInfoPublicationStatuses = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_OI_PUBLICATIONSTATUSES, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const oiPublicationStatuses = res.data;
+          dispatch(setOIPublicationStatuses(oiPublicationStatuses));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching OI publication statuses master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching OI publication statuses master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+}
+
+export const fetchOpenInfoExemptions = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_OI_EXEMPTIONS, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const oiExemptions = res.data;
+          oiExemptions.unshift({ name: "Select Reason", oiexemptionid: 0, isactive: true })
+          dispatch(setOIExemptions(oiExemptions));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching OI exemptions master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching OI exemptions master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+}
+
+export const fetchOpenInfoStatuses = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_OI_STATUSES, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const oiStatuses = res.data;
+          dispatch(setOIStatuses(oiStatuses));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching OI statuses master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching OI statuses master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+}
+export const fetchFOICommentTypes = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_COMMENT_TYPES, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const foiCommentTypes = res.data;
+          let data = foiCommentTypes?.map((type) => {
+            return { ...type };
+          });
+          dispatch(setFOICommentTypes(data));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching comment types master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching comment types master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+
+export const fetchFOIEmailTemplates = () => {
+  return (dispatch) => {
+    httpGETRequest(API.FOI_GET_EMAIL_TEMPLATES, {}, UserService.getToken())
+      .then((res) => {
+        if (res.data) {
+          const foiEmailTemplates = res.data;
+          dispatch(setFOIEmailTemplates(foiEmailTemplates));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error while fetching email templates master data", res);
+          dispatch(serviceActionError(res));
+          dispatch(setFOILoader(false));
+        }
+      })
+      .catch((error) => {
+        console.log("Error while fetching email templates master data", error);
+        dispatch(serviceActionError(error));
+        dispatch(setFOILoader(false));
+      });
+  };
+};
+

--- a/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
+++ b/forms-flow-web/src/apiManager/services/FOI/foiRequestServices.js
@@ -14,11 +14,11 @@ import {
   setFOIRequestDescriptionHistory,
   setFOIMinistryRequestList,
   setOpenedMinistries,
-  setRestrictedReqTaglist,  
+  setRestrictedReqTaglist,
   setRequestExtensions,
 } from "../../../actions/FOI/foiRequestActions";
 import { fetchFOIAssignedToList, fetchFOIMinistryAssignedToList, fetchFOIProcessingTeamList } from "./foiMasterDataServices";
-import { catchError, fnDone} from './foiServicesUtil';
+import { catchError, fnDone } from './foiServicesUtil';
 import UserService from "../../../services/UserService";
 import { replaceUrl } from "../../../helper/FOI/helper";
 import { persistRequestFieldsNotInAxis } from "../../../components/FOI/FOIRequest/utils";
@@ -105,7 +105,7 @@ export const fetchFOIMinistryRequestList = () => {
           });
           dispatch(clearMinistryViewRequestDetails({}));
           if (foiRequests > 0)
-            dispatch(fetchFOIMinistryAssignedToList( foiRequests[0].bcgovcode.toLowerCase()));     
+            dispatch(fetchFOIMinistryAssignedToList(foiRequests[0].bcgovcode.toLowerCase()));
           dispatch(setFOIMinistryRequestList(data));
           dispatch(setFOILoader(false));
         } else {
@@ -113,41 +113,41 @@ export const fetchFOIMinistryRequestList = () => {
           throw new Error("Error in fetching dashboard data for Ministry");
         }
       })
-      .catch((error) => {        
+      .catch((error) => {
         catchError(error, dispatch);
       });
   };
 };
 
-export const fetchFOIMinistryRequestListByPage = (page = 1, size = 10, sort = [{field:'defaultSorting', sort:'asc'}], filters = null, keyword = null, additionalFilter = 'All', userID = null) => {
+export const fetchFOIMinistryRequestListByPage = (page = 1, size = 10, sort = [{ field: 'defaultSorting', sort: 'asc' }], filters = null, keyword = null, additionalFilter = 'All', userID = null) => {
   let sortingItems = [];
   let sortingOrders = [];
-  sort.forEach((item)=>{
+  sort.forEach((item) => {
     sortingItems.push(item.field);
     sortingOrders.push(item.sort);
   });
 
   return (dispatch) => {
     httpGETRequest(
-          API.FOI_GET_MINISTRY_REQUESTS_PAGE_API,
-          {
-            "page": page,
-            "size": size,
-            "sortingitems": sortingItems,
-            "sortingorders": sortingOrders,
-            "filters": filters,
-            "keyword": keyword,
-            "additionalfilter": additionalFilter,
-            "userid": userID
-          },
-          UserService.getToken())
+      API.FOI_GET_MINISTRY_REQUESTS_PAGE_API,
+      {
+        "page": page,
+        "size": size,
+        "sortingitems": sortingItems,
+        "sortingorders": sortingOrders,
+        "filters": filters,
+        "keyword": keyword,
+        "additionalfilter": additionalFilter,
+        "userid": userID
+      },
+      UserService.getToken())
       .then((res) => {
         if (res.data) {
           dispatch(clearMinistryViewRequestDetails({}));
           dispatch(setFOIMinistryRequestList(res.data));
           dispatch(setFOILoader(false));
           if (res.data?.data[0]?.bcgovcode)
-            dispatch(fetchFOIMinistryAssignedToList(res.data.data[0].bcgovcode));     
+            dispatch(fetchFOIMinistryAssignedToList(res.data.data[0].bcgovcode));
         } else {
           dispatch(serviceActionError(res));
           throw new Error("Error in fetching dashboard data for IAO");
@@ -161,7 +161,7 @@ export const fetchFOIMinistryRequestListByPage = (page = 1, size = 10, sort = [{
 
 export const fetchFOIRequestDetailsWrapper = (requestId, ministryId, userGroups) => {
   if (ministryId) {
-    return fetchFOIRequestDetails(requestId, ministryId);
+    return fetchFOIRequestDetails(requestId, ministryId, userGroups);
   } else {
     return fetchFOIRawRequestDetails(requestId, userGroups);
   }
@@ -182,7 +182,7 @@ export const fetchFOIRawRequestDetails = (requestId, userGroups) => {
           dispatch(setFOIRequestDetail(foiRequest));
           const ministryCode = (foiRequest.currentState !== StateEnum.redirect.name && foiRequest.requestType === 'personal') ? foiRequest.selectedMinistries[0].code.toLowerCase() : "";
           let isagbcpsteam = false;
-          if (!ministryCode && foiRequest.selectedMinistries[0].code.toLowerCase() == 'ag' && userGroups.includes('BCPS Team')) isagbcpsteam = true;
+          if (!ministryCode && foiRequest.selectedMinistries[0].code.toLowerCase() == 'ag' && userGroups && userGroups.includes('BCPS Team')) isagbcpsteam = true;
           dispatch(fetchFOIAssignedToList(foiRequest.requestType.toLowerCase(), foiRequest.currentState.replace(/\s/g, '').toLowerCase(), ministryCode, isagbcpsteam));
           dispatch(fetchFOIProcessingTeamList(foiRequest.requestType.toLowerCase()));
           dispatch(setFOILoader(false));
@@ -197,8 +197,8 @@ export const fetchFOIRawRequestDetails = (requestId, userGroups) => {
   }
 };
 
-export const fetchFOIRequestDetails = (requestId, ministryId) => {
-  
+export const fetchFOIRequestDetails = (requestId, ministryId, userGroups) => {
+
   const apiUrlgetRequestDetails = replaceUrl(replaceUrl(
     API.FOI_REQUEST_API,
     "<requestid>",
@@ -212,7 +212,9 @@ export const fetchFOIRequestDetails = (requestId, ministryId) => {
           dispatch(clearRequestDetails({}));
           dispatch(setFOIRequestDetail(foiRequest));
           const ministryCode = foiRequest.selectedMinistries[0].code.toLowerCase();
-          dispatch(fetchFOIAssignedToList(foiRequest.requestType.toLowerCase(), foiRequest.currentState.replace(/\s/g, '').toLowerCase(), ministryCode));
+          let isagbcpsteam = false;
+          if (ministryCode == 'ag' && userGroups && userGroups.includes('BCPS Team')) isagbcpsteam = true;
+          dispatch(fetchFOIAssignedToList(foiRequest.requestType.toLowerCase(), foiRequest.currentState.replace(/\s/g, '').toLowerCase(), ministryCode, isagbcpsteam));
           dispatch(fetchFOIMinistryAssignedToList(ministryCode));
           dispatch(fetchFOIProcessingTeamList(foiRequest.requestType.toLowerCase()));
           dispatch(setFOILoader(false));
@@ -325,7 +327,7 @@ export const saveMinistryRequestDetails = (data, requestId, ministryId, ...rest)
             done(null, res.data);
           } else {
             dispatch(serviceActionError(res));
-            throw new Error(`Error while saving the ministry request (request# ${requestId}, ministry# ${ministryId})`);            
+            throw new Error(`Error while saving the ministry request (request# ${requestId}, ministry# ${ministryId})`);
           }
         })
         .catch((error) => {
@@ -394,7 +396,7 @@ export const fetchOpenedMinistriesForNotification = (notification, ...rest) => {
   }
 };
 
-export const checkDuplicateAndFetchRequestDataFromAxis = (axisRequestId, isModal,requestDetails, ...rest) => {
+export const checkDuplicateAndFetchRequestDataFromAxis = (axisRequestId, isModal, requestDetails, ...rest) => {
   const done = fnDone(rest);
   const apiUrlCheckAxisIdExists = replaceUrl(
     API.FOI_CHECK_AXIS_REQUEST_ID,
@@ -405,19 +407,19 @@ export const checkDuplicateAndFetchRequestDataFromAxis = (axisRequestId, isModal
     httpGETRequest(apiUrlCheckAxisIdExists, {}, UserService.getToken())
       .then((res) => {
         if (res.data) {
-          if(!res.data.ispresent){
-            dispatch(fetchRequestDataFromAxis(axisRequestId, isModal,requestDetails,(err, data) => {
-              if(!err)
+          if (!res.data.ispresent) {
+            dispatch(fetchRequestDataFromAxis(axisRequestId, isModal, requestDetails, (err, data) => {
+              if (!err)
                 done(null, data);
               else {
-                  done(null,"Exception happened while fetching request from AXIS.");
-                  dispatch(serviceActionError(res));
-                  throw new Error(`Error in fetching request from AXIS.`);
+                done(null, "Exception happened while fetching request from AXIS.");
+                dispatch(serviceActionError(res));
+                throw new Error(`Error in fetching request from AXIS.`);
               }
             }));
           }
           else
-            done(null,"Axis Id exists");
+            done(null, "Axis Id exists");
         } else {
           dispatch(serviceActionError(res));
           throw new Error(`Error in fetching axis request ids.`);
@@ -429,7 +431,7 @@ export const checkDuplicateAndFetchRequestDataFromAxis = (axisRequestId, isModal
   }
 };
 
-export const fetchRequestDataFromAxis = (axisRequestId, isModal,requestDetails, ...rest) => {
+export const fetchRequestDataFromAxis = (axisRequestId, isModal, requestDetails, ...rest) => {
   const done = fnDone(rest);
   const apiUrlgetRequestDetails = replaceUrl(
     API.FOI_GET_AXIS_REQUEST_DATA,
@@ -441,45 +443,44 @@ export const fetchRequestDataFromAxis = (axisRequestId, isModal,requestDetails, 
       .then((res) => {
         if (res.data) {
           let newRequest = res.data;
-          if(!isModal && Object.entries(newRequest).length !== 0){
-            if(Object.entries(requestDetails).length !== 0 && requestDetails.currentState === "Unopened"){
-              newRequest= persistRequestFieldsNotInAxis(newRequest,requestDetails);
+          if (!isModal && Object.entries(newRequest).length !== 0) {
+            if (Object.entries(requestDetails).length !== 0 && requestDetails.currentState === "Unopened") {
+              newRequest = persistRequestFieldsNotInAxis(newRequest, requestDetails);
             }
             dispatch(setFOIRequestDetail(newRequest));
           }
           done(null, newRequest);
         } else {
-          done(null,"Exception happened while GET operations of request");
+          done(null, "Exception happened while GET operations of request");
           dispatch(serviceActionError(res));
           throw new Error(`Error in fetching request from AXIS.`);
         }
       })
       .catch((error) => {
         catchError(error, dispatch);
-        if (error.message.indexOf('401')> -1)
-        {
-          done(null,"Unauthorized-RestrictedAxisRequest");
+        if (error.message.indexOf('401') > -1) {
+          done(null, "Unauthorized-RestrictedAxisRequest");
         }
-        else{
-        
-        done(null,"Exception happened while GET operations of request");
+        else {
+
+          done(null, "Exception happened while GET operations of request");
         }
       });
   }
 };
 
-export const restrictRequest = (data, requestId, ministryId, type="iao", ...rest) => {
+export const restrictRequest = (data, requestId, ministryId, type = "iao", ...rest) => {
   const done = fnDone(rest);
   let apiUrl = "";
-  if (ministryId){
-    apiUrl= replaceUrl(replaceUrl(
+  if (ministryId) {
+    apiUrl = replaceUrl(replaceUrl(
       API.FOI_POST_MINISTRYREQUEST_RESTRICTION,
       "<ministryrequestid>",
-      ministryId),"<type>",type
-    ); 
+      ministryId), "<type>", type
+    );
   }
-  else{
-    apiUrl= replaceUrl(
+  else {
+    apiUrl = replaceUrl(
       API.FOI_POST_RAWREQUEST_RESTRICTION,
       "<requestid>",
       requestId
@@ -504,7 +505,7 @@ export const restrictRequest = (data, requestId, ministryId, type="iao", ...rest
 
 export const fetchRestrictedRequestCommentTagList = (requestid, ministryId, ...rest) => {
   const done = fnDone(rest);
-  const apiUrlgetRequestDetails = ministryId? replaceUrl(
+  const apiUrlgetRequestDetails = ministryId ? replaceUrl(
     API.FOI_GET_RESTRICTED_MINISTRYREQUEST_TAG_LIST,
     "<ministryrequestid>",
     ministryId
@@ -532,12 +533,12 @@ export const fetchRestrictedRequestCommentTagList = (requestid, ministryId, ...r
 
 export const deleteOIPCDetails = (requestId, ministryId, ...rest) => {
   const done = fnDone(rest);
-  let apiUrl= replaceUrl(replaceUrl(
+  let apiUrl = replaceUrl(replaceUrl(
     API.FOI_REQUEST_SECTION_API,
     "<ministryid>",
-    ministryId),"<requestid>",requestId
+    ministryId), "<requestid>", requestId
   );
-  const data = {isoipcreview: false, oipcdetails: []}
+  const data = { isoipcreview: false, oipcdetails: [] }
   return (dispatch) => {
     httpPOSTRequest(`${apiUrl}/oipc`, data)
       .then((res) => {
@@ -545,7 +546,7 @@ export const deleteOIPCDetails = (requestId, ministryId, ...rest) => {
           done(null, res.data);
         } else {
           dispatch(serviceActionError(res));
-          throw new Error(`Error while saving the OIPC Details for the (request# ${requestId}, ministry# ${ministryId})`);            
+          throw new Error(`Error while saving the OIPC Details for the (request# ${requestId}, ministry# ${ministryId})`);
         }
       })
       .catch((error) => {
@@ -556,7 +557,7 @@ export const deleteOIPCDetails = (requestId, ministryId, ...rest) => {
 }
 
 export const fetchHistoricalRequestDetails = (requestId) => {
-  
+
   const apiUrlgetRequestDetails = API.FOI_HISTORICAL_REQUEST_API + "/" + requestId;
   return (dispatch) => {
     httpGETRequest(apiUrlgetRequestDetails, {}, UserService.getToken())
@@ -606,28 +607,28 @@ export const fetchHistoricalExtensions = (
 
   return (dispatch) => {
     httpGETRequest(apiUrl, {}, UserService.getToken())
-    .then((res) => {
-      if (res.data) {
-        dispatch(setRequestExtensions(res.data));
-        dispatch(setFOILoader(false));
-      } else {
-        console.log("Error in fetching attachment list", res);
-        dispatch(serviceActionError(res));
-      }
-    })
-    .catch((error) => {
-      console.log("Error in fetching attachment list", error);
-      dispatch(serviceActionError(error));
-    });
+      .then((res) => {
+        if (res.data) {
+          dispatch(setRequestExtensions(res.data));
+          dispatch(setFOILoader(false));
+        } else {
+          console.log("Error in fetching attachment list", res);
+          dispatch(serviceActionError(res));
+        }
+      })
+      .catch((error) => {
+        console.log("Error in fetching attachment list", error);
+        dispatch(serviceActionError(error));
+      });
   }
 };
 
 export const updateSpecificRequestSection = (data, field, requestId, ministryId, ...rest) => {
   const done = fnDone(rest);
-  let apiUrl= replaceUrl(replaceUrl(
+  let apiUrl = replaceUrl(replaceUrl(
     API.FOI_REQUEST_SECTION_API,
     "<ministryid>",
-    ministryId),"<requestid>",requestId
+    ministryId), "<requestid>", requestId
   );
   return (dispatch) => {
     httpPOSTRequest(`${apiUrl}/${field}`, data)
@@ -636,7 +637,7 @@ export const updateSpecificRequestSection = (data, field, requestId, ministryId,
           done(null, res.data);
         } else {
           dispatch(serviceActionError(res));
-          throw new Error(`Error while updating ${field} for the (request# ${requestId}, ministry# ${ministryId})`);            
+          throw new Error(`Error while updating ${field} for the (request# ${requestId}, ministry# ${ministryId})`);
         }
       })
       .catch((error) => {
@@ -646,16 +647,16 @@ export const updateSpecificRequestSection = (data, field, requestId, ministryId,
   };
 }
 
-export const linkedRequestsLists = (queryParams,axisrequestid, ministrycode, ...rest) => {
+export const linkedRequestsLists = (queryParams, axisrequestid, ministrycode, ...rest) => {
   const done = fnDone(rest);
   const serializedQueryParams = new URLSearchParams(queryParams).toString();
   const fixedQueryParams = serializedQueryParams.replace(/\+/g, '%20');
-  let url= replaceUrl(replaceUrl(
-      API.FOI_GET_LINKED_REQUESTS_LIST+`?${fixedQueryParams}`,
-      "<ministrycode>",
-      ministrycode),"<axisrequestid>",
-      axisrequestid
-    );
+  let url = replaceUrl(replaceUrl(
+    API.FOI_GET_LINKED_REQUESTS_LIST + `?${fixedQueryParams}`,
+    "<ministrycode>",
+    ministrycode), "<axisrequestid>",
+    axisrequestid
+  );
   return (dispatch) => {
     httpGETRequest(url, {}, UserService.getToken())
       .then((res) => {
@@ -673,7 +674,7 @@ export const linkedRequestsLists = (queryParams,axisrequestid, ministrycode, ...
 };
 
 export const getFOIMinistryLinkedRequestInfo = (axisid) => async (dispatch) => {
-  const apiUrl= replaceUrl(API.FOI_MINISTRY_REQUEST_LINKEDREQUESTINFO, "<axisrequestid>", axisid);
+  const apiUrl = replaceUrl(API.FOI_MINISTRY_REQUEST_LINKEDREQUESTINFO, "<axisrequestid>", axisid);
   try {
     const res = await httpGETRequest(apiUrl, {}, UserService.getToken());
     if (res.data) {

--- a/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -225,7 +225,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
   const [unsavedMessage, setUnsavedMessage] = useState(<></>);
   const commentTypes = useSelector((state) => state.foiRequests.foiCommentTypes);
   const activePublicationRequest = !SKIP_OPENINFO_MINISTRIES.split(",").includes(requestDetails?.bcgovcode?.toUpperCase()) &&
-                                      requestDetails?.requestType === FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_GENERAL;
+    requestDetails?.requestType === FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_GENERAL;
 
   let isMinistry = false;
   const userGroups = userDetail && userDetail.groups.map(group => group.slice(1));
@@ -317,7 +317,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
     requestState &&
     requestState.toLowerCase() !== StateEnum.open.name.toLowerCase() &&
     requestState.toLowerCase() !==
-      StateEnum.intakeinprogress.name.toLowerCase();
+    StateEnum.intakeinprogress.name.toLowerCase();
   const [axisSyncedData, setAxisSyncedData] = useState({});
   const [checkExtension, setCheckExtension] = useState(true);
   let bcgovcode = isHistoricalRequest ? "" : getBCgovCode(ministryId, requestDetails);
@@ -330,7 +330,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
   const [isIAORestricted, setIsIAORestricted] = useState(false);
   const [redactedSections, setRedactedSections] = useState("");
   const [isMCFPersonal, setIsMCFPersonal] = useState(bcgovcode.replaceAll('"', '') == "MCF" && requestDetails.requestType == FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_PERSONAL);
-  const {oipcData, addOIPC, removeOIPC, updateOIPC, isOIPCReview, setIsOIPCReview, removeAllOIPCs} = useOIPCHook();
+  const { oipcData, addOIPC, removeOIPC, updateOIPC, isOIPCReview, setIsOIPCReview, removeAllOIPCs } = useOIPCHook();
   const [oipcDataInitial, setOipcDataInitial] = useState(oipcData);
   const [lockRecordsTab, setLockRecordsTab] = useState(false);
 
@@ -436,7 +436,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
     }
   }, [requestId, ministryId, requestDetails])
 
-  const validLockRecordsState = (currentState=requestDetails.currentState) => {
+  const validLockRecordsState = (currentState = requestDetails.currentState) => {
     return (
       currentState === StateEnum.harms.name ||
       currentState === StateEnum.onhold.name ||
@@ -457,7 +457,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
     const assignedTo = isHistoricalRequest ? requestDetails.assignedTo : getAssignedTo(requestDetails);
     setAssignedToValue(assignedTo);
     if (Object.entries(requestDetails)?.length !== 0) {
-       let requestStateFromId = findRequestState(requestDetails.requeststatuslabel)
+      let requestStateFromId = findRequestState(requestDetails.requeststatuslabel)
         ? findRequestState(requestDetails.requeststatuslabel)
         : StateEnum.unopened.name;
       setRequestState(requestStateFromId);
@@ -475,13 +475,13 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
       setIsIAORestricted(isRequestRestricted(requestDetails, ministryId));
     }
 
-    if(
+    if (
       MinistryNeedsScanning.includes(bcgovcode.replaceAll('"', '')) &&
       requestDetails.requestType ==
-        FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_PERSONAL
+      FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_PERSONAL
     ) {
       dispatch(fetchFOIPersonalDivisionsAndSections(bcgovcode.replaceAll('"', '')));
-      if(bcgovcode.replaceAll('"', '') == "MCF") {
+      if (bcgovcode.replaceAll('"', '') == "MCF") {
         dispatch(fetchFOIPersonalPeople(bcgovcode.replaceAll('"', '')));
         dispatch(fetchFOIPersonalFiletypes(bcgovcode.replaceAll('"', '')));
         dispatch(fetchFOIPersonalVolumes(bcgovcode.replaceAll('"', '')));
@@ -489,7 +489,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
       }
     }
 
-    if(requestDetails.isoipcreview) {
+    if (requestDetails.isoipcreview) {
       setIsOIPCReview(true);
     } else {
       setIsOIPCReview(false);
@@ -497,7 +497,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
 
     //Adjust lockRecords value based on requestState if there is no manual user lockedrecords value present in requestDetails from DB
     const updateRecordsTabAccess = () => {
-      if(requestDetails.userrecordslockstatus === null) {
+      if (requestDetails.userrecordslockstatus === null) {
         return validLockRecordsState(requestDetails.currentState);
       } else {
         return requestDetails.userrecordslockstatus;
@@ -508,7 +508,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
 
   //useEffect to manage isoipcreview attribute for requestdetails state
   useEffect(() => {
-    if(Object.keys(requestDetails).length !== 0 && oipcData?.length <= 0) {
+    if (Object.keys(requestDetails).length !== 0 && oipcData?.length <= 0) {
       requestDetails.isoipcreview = false;
       setIsOIPCReview(false);
     }
@@ -526,7 +526,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
             newRequestDetails["additionalPersonalInfo"] = newRequestDetails["additionalPersonalInfo"] || {}
             for (let infofield in requestApplicantProfile[field]) {
               newRequestDetails[field][infofield] =
-              requestApplicantProfile[field][infofield];
+                requestApplicantProfile[field][infofield];
             }
           } else {
             newRequestDetails[field] = requestApplicantProfile[field];
@@ -880,34 +880,34 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
         requestId,
         ministryId,
         (err, _res) => {
-        if(!err) {
-          toast.update(toastID, {
-            type: "success",
-            render: "OIPC details have been saved successfully.",
-            position: "top-right",
-            isLoading: false,
-            autoClose: 3000,
-            hideProgressBar: true,
-            closeOnClick: true,
-            pauseOnHover: true,
-            draggable: true,
-            progress: undefined,
-          });
-        } else {
-          toast.error(
-            "Temporarily unable to save the OIPC details. Please try again in a few minutes.",
-            {
+          if (!err) {
+            toast.update(toastID, {
+              type: "success",
+              render: "OIPC details have been saved successfully.",
               position: "top-right",
+              isLoading: false,
               autoClose: 3000,
               hideProgressBar: true,
               closeOnClick: true,
               pauseOnHover: true,
               draggable: true,
               progress: undefined,
-            }
-          );
-        }
-      })
+            });
+          } else {
+            toast.error(
+              "Temporarily unable to save the OIPC details. Please try again in a few minutes.",
+              {
+                position: "top-right",
+                autoClose: 3000,
+                hideProgressBar: true,
+                closeOnClick: true,
+                pauseOnHover: true,
+                draggable: true,
+                progress: undefined,
+              }
+            );
+          }
+        })
     )
   }
 
@@ -1011,7 +1011,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
 
     if (!_unSaved) {
       setUnSavedRequest(_unSaved);
-      dispatch(fetchFOIRequestDetailsWrapper(id || requestId, ministryId));
+      dispatch(fetchFOIRequestDetailsWrapper(id || requestId, ministryId, userGroups));
       dispatch(fetchFOIRequestDescriptionList(id || requestId, ministryId));
       dispatch(fetchFOIRequestAttachmentsList(id || requestId, ministryId));
       fetchCFRForm(ministryId, dispatch);
@@ -1172,7 +1172,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
       requestState !== StateEnum.unopened.name &&
       requestState !== StateEnum.open.name &&
       (requestDetails?.divisions?.length > 0 || isMCFPersonal) &&
-      DISABLE_GATHERINGRECORDS_TAB?.toLowerCase() =='false'
+      DISABLE_GATHERINGRECORDS_TAB?.toLowerCase() == 'false'
     );
   };
 
@@ -1197,7 +1197,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
         requestState !== StateEnum.unopened.name &&
         requestState !== StateEnum.open.name &&
         requestDetails?.requestType ===
-          FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_GENERAL
+        FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_GENERAL
       );
     } else {
       return (requestDetails?.requestType === FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_GENERAL);
@@ -1222,11 +1222,11 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
   }
 
   const getHistoryCount = () => {
-    let historyCount= visibleCorrespondence.length + requestNotes.filter(
-            c => c.commentTypeId !== getCommentTypeIdByName(commentTypes, "Ministry Internal") &&
-                c.commentTypeId !== getCommentTypeIdByName(commentTypes, "Ministry Peer Review")
-        ).length;
-    return '('+historyCount+')'
+    let historyCount = visibleCorrespondence.length + requestNotes.filter(
+      c => c.commentTypeId !== getCommentTypeIdByName(commentTypes, "Ministry Internal") &&
+        c.commentTypeId !== getCommentTypeIdByName(commentTypes, "Ministry Peer Review")
+    ).length;
+    return '(' + historyCount + ')'
   }
 
   const getMergedHistory = (applicantCorrespondence, requestNotes) => {
@@ -1249,11 +1249,11 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
     });
   };
   const getCommentsCount = () => {
-    let commentsCount= (requestNotes.filter( c => c.commentTypeId !== getCommentTypeIdByName(commentTypes,"Ministry Internal") &&
-          c.commentTypeId !== getCommentTypeIdByName(commentTypes, "Ministry Peer Review"))).length;
-    return '('+commentsCount+')'
+    let commentsCount = (requestNotes.filter(c => c.commentTypeId !== getCommentTypeIdByName(commentTypes, "Ministry Internal") &&
+      c.commentTypeId !== getCommentTypeIdByName(commentTypes, "Ministry Peer Review"))).length;
+    return '(' + commentsCount + ')'
 
-}
+  }
   const visibleCorrespondence = applicantCorrespondence?.filter(
     (c) => c.category !== 'draft'
   ) || [];
@@ -1271,11 +1271,10 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
     Object.keys(requestDetails).length !== 0) ||
     isAddRequest ? (
     <div
-      className={`foiformcontent ${
-        axisMessage === "WARNING" &&
+      className={`foiformcontent ${axisMessage === "WARNING" &&
         !disableBannerForClosed() &&
         "request-scrollbar-height"
-      }`}
+        }`}
     >
       <div className="foitabbedContainer">
         <div className={foitabheaderBG}>
@@ -1398,7 +1397,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
 
           <div className="foileftpanelstatus">
             {isOIPCReview && requestDetails.isreopened ? ""
-            : bottomTextArray.length > 0 &&
+              : bottomTextArray.length > 0 &&
               _requestStatus &&
               _requestStatus.toLowerCase().includes("days") &&
               bottomTextArray.map((text) => {
@@ -1514,18 +1513,18 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
                       />
                       {(isAddRequest ||
                         requestState === StateEnum.unopened.name) && (
-                        <AxisDetails
-                          requestDetails={requestDetails}
-                          createSaveRequestObject={createSaveRequestObject}
-                          handleAxisDetailsInitialValue={
-                            handleAxisDetailsInitialValue
-                          }
-                          handleAxisDetailsValue={handleAxisDetailsValue}
-                          handleAxisIdValidation={handleAxisIdValidation}
-                          setAxisMessage={setAxisMessage}
-                          saveRequestObject={saveRequestObject}
-                        />
-                      )}
+                          <AxisDetails
+                            requestDetails={requestDetails}
+                            createSaveRequestObject={createSaveRequestObject}
+                            handleAxisDetailsInitialValue={
+                              handleAxisDetailsInitialValue
+                            }
+                            handleAxisDetailsValue={handleAxisDetailsValue}
+                            handleAxisIdValidation={handleAxisIdValidation}
+                            setAxisMessage={setAxisMessage}
+                            saveRequestObject={saveRequestObject}
+                          />
+                        )}
                       <ApplicantDetails
                         requestDetails={requestDetails}
                         requestStatus={_requestStatus}
@@ -1543,27 +1542,27 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
                       />
                       {requiredRequestDetailsValues.requestType.toLowerCase() ===
                         FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_PERSONAL && (
-                        <>
-                          <ChildDetails
-                            additionalInfo={
-                              requestDetails.additionalPersonalInfo
-                            }
-                            createSaveRequestObject={createSaveRequestObject}
-                            disableInput={disableInput || isHistoricalRequest}
-                            userDetail={userDetail}
-                            requestType={requestDetails?.requestType}
-                            setError={setPersonalRequestDetailErrors}
-                          />
-                          <OnBehalfOfDetails
-                            additionalInfo={
-                              requestDetails.additionalPersonalInfo
-                            }
-                            createSaveRequestObject={createSaveRequestObject}
-                            disableInput={disableInput || isHistoricalRequest}
-                            setError={setPersonalRequestDetailErrors}
-                          />
-                        </>
-                      )}
+                          <>
+                            <ChildDetails
+                              additionalInfo={
+                                requestDetails.additionalPersonalInfo
+                              }
+                              createSaveRequestObject={createSaveRequestObject}
+                              disableInput={disableInput || isHistoricalRequest}
+                              userDetail={userDetail}
+                              requestType={requestDetails?.requestType}
+                              setError={setPersonalRequestDetailErrors}
+                            />
+                            <OnBehalfOfDetails
+                              additionalInfo={
+                                requestDetails.additionalPersonalInfo
+                              }
+                              createSaveRequestObject={createSaveRequestObject}
+                              disableInput={disableInput || isHistoricalRequest}
+                              setError={setPersonalRequestDetailErrors}
+                            />
+                          </>
+                        )}
 
                       <AddressContactDetails
                         requestDetails={requestDetails}
@@ -1575,7 +1574,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
                         handleContanctDetailsValue={handleContanctDetailsValue}
                         disableInput={disableInput || isHistoricalRequest /* || requestDetails?.axisApplicantID /* requestDetails?.foiRequestApplicantID > 0 comment back in after axis decommission*/}
                         handleEmailValidation={handleEmailValidation}
-                        defaultExpanded={!closeContactInfo(userDetail,requestDetails)}
+                        defaultExpanded={!closeContactInfo(userDetail, requestDetails)}
                         moreInfoAction={openApplicantProfileModal}
                         userDetail={userDetail}
                       />
@@ -1599,7 +1598,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
                         createSaveRequestObject={createSaveRequestObject}
                         disableInput={disableInput || isHistoricalRequest}
                       />
-                      {requestDetails?.axisRequestId && 
+                      {requestDetails?.axisRequestId &&
                         <LinkedRequests
                           requestDetails={requestDetails}
                           requestStatus={_requestStatus}
@@ -1625,7 +1624,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
                         requestExtensions={requestExtensions}
                       />
                       {(redactedSections && Object.keys(redactedSections).length > 0 && (
-                        <RedactionSummary sections={redactedSections} isoipcreview={isOIPCReview}/>
+                        <RedactionSummary sections={redactedSections} isoipcreview={isOIPCReview} />
                       ))}
 
                       <ExtensionDetails
@@ -1634,14 +1633,14 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
                       />
                       {requiredRequestDetailsValues.requestType.toLowerCase() ===
                         FOI_COMPONENT_CONSTANTS.REQUEST_TYPE_PERSONAL && (
-                        <AdditionalApplicantDetails
-                          requestDetails={requestDetails}
-                          createSaveRequestObject={createSaveRequestObject}
-                          disableInput={disableInput /* || requestDetails?.axisApplicantID /* requestDetails?.foiRequestApplicantID > 0 comment back in after axis decommission*/}
-                          defaultExpanded={true}
-                          setError={setPersonalRequestDetailErrors}
-                        />
-                      )}
+                          <AdditionalApplicantDetails
+                            requestDetails={requestDetails}
+                            createSaveRequestObject={createSaveRequestObject}
+                            disableInput={disableInput /* || requestDetails?.axisApplicantID /* requestDetails?.foiRequestApplicantID > 0 comment back in after axis decommission*/}
+                            defaultExpanded={true}
+                            setError={setPersonalRequestDetailErrors}
+                          />
+                        )}
                       {showDivisionalTracking && (
                         <DivisionalTracking
                           divisions={requestDetails.divisions}


### PR DESCRIPTION
This PR fixes an issue where the AssignedTo component would drop the BCPS Team value after transitioning an FOI Request to the "Open" state.

The root cause was that `userGroups` was not propagated during the save → refresh flow, which caused the AssignedTo list to be rebuilt using the generic intake endpoint instead of the BCPS team endpoint.

Main changes:
- Pass `userGroups` during request save refresh.
- Propagate context through request detail services.
- Prevent BCPS API URL from being overridden by the standard govcode endpoint.

After this change, BCPS assignments remain consistent across state transitions.


<img width="1694" height="799" alt="Screenshot from 2026-02-26 13-35-23" src="https://github.com/user-attachments/assets/e2a7a872-a4a6-4a81-bda7-1c1359a04e3b" />
