### PR TITLE
fix: reassign records from other document sets during create

### DIFF
--- a/request-management-api/request_api/models/FOIRequestRecordGroup.py
+++ b/request-management-api/request_api/models/FOIRequestRecordGroup.py
@@ -60,6 +60,8 @@ class FOIRequestRecordGroup(db.Model):
     ) -> "FOIRequestRecordGroup | None":
 
         try:
+            record_ids = set(records)
+
             # 1. Insert parent group
             group = cls(
                 ministry_request_id=ministry_request_id,
@@ -70,10 +72,16 @@ class FOIRequestRecordGroup(db.Model):
             db.session.add(group)
             db.session.flush()  # now group.document_set_id is available
 
-            # 2. Insert into association table
+            # 2. Enforce one-group-per-record before inserting associations
+            FOIRequestRecordGroups.remove_from_other_groups(
+                document_set_id=group.document_set_id,
+                record_ids=record_ids,
+            )
+
+            # 3. Insert into association table
             FOIRequestRecordGroups.add_records(
                 document_set_id=group.document_set_id,
-                record_ids=set(records),
+                record_ids=record_ids,
             )
 
             db.session.commit()

--- a/request-management-api/tests/services/test_recordgroupservice.py
+++ b/request-management-api/tests/services/test_recordgroupservice.py
@@ -1,6 +1,9 @@
 from types import SimpleNamespace
 
+import request_api.services.records.recordgroupservice as recordgroupservice_module
+from request_api.models.FOIRequestRecordGroup import FOIRequestRecordGroup
 from request_api.models.FOIRequestRecordGroups import FOIRequestRecordGroups
+from request_api.models.db import db
 from request_api.services.records.recordgroupservice import recordgroupservice
 
 
@@ -10,16 +13,62 @@ def test_add_records_deduplicates_rows(monkeypatch):
     def fake_execute(statement, rows):
         captured["rows"] = rows
 
-    monkeypatch.setattr(
-        "request_api.models.FOIRequestRecordGroups.db.session.execute",
-        fake_execute,
-    )
+    monkeypatch.setattr(db.session, "execute", fake_execute)
 
     FOIRequestRecordGroups.add_records(77, [4, 4, 2])
 
     assert captured["rows"] == [
         {"document_set_id": 77, "record_id": 2},
         {"document_set_id": 77, "record_id": 4},
+    ]
+
+
+def test_create_group_removes_records_from_other_groups_before_add(monkeypatch):
+    captured = {}
+    calls = []
+
+    class FakeGroup:
+        def __init__(self, **kwargs):
+            self.document_set_id = None
+            self.__dict__.update(kwargs)
+
+    def fake_add(group):
+        captured["group"] = group
+
+    def fake_flush():
+        captured["group"].document_set_id = 170
+
+    monkeypatch.setattr(db.session, "add", fake_add)
+    monkeypatch.setattr(db.session, "flush", fake_flush)
+    monkeypatch.setattr(db.session, "commit", lambda: None)
+    monkeypatch.setattr(
+        FOIRequestRecordGroups,
+        "remove_from_other_groups",
+        lambda document_set_id, record_ids: calls.append(
+            ("remove", document_set_id, record_ids)
+        ),
+    )
+    monkeypatch.setattr(
+        FOIRequestRecordGroups,
+        "add_records",
+        lambda document_set_id, record_ids: calls.append(
+            ("add", document_set_id, record_ids)
+        ),
+    )
+
+    group = FOIRequestRecordGroup.create_group.__func__(
+        FakeGroup,
+        ministry_request_id=15745,
+        request_id=15722,
+        name="Document Set 4",
+        created_by="idir\\tester",
+        records=[12850, 12847, 12850],
+    )
+
+    assert group is not None
+    assert calls == [
+        ("remove", 170, {12847, 12850}),
+        ("add", 170, {12847, 12850}),
     ]
 
 
@@ -44,8 +93,9 @@ def test_update_returns_persisted_record_ids(monkeypatch):
     persisted_sets = iter([{101}, {101, 102}])
 
     monkeypatch.setattr(
-        "request_api.services.records.recordgroupservice.FOIRequestRecordGroup.query",
-        _FakeQuery(),
+        recordgroupservice_module,
+        "FOIRequestRecordGroup",
+        SimpleNamespace(query=_FakeQuery()),
     )
     monkeypatch.setattr(
         service,
@@ -53,7 +103,8 @@ def test_update_returns_persisted_record_ids(monkeypatch):
         lambda ministryrequestid, records, requestid: {101, 102},
     )
     monkeypatch.setattr(
-        "request_api.services.records.recordgroupservice.FOIRequestRecordGroups.get_record_ids",
+        recordgroupservice_module.FOIRequestRecordGroups,
+        "get_record_ids",
         lambda document_set_id: next(persisted_sets),
     )
 
@@ -61,19 +112,22 @@ def test_update_returns_persisted_record_ids(monkeypatch):
     added = {}
 
     monkeypatch.setattr(
-        "request_api.services.records.recordgroupservice.FOIRequestRecordGroups.remove_from_other_groups",
+        recordgroupservice_module.FOIRequestRecordGroups,
+        "remove_from_other_groups",
         lambda document_set_id, record_ids: removed.update(
             {"document_set_id": document_set_id, "record_ids": record_ids}
         ),
     )
     monkeypatch.setattr(
-        "request_api.services.records.recordgroupservice.FOIRequestRecordGroups.add_records",
+        recordgroupservice_module.FOIRequestRecordGroups,
+        "add_records",
         lambda document_set_id, record_ids: added.update(
             {"document_set_id": document_set_id, "record_ids": record_ids}
         ),
     )
     monkeypatch.setattr(
-        "request_api.services.records.recordgroupservice.db.session.commit",
+        recordgroupservice_module.db.session,
+        "commit",
         lambda: None,
     )
 


### PR DESCRIPTION
This PR fixes document set creation when the payload includes records already associated with another document set.

  Changes:

  - Update FOIRequestRecordGroup.create_group() to remove matching record associations from other document sets before inserting new FOIRequestRecordGroups rows.
  - Add a regression test covering the create path so it mirrors the existing update behavior.
  - Clean up the related test monkeypatches so the service test file runs reliably.

  Result:

  - Creating a new document set now reassigns those records instead of failing with uq_foirequestrecordgroups_record_id.

  Verification:

  - pytest tests/services/test_recordgroupservice.py -q passed.
