### PR TITLE
Release 24.2 - fix(record-groups): ensure consistent document set reassignment and deletion cleanup

### DIFF
--- a/request-management-api/request_api/models/FOIRequestRecordGroup.py
+++ b/request-management-api/request_api/models/FOIRequestRecordGroup.py
@@ -60,6 +60,8 @@ class FOIRequestRecordGroup(db.Model):
     ) -> "FOIRequestRecordGroup | None":
 
         try:
+            record_ids = set(records)
+
             # 1. Insert parent group
             group = cls(
                 ministry_request_id=ministry_request_id,
@@ -70,14 +72,17 @@ class FOIRequestRecordGroup(db.Model):
             db.session.add(group)
             db.session.flush()  # now group.document_set_id is available
 
-            # 2. Insert into association table
-            for rid in sorted(set(records)):
-                db.session.execute(
-                    db.insert(FOIRequestRecordGroups).values(
-                        document_set_id=group.document_set_id,
-                        record_id=rid,
-                    )
-                )
+            # 2. Enforce one-group-per-record before inserting associations
+            FOIRequestRecordGroups.remove_from_other_groups(
+                document_set_id=group.document_set_id,
+                record_ids=record_ids,
+            )
+
+            # 3. Insert into association table
+            FOIRequestRecordGroups.add_records(
+                document_set_id=group.document_set_id,
+                record_ids=record_ids,
+            )
 
             db.session.commit()
             return group
@@ -187,4 +192,3 @@ class FOIRequestRecordGroup(db.Model):
             )
             .first()
         )
-

--- a/request-management-api/request_api/models/FOIRequestRecordGroups.py
+++ b/request-management-api/request_api/models/FOIRequestRecordGroups.py
@@ -1,3 +1,4 @@
+from sqlalchemy import UniqueConstraint
 
 from .db import db
 
@@ -18,6 +19,10 @@ class FOIRequestRecordGroups(db.Model):
         db.Integer,
         db.ForeignKey("FOIRequestRecords.recordid", ondelete="CASCADE"),
         primary_key=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint("record_id", name="uq_foirequestrecordgroups_record_id"),
     )
 
     def __repr__(self) -> str:
@@ -62,8 +67,10 @@ class FOIRequestRecordGroups(db.Model):
         if not record_ids:
             return
 
-        rows = [{"document_set_id": document_set_id, "record_id": rid}
-                for rid in record_ids]
+        rows = [
+            {"document_set_id": document_set_id, "record_id": rid}
+            for rid in sorted(set(record_ids))
+        ]
 
         db.session.execute(cls.__table__.insert(), rows)
 

--- a/request-management-api/request_api/models/FOIRequestRecordGroups.py
+++ b/request-management-api/request_api/models/FOIRequestRecordGroups.py
@@ -38,6 +38,17 @@ class FOIRequestRecordGroups(db.Model):
         )
 
     @classmethod
+    def remove_records_from_all_groups(cls, record_ids: set[int]) -> None:
+        if not record_ids:
+            return
+
+        (
+            db.session.query(cls)
+            .filter(cls.record_id.in_(record_ids))
+            .delete(synchronize_session=False)
+        )
+
+    @classmethod
     def get_record_ids(cls, document_set_id: int) -> set[int]:
         rows = (
             db.session.query(cls.record_id)
@@ -95,4 +106,3 @@ class FOIRequestRecordGroups(db.Model):
         )
 
         return deleted_count
-

--- a/request-management-api/request_api/services/records/recordgroupservice.py
+++ b/request-management-api/request_api/services/records/recordgroupservice.py
@@ -227,6 +227,8 @@ class recordgroupservice:
         # Commit once
         db.session.commit()
 
+        persisted_records = sorted(FOIRequestRecordGroups.get_record_ids(document_set_id))
+
         return DefaultMethodResult(
             True,
             "Group updated.",
@@ -234,7 +236,7 @@ class recordgroupservice:
             data={
                 "documentsetid": group.document_set_id,
                 "name": group.name,
-                "records": sorted(payload.get("records", [])),
+                "records": persisted_records,
             },
         )
 
@@ -288,4 +290,3 @@ class recordgroupservice:
         except Exception:
             current_app.logger.exception("Error fetching record groups")
             return DefaultMethodResult(False, "Unexpected error fetching groups.", 500)
-

--- a/request-management-api/request_api/services/recordservice.py
+++ b/request-management-api/request_api/services/recordservice.py
@@ -5,6 +5,7 @@ from request_api.models.FOIRequestRecordHistory import FOIRequestRecordHistory
 from request_api.utils import json_utils
 from request_api.utils.constants import FILE_CONVERSION_FILE_TYPES, DEDUPE_FILE_TYPES, NONREDACTABLE_FILE_TYPES
 from request_api.models.FOIRequestRecords import FOIRequestRecord
+from request_api.models.FOIRequestRecordGroups import FOIRequestRecordGroups
 from request_api.models.FOIMinistryRequests import FOIMinistryRequest
 from request_api.models.HistoricalRecords import HistoricalRecords
 from request_api.services.external.eventqueueservice import eventqueueservice
@@ -155,6 +156,9 @@ class recordservice(recordservicebase):
                 # Apply all updates to the main record
                 updated_record = self._prepare_record_update(record, requestdata, userid)
                 updated_orm_records.append(updated_record)
+
+            if requestdata['isdelete']:
+                FOIRequestRecordGroups.remove_records_from_all_groups(set(recordids))
 
             # 3. Database Transaction (Atomic Save)
             response = FOIRequestRecord.create(updated_orm_records, historical_records)
@@ -631,4 +635,3 @@ class recordservice(recordservicebase):
     
 
     
-

--- a/request-management-api/request_api/services/recordservice.py
+++ b/request-management-api/request_api/services/recordservice.py
@@ -155,6 +155,8 @@ class recordservice(recordservicebase):
 
                 # Apply all updates to the main record
                 updated_record = self._prepare_record_update(record, requestdata, userid)
+                if requestdata['isdelete'] and hasattr(updated_record, 'groups'):
+                    updated_record.groups = []
                 updated_orm_records.append(updated_record)
 
             if requestdata['isdelete']:

--- a/request-management-api/requirements.txt
+++ b/request-management-api/requirements.txt
@@ -63,6 +63,7 @@ redis==4.1.4
 flask_jwt_oidc==0.3.0
 maya==0.6.1
 pyjwt==2.4.0
+pytest==8.4.2
 aws-requests-auth==0.4.3
 holidays==0.12
 Flask-SocketIO==5.3.6

--- a/request-management-api/tests/services/test_recordgroupservice.py
+++ b/request-management-api/tests/services/test_recordgroupservice.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+
+import request_api.services.records.recordgroupservice as recordgroupservice_module
+from request_api.models.FOIRequestRecordGroup import FOIRequestRecordGroup
+from request_api.models.FOIRequestRecordGroups import FOIRequestRecordGroups
+from request_api.models.db import db
+from request_api.services.records.recordgroupservice import recordgroupservice
+
+
+def test_add_records_deduplicates_rows(monkeypatch):
+    captured = {}
+
+    def fake_execute(statement, rows):
+        captured["rows"] = rows
+
+    monkeypatch.setattr(db.session, "execute", fake_execute)
+
+    FOIRequestRecordGroups.add_records(77, [4, 4, 2])
+
+    assert captured["rows"] == [
+        {"document_set_id": 77, "record_id": 2},
+        {"document_set_id": 77, "record_id": 4},
+    ]
+
+
+def test_create_group_removes_records_from_other_groups_before_add(monkeypatch):
+    captured = {}
+    calls = []
+
+    class FakeGroup:
+        def __init__(self, **kwargs):
+            self.document_set_id = None
+            self.__dict__.update(kwargs)
+
+    def fake_add(group):
+        captured["group"] = group
+
+    def fake_flush():
+        captured["group"].document_set_id = 170
+
+    monkeypatch.setattr(db.session, "add", fake_add)
+    monkeypatch.setattr(db.session, "flush", fake_flush)
+    monkeypatch.setattr(db.session, "commit", lambda: None)
+    monkeypatch.setattr(
+        FOIRequestRecordGroups,
+        "remove_from_other_groups",
+        lambda document_set_id, record_ids: calls.append(
+            ("remove", document_set_id, record_ids)
+        ),
+    )
+    monkeypatch.setattr(
+        FOIRequestRecordGroups,
+        "add_records",
+        lambda document_set_id, record_ids: calls.append(
+            ("add", document_set_id, record_ids)
+        ),
+    )
+
+    group = FOIRequestRecordGroup.create_group.__func__(
+        FakeGroup,
+        ministry_request_id=15745,
+        request_id=15722,
+        name="Document Set 4",
+        created_by="idir\\tester",
+        records=[12850, 12847, 12850],
+    )
+
+    assert group is not None
+    assert calls == [
+        ("remove", 170, {12847, 12850}),
+        ("add", 170, {12847, 12850}),
+    ]
+
+
+def test_update_returns_persisted_record_ids(monkeypatch):
+    service = recordgroupservice()
+    group = SimpleNamespace(
+        document_set_id=77,
+        request_id=12,
+        ministry_request_id=34,
+        name="Set A",
+        updated_by=None,
+        updated_at=None,
+    )
+
+    class _FakeQuery:
+        def filter_by(self, **kwargs):
+            return self
+
+        def first(self):
+            return group
+
+    persisted_sets = iter([{101}, {101, 102}])
+
+    monkeypatch.setattr(
+        recordgroupservice_module,
+        "FOIRequestRecordGroup",
+        SimpleNamespace(query=_FakeQuery()),
+    )
+    monkeypatch.setattr(
+        service,
+        "fetch_valid_records",
+        lambda ministryrequestid, records, requestid: {101, 102},
+    )
+    monkeypatch.setattr(
+        recordgroupservice_module.FOIRequestRecordGroups,
+        "get_record_ids",
+        lambda document_set_id: next(persisted_sets),
+    )
+
+    removed = {}
+    added = {}
+
+    monkeypatch.setattr(
+        recordgroupservice_module.FOIRequestRecordGroups,
+        "remove_from_other_groups",
+        lambda document_set_id, record_ids: removed.update(
+            {"document_set_id": document_set_id, "record_ids": record_ids}
+        ),
+    )
+    monkeypatch.setattr(
+        recordgroupservice_module.FOIRequestRecordGroups,
+        "add_records",
+        lambda document_set_id, record_ids: added.update(
+            {"document_set_id": document_set_id, "record_ids": record_ids}
+        ),
+    )
+    monkeypatch.setattr(
+        recordgroupservice_module.db.session,
+        "commit",
+        lambda: None,
+    )
+
+    result = service.update(
+        12,
+        34,
+        {"documentsetid": 77, "records": [101, 101, 102]},
+        "idir\\tester",
+    )
+
+    assert result.success is True
+    assert removed == {"document_set_id": 77, "record_ids": {102}}
+    assert added == {"document_set_id": 77, "record_ids": {102}}
+    assert result.data["records"] == [101, 102]

--- a/request-management-api/tests/services/test_recordservice.py
+++ b/request-management-api/tests/services/test_recordservice.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+
+from request_api.models.default_method_result import DefaultMethodResult
+from request_api.services.recordservice import recordservice
+
+
+def test_update_delete_clears_loaded_group_relationships_before_save(monkeypatch):
+    service = recordservice()
+    fake_record = SimpleNamespace(
+        recordid=26138,
+        groups=[SimpleNamespace(document_set_id=99)],
+    )
+
+    monkeypatch.setattr(
+        "request_api.services.recordservice.FOIRequestRecord.getrecordsbyid",
+        lambda recordids: [fake_record],
+    )
+    monkeypatch.setattr(
+        service,
+        "_create_historical_record",
+        lambda record: object(),
+    )
+    monkeypatch.setattr(
+        service,
+        "_prepare_record_update",
+        lambda record, requestdata, userid: record,
+    )
+
+    removed_record_ids = []
+
+    def fake_remove_records_from_all_groups(record_ids):
+        removed_record_ids.append(record_ids)
+
+    monkeypatch.setattr(
+        "request_api.services.recordservice.FOIRequestRecordGroups.remove_records_from_all_groups",
+        fake_remove_records_from_all_groups,
+    )
+
+    def fake_create(records, historical_records):
+        assert records[0].groups == []
+        return DefaultMethodResult(True, "Records saved/updated", -1, {})
+
+    monkeypatch.setattr(
+        "request_api.services.recordservice.FOIRequestRecord.create",
+        fake_create,
+    )
+    monkeypatch.setattr(
+        service,
+        "_handle_doc_reviewer_api",
+        lambda ministryrequestid, records_data, requestdata: DefaultMethodResult(
+            True,
+            "Record deleted in Doc Reviewer DB",
+            -1,
+            [],
+        ),
+    )
+
+    result = service.update(
+        21980,
+        21965,
+        {
+            "records": [
+                {
+                    "recordid": 26138,
+                    "documentmasterid": 38226,
+                    "filepath": "https://example.com/record.pdf",
+                }
+            ],
+            "isdelete": True,
+        },
+        "tester",
+    )
+
+    assert result.success is True
+    assert removed_record_ids == [{26138}]


### PR DESCRIPTION
This PR promotes fixes from dev to main addressing issues with document set associations during create and delete flows.

It ensures that records are correctly reassigned between document sets and that stale associations are not unintentionally restored.