### PR TITLE
feat: enforce single document set per record

### DIFF
--- a/request-management-api/migrations/versions/c94f5a9b3e21_enforce_single_document_set_per_record.py
+++ b/request-management-api/migrations/versions/c94f5a9b3e21_enforce_single_document_set_per_record.py
@@ -1,7 +1,7 @@
 """Enforce single document set ownership per record
 
 Revision ID: c94f5a9b3e21
-Revises: 8253475faad7
+Revises: 786d5b509254
 Create Date: 2026-03-17 11:30:00.000000
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'c94f5a9b3e21'
-down_revision = '8253475faad7'
+down_revision = '786d5b509254'
 branch_labels = None
 depends_on = None
 

--- a/request-management-api/migrations/versions/c94f5a9b3e21_enforce_single_document_set_per_record.py
+++ b/request-management-api/migrations/versions/c94f5a9b3e21_enforce_single_document_set_per_record.py
@@ -1,0 +1,32 @@
+"""Enforce single document set ownership per record
+
+Revision ID: c94f5a9b3e21
+Revises: 8253475faad7
+Create Date: 2026-03-17 11:30:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'c94f5a9b3e21'
+down_revision = '8253475faad7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    op.create_unique_constraint(
+        "uq_foirequestrecordgroups_record_id",
+        "FOIRequestRecordGroups",
+        ["record_id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "uq_foirequestrecordgroups_record_id",
+        "FOIRequestRecordGroups",
+        type_="unique",
+    )

--- a/request-management-api/request_api/models/FOIRequestRecordGroup.py
+++ b/request-management-api/request_api/models/FOIRequestRecordGroup.py
@@ -71,13 +71,10 @@ class FOIRequestRecordGroup(db.Model):
             db.session.flush()  # now group.document_set_id is available
 
             # 2. Insert into association table
-            for rid in sorted(set(records)):
-                db.session.execute(
-                    db.insert(FOIRequestRecordGroups).values(
-                        document_set_id=group.document_set_id,
-                        record_id=rid,
-                    )
-                )
+            FOIRequestRecordGroups.add_records(
+                document_set_id=group.document_set_id,
+                record_ids=set(records),
+            )
 
             db.session.commit()
             return group
@@ -187,4 +184,3 @@ class FOIRequestRecordGroup(db.Model):
             )
             .first()
         )
-

--- a/request-management-api/request_api/models/FOIRequestRecordGroups.py
+++ b/request-management-api/request_api/models/FOIRequestRecordGroups.py
@@ -1,3 +1,4 @@
+from sqlalchemy import UniqueConstraint
 
 from .db import db
 
@@ -18,6 +19,10 @@ class FOIRequestRecordGroups(db.Model):
         db.Integer,
         db.ForeignKey("FOIRequestRecords.recordid", ondelete="CASCADE"),
         primary_key=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint("record_id", name="uq_foirequestrecordgroups_record_id"),
     )
 
     def __repr__(self) -> str:
@@ -62,8 +67,10 @@ class FOIRequestRecordGroups(db.Model):
         if not record_ids:
             return
 
-        rows = [{"document_set_id": document_set_id, "record_id": rid}
-                for rid in record_ids]
+        rows = [
+            {"document_set_id": document_set_id, "record_id": rid}
+            for rid in sorted(set(record_ids))
+        ]
 
         db.session.execute(cls.__table__.insert(), rows)
 

--- a/request-management-api/request_api/services/records/recordgroupservice.py
+++ b/request-management-api/request_api/services/records/recordgroupservice.py
@@ -227,6 +227,8 @@ class recordgroupservice:
         # Commit once
         db.session.commit()
 
+        persisted_records = sorted(FOIRequestRecordGroups.get_record_ids(document_set_id))
+
         return DefaultMethodResult(
             True,
             "Group updated.",
@@ -234,7 +236,7 @@ class recordgroupservice:
             data={
                 "documentsetid": group.document_set_id,
                 "name": group.name,
-                "records": sorted(payload.get("records", [])),
+                "records": persisted_records,
             },
         )
 
@@ -288,4 +290,3 @@ class recordgroupservice:
         except Exception:
             current_app.logger.exception("Error fetching record groups")
             return DefaultMethodResult(False, "Unexpected error fetching groups.", 500)
-

--- a/request-management-api/tests/services/test_recordgroupservice.py
+++ b/request-management-api/tests/services/test_recordgroupservice.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+
+from request_api.models.FOIRequestRecordGroups import FOIRequestRecordGroups
+from request_api.services.records.recordgroupservice import recordgroupservice
+
+
+def test_add_records_deduplicates_rows(monkeypatch):
+    captured = {}
+
+    def fake_execute(statement, rows):
+        captured["rows"] = rows
+
+    monkeypatch.setattr(
+        "request_api.models.FOIRequestRecordGroups.db.session.execute",
+        fake_execute,
+    )
+
+    FOIRequestRecordGroups.add_records(77, [4, 4, 2])
+
+    assert captured["rows"] == [
+        {"document_set_id": 77, "record_id": 2},
+        {"document_set_id": 77, "record_id": 4},
+    ]
+
+
+def test_update_returns_persisted_record_ids(monkeypatch):
+    service = recordgroupservice()
+    group = SimpleNamespace(
+        document_set_id=77,
+        request_id=12,
+        ministry_request_id=34,
+        name="Set A",
+        updated_by=None,
+        updated_at=None,
+    )
+
+    class _FakeQuery:
+        def filter_by(self, **kwargs):
+            return self
+
+        def first(self):
+            return group
+
+    persisted_sets = iter([{101}, {101, 102}])
+
+    monkeypatch.setattr(
+        "request_api.services.records.recordgroupservice.FOIRequestRecordGroup.query",
+        _FakeQuery(),
+    )
+    monkeypatch.setattr(
+        service,
+        "fetch_valid_records",
+        lambda ministryrequestid, records, requestid: {101, 102},
+    )
+    monkeypatch.setattr(
+        "request_api.services.records.recordgroupservice.FOIRequestRecordGroups.get_record_ids",
+        lambda document_set_id: next(persisted_sets),
+    )
+
+    removed = {}
+    added = {}
+
+    monkeypatch.setattr(
+        "request_api.services.records.recordgroupservice.FOIRequestRecordGroups.remove_from_other_groups",
+        lambda document_set_id, record_ids: removed.update(
+            {"document_set_id": document_set_id, "record_ids": record_ids}
+        ),
+    )
+    monkeypatch.setattr(
+        "request_api.services.records.recordgroupservice.FOIRequestRecordGroups.add_records",
+        lambda document_set_id, record_ids: added.update(
+            {"document_set_id": document_set_id, "record_ids": record_ids}
+        ),
+    )
+    monkeypatch.setattr(
+        "request_api.services.records.recordgroupservice.db.session.commit",
+        lambda: None,
+    )
+
+    result = service.update(
+        12,
+        34,
+        {"documentsetid": 77, "records": [101, 101, 102]},
+        "idir\\tester",
+    )
+
+    assert result.success is True
+    assert removed == {"document_set_id": 77, "record_ids": {102}}
+    assert added == {"document_set_id": 77, "record_ids": {102}}
+    assert result.data["records"] == [101, 102]


### PR DESCRIPTION
  - Added a DB uniqueness rule on FOIRequestRecordGroups.record_id via migration so one record can belong to only one document set total.
  - Updated record-group creation to reuse the shared bulk insert helper.
  - Updated FOIRequestRecordGroups.add_records(...) to dedupe incoming record ids before insert.
  - Updated recordgroupservice.update(...) to return the persisted record list instead of echoing duplicate ids from the request payload.