### PR TITLE
Implemented a log-only consumer path for publication.unpublish.completed.

### DIFF
--- a/request-management-api/request_api/services/publication_events/completed_stream_consumer.py
+++ b/request-management-api/request_api/services/publication_events/completed_stream_consumer.py
@@ -12,7 +12,9 @@ import redis
 
 from request_api.services.publication_events.consumer import (
     OpenInfoPublishCompletedConsumer,
+    OpenInfoUnpublishCompletedConsumer,
     ProactiveDisclosurePublishCompletedConsumer,
+    ProactiveDisclosureUnpublishCompletedConsumer,
 )
 from request_api.services.publication_events.types import PublicationEventType
 
@@ -21,7 +23,7 @@ _PD_CORRELATION = re.compile(r"^proactivedisclosure-")
 
 
 class PublicationCompletedStreamConsumer:
-    """Consumes unified publication.publish.completed Redis Stream messages and routes by correlation_id."""
+    """Consumes completed publication Redis Stream messages and routes by event type and kind."""
 
     def __init__(
         self,
@@ -40,8 +42,14 @@ class PublicationCompletedStreamConsumer:
         self.group_name = group_name
         self.consumer_name = consumer_name
         self.handlers = handlers or {
-            "openinfo": OpenInfoPublishCompletedConsumer(),
-            "proactivedisclosure": ProactiveDisclosurePublishCompletedConsumer(),
+            PublicationEventType.PUBLISH_COMPLETED: {
+                "openinfo": OpenInfoPublishCompletedConsumer(),
+                "proactivedisclosure": ProactiveDisclosurePublishCompletedConsumer(),
+            },
+            PublicationEventType.UNPUBLISH_COMPLETED: {
+                "openinfo": OpenInfoUnpublishCompletedConsumer(),
+                "proactivedisclosure": ProactiveDisclosureUnpublishCompletedConsumer(),
+            },
         }
         self.app = app
         self.count = count
@@ -69,6 +77,10 @@ class PublicationCompletedStreamConsumer:
                 PublicationEventType.PUBLISH_COMPLETED: os.getenv(
                     "PUBLICATION_PUBLISH_COMPLETED_STREAM_NAME",
                     "publication.publish.completed",
+                ),
+                PublicationEventType.UNPUBLISH_COMPLETED: os.getenv(
+                    "PUBLICATION_UNPUBLISH_COMPLETED_STREAM_NAME",
+                    "publication.unpublish.completed",
                 ),
             },
             group_name=os.getenv(
@@ -149,7 +161,12 @@ class PublicationCompletedStreamConsumer:
 
     @staticmethod
     def _resolve_kind(envelope):
-        """Determine kind from correlation_id pattern."""
+        """Determine kind from payload discriminator, falling back to correlation_id pattern."""
+        payload = envelope.get("payload") or {}
+        kind = payload.get("kind")
+        if kind in ("openinfo", "proactivedisclosure"):
+            return kind
+
         correlation_id = envelope.get("correlation_id", "")
         if _OI_CORRELATION.match(correlation_id):
             return "openinfo"
@@ -157,13 +174,21 @@ class PublicationCompletedStreamConsumer:
             return "proactivedisclosure"
         return None
 
+    def _resolve_handler(self, envelope, kind):
+        event_type = envelope.get("event_type")
+        handlers_for_event = self.handlers.get(event_type)
+        if isinstance(handlers_for_event, dict):
+            return handlers_for_event.get(kind)
+        return self.handlers.get(kind)
+
     def _handle_message(self, stream_name, message_id, fields):
         envelope = self._parse_envelope(fields)
         kind = self._resolve_kind(envelope)
-        handler = self.handlers.get(kind)
+        handler = self._resolve_handler(envelope, kind)
         if handler is None:
             logging.error(
-                "No publication completed handler for kind=%s correlation_id=%s",
+                "No publication completed handler for event_type=%s kind=%s correlation_id=%s",
+                envelope.get("event_type"),
                 kind,
                 envelope.get("correlation_id"),
             )

--- a/request-management-api/request_api/services/publication_events/consumer.py
+++ b/request-management-api/request_api/services/publication_events/consumer.py
@@ -45,6 +45,29 @@ class OpenInfoPublishCompletedConsumer:
         return self.openinfo_model.create_published_version_from_openinfo_id(openinfo_id, message)
 
 
+class OpenInfoUnpublishCompletedConsumer:
+    """Logs completed unpublish events for OpenInfo records."""
+
+    def handle(self, envelope):
+        """Validate and log a publication.unpublish.completed event for OpenInfo."""
+        if envelope.get("event_type") != PublicationEventType.UNPUBLISH_COMPLETED:
+            return DefaultMethodResult(False, "Unsupported event type")
+
+        payload = envelope.get("payload") or {}
+        # FIXME: status needs to be updated
+        logging.info(
+            "Handling OpenInfo unpublish completed event | "
+            f"event_id={envelope.get('event_id')} "
+            f"correlation_id={envelope.get('correlation_id')} "
+            f"kind={payload.get('kind')} "
+            f"publication_id={payload.get('publication_id')} "
+            f"status={payload.get('status')} "
+            f"objects_deleted={payload.get('objects_deleted')} "
+            f"sitemap_result={payload.get('sitemap_result')}"
+        )
+        return DefaultMethodResult(True, "Unpublish completion logged")
+
+
 class ProactiveDisclosurePublishCompletedConsumer:
     """Handles completed publication events for Proactive Disclosure records."""
 
@@ -85,3 +108,26 @@ class ProactiveDisclosurePublishCompletedConsumer:
             proactive_id,
             message,
         )
+
+
+class ProactiveDisclosureUnpublishCompletedConsumer:
+    """Logs completed unpublish events for Proactive Disclosure records."""
+
+    def handle(self, envelope):
+        """Validate and log a publication.unpublish.completed event for Proactive Disclosure."""
+        if envelope.get("event_type") != PublicationEventType.UNPUBLISH_COMPLETED:
+            return DefaultMethodResult(False, "Unsupported event type")
+        payload = envelope.get("payload") or {}
+
+        # FIXME: status needs to be updated
+        logging.info(
+            "Handling Proactive Disclosure unpublish completed event | "
+            f"event_id={envelope.get('event_id')} "
+            f"correlation_id={envelope.get('correlation_id')} "
+            f"kind={payload.get('kind')} "
+            f"publication_id={payload.get('publication_id')} "
+            f"status={payload.get('status')} "
+            f"objects_deleted={payload.get('objects_deleted')} "
+            f"sitemap_result={payload.get('sitemap_result')}"
+        )
+        return DefaultMethodResult(True, "Unpublish completion logged")

--- a/request-management-api/request_api/services/publication_events/mappers.py
+++ b/request-management-api/request_api/services/publication_events/mappers.py
@@ -120,15 +120,17 @@ class UnpublishRequestedMapper:
         self.path_resolver = path_resolver or PublicationPathResolver()
         self.public_base_url = os.getenv(
             "PUBLICATION_PUBLIC_BASE_URL",
-            "https://openinfo.gov.bc.ca",
-        )
+            "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages",
+        ).rstrip("/")
 
     def map(self, row, publication_type="openinfo"):
         axis_request_id = row.get("axisrequestid")
         return UnpublishRequestedPayload(
             tenant_id=self.path_resolver.resolve_tenant_id(row),
             publication_id=axis_request_id,
-            public_url=f"{self.public_base_url}/public/{axis_request_id}.html",
+            public_url=(
+                f"{self.public_base_url}/{axis_request_id}/openinfo/{axis_request_id}.html"
+            ),
             public_repository=S3Location(
                 bucket=self.path_resolver.openinfo_publication_bucket,
                 prefix=f"{publication_type}/{axis_request_id}",

--- a/request-management-api/tests/services/test_publication_completed_consumer.py
+++ b/request-management-api/tests/services/test_publication_completed_consumer.py
@@ -7,7 +7,9 @@ from request_api.models.FOIOpenInformationRequests import FOIOpenInformationRequ
 from request_api.models.FOIProactiveDisclosureRequests import FOIProactiveDisclosureRequests
 from request_api.services.publication_events.consumer import (
     OpenInfoPublishCompletedConsumer,
+    OpenInfoUnpublishCompletedConsumer,
     ProactiveDisclosurePublishCompletedConsumer,
+    ProactiveDisclosureUnpublishCompletedConsumer,
 )
 
 proactive_module = import_module("request_api.models.FOIProactiveDisclosureRequests")
@@ -61,6 +63,25 @@ def proactive_completed_envelope(**overrides):
     return envelope
 
 
+def unpublish_completed_envelope(**overrides):
+    envelope = {
+        "event_id": "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d93",
+        "event_type": "publication.unpublish.completed",
+        "correlation_id": "openinfo-unpublish-345",
+        "payload": {
+            "tenant_id": "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d91",
+            "kind": "openinfo",
+            "publication_id": "EDU-2024-12345",
+            "request_event_id": "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90",
+            "status": "completed",
+            "objects_deleted": 4,
+            "sitemap_result": "removed",
+        },
+    }
+    envelope.update(overrides)
+    return envelope
+
+
 def test_handle_openinfo_publish_completed_updates_published_version():
     openinfo_model = FakeOpenInfoModel()
     consumer = OpenInfoPublishCompletedConsumer(openinfo_model=openinfo_model)
@@ -69,6 +90,51 @@ def test_handle_openinfo_publish_completed_updates_published_version():
 
     assert result.success is True
     assert openinfo_model.calls == [(345, "Publication completed")]
+
+
+def test_handle_openinfo_unpublish_completed_logs_without_model_side_effects(caplog):
+    consumer = OpenInfoUnpublishCompletedConsumer()
+
+    result = consumer.handle(unpublish_completed_envelope())
+
+    assert result.success is True
+    assert result.message == "Unpublish completion logged"
+    assert "Handling OpenInfo unpublish completed event" in caplog.text
+    assert "publication_id=EDU-2024-12345" in caplog.text
+    assert "objects_deleted=4" in caplog.text
+
+
+def test_handle_proactive_disclosure_unpublish_completed_logs_without_model_side_effects(caplog):
+    consumer = ProactiveDisclosureUnpublishCompletedConsumer()
+
+    result = consumer.handle(
+        unpublish_completed_envelope(
+            correlation_id="proactivedisclosure-unpublish-71",
+            payload={
+                "tenant_id": "tenant-1",
+                "kind": "proactivedisclosure",
+                "publication_id": "PD-2024-56789",
+                "request_event_id": "request-event-1",
+                "status": "completed",
+                "objects_deleted": 2,
+                "sitemap_result": "removed",
+            },
+        )
+    )
+
+    assert result.success is True
+    assert result.message == "Unpublish completion logged"
+    assert "Handling Proactive Disclosure unpublish completed event" in caplog.text
+    assert "publication_id=PD-2024-56789" in caplog.text
+
+
+def test_handle_openinfo_unpublish_completed_rejects_wrong_event_type():
+    consumer = OpenInfoUnpublishCompletedConsumer()
+
+    result = consumer.handle(unpublish_completed_envelope(event_type="publication.publish.completed"))
+
+    assert result.success is False
+    assert result.message == "Unsupported event type"
 
 
 def test_handle_openinfo_publish_completed_uses_payload_message():

--- a/request-management-api/tests/services/test_publication_completed_stream_consumer.py
+++ b/request-management-api/tests/services/test_publication_completed_stream_consumer.py
@@ -37,6 +37,7 @@ class FakeHandler:
 
 def test_from_env_configures_completed_streams(monkeypatch):
     monkeypatch.setenv("PUBLICATION_PUBLISH_COMPLETED_STREAM_NAME", "publication.publish.completed")
+    monkeypatch.setenv("PUBLICATION_UNPUBLISH_COMPLETED_STREAM_NAME", "publication.unpublish.completed")
     monkeypatch.setenv("PUBLICATION_COMPLETED_CONSUMER_GROUP", "request-management-api")
     monkeypatch.setenv("PUBLICATION_COMPLETED_CONSUMER_NAME", "request-management-api-1")
 
@@ -44,6 +45,7 @@ def test_from_env_configures_completed_streams(monkeypatch):
 
     assert consumer.stream_names == {
         "publication.publish.completed": "publication.publish.completed",
+        "publication.unpublish.completed": "publication.unpublish.completed",
     }
     assert consumer.group_name == "request-management-api"
     assert consumer.consumer_name == "request-management-api-1"
@@ -55,6 +57,7 @@ def test_ensure_groups_creates_configured_stream_groups():
         redis_client=redis_client,
         stream_names={
             PublicationEventType.PUBLISH_COMPLETED: "publication.publish.completed",
+            PublicationEventType.UNPUBLISH_COMPLETED: "publication.unpublish.completed",
         },
         group_name="request-management-api",
         consumer_name="worker-1",
@@ -64,6 +67,7 @@ def test_ensure_groups_creates_configured_stream_groups():
 
     assert redis_client.created_groups == [
         ("publication.publish.completed", "request-management-api", "0", True),
+        ("publication.unpublish.completed", "request-management-api", "0", True),
     ]
 
 
@@ -137,3 +141,46 @@ def test_read_once_does_not_ack_failed_handler_result():
     assert pd_handler.calls == [envelope]
     assert oi_handler.calls == []
     assert redis_client.acked == []
+
+
+def test_read_once_dispatches_unpublish_completion_by_payload_kind_and_acks_success(caplog):
+    envelope = {
+        "event_type": "publication.unpublish.completed",
+        "correlation_id": "corr-unpub-123",
+        "payload": {
+            "tenant_id": "tenant-1",
+            "kind": "openinfo",
+            "publication_id": "EDU-2024-12345",
+            "request_event_id": "request-event-1",
+            "status": "completed",
+            "objects_deleted": 4,
+            "sitemap_result": "removed",
+        },
+    }
+    redis_client = FakeRedisClient(
+        messages=[
+            [
+                (
+                    "publication.unpublish.completed",
+                    [("1700000000000-2", {"payload": json.dumps(envelope)})],
+                )
+            ]
+        ]
+    )
+    consumer = PublicationCompletedStreamConsumer(
+        redis_client=redis_client,
+        stream_names={
+            PublicationEventType.UNPUBLISH_COMPLETED: "publication.unpublish.completed"
+        },
+        group_name="request-management-api",
+        consumer_name="worker-1",
+    )
+
+    processed = consumer.read_once()
+
+    assert processed == 1
+    assert redis_client.acked == [
+        ("publication.unpublish.completed", "request-management-api", "1700000000000-2")
+    ]
+    assert "Handling OpenInfo unpublish completed event" in caplog.text
+    assert "publication_id=EDU-2024-12345" in caplog.text

--- a/request-management-api/tests/services/test_unpublish_event_service.py
+++ b/request-management-api/tests/services/test_unpublish_event_service.py
@@ -147,7 +147,10 @@ def test_unpublish_mapper_sets_kind_for_proactivedisclosure(monkeypatch):
 
 def test_unpublish_mapper_maps_openinfo_row(monkeypatch):
     monkeypatch.setenv("OPENINFO_PUBLICATION_BUCKET", "dev-openinfopub")
-    monkeypatch.setenv("PUBLICATION_PUBLIC_BASE_URL", "https://openinfo.gov.bc.ca")
+    monkeypatch.setenv(
+        "PUBLICATION_PUBLIC_BASE_URL",
+        "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages",
+    )
 
     mapper = UnpublishRequestedMapper()
     row = {
@@ -161,7 +164,10 @@ def test_unpublish_mapper_maps_openinfo_row(monkeypatch):
 
     assert payload.tenant_id == str(uuid.uuid5(uuid.NAMESPACE_DNS, "bcgov:edu"))
     assert payload.publication_id == "EDU-2024-12345"
-    assert payload.public_url == "https://openinfo.gov.bc.ca/public/EDU-2024-12345.html"
+    assert (
+        payload.public_url
+        == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/EDU-2024-12345/openinfo/EDU-2024-12345.html"
+    )
     assert payload.public_repository.bucket == "dev-openinfopub"
     assert payload.public_repository.prefix == "openinfo/EDU-2024-12345"
     assert payload.last_modified == "2026-04-27"
@@ -169,7 +175,10 @@ def test_unpublish_mapper_maps_openinfo_row(monkeypatch):
 
 def test_unpublish_mapper_maps_pd_row(monkeypatch):
     monkeypatch.setenv("OPENINFO_PUBLICATION_BUCKET", "dev-openinfopub")
-    monkeypatch.setenv("PUBLICATION_PUBLIC_BASE_URL", "https://openinfo.gov.bc.ca")
+    monkeypatch.setenv(
+        "PUBLICATION_PUBLIC_BASE_URL",
+        "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages",
+    )
 
     mapper = UnpublishRequestedMapper()
     row = {
@@ -183,6 +192,10 @@ def test_unpublish_mapper_maps_pd_row(monkeypatch):
 
     assert payload.tenant_id == str(uuid.uuid5(uuid.NAMESPACE_DNS, "bcgov:fin"))
     assert payload.publication_id == "PD-FIN-2026-001"
+    assert (
+        payload.public_url
+        == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/PD-FIN-2026-001/openinfo/PD-FIN-2026-001.html"
+    )
     assert payload.public_repository.prefix == "proactivedisclosure/PD-FIN-2026-001"
     assert payload.last_modified == "2026-04-20"
 
@@ -288,7 +301,10 @@ class FakeOpenInfoService:
 
 def test_queue_openinfo_unpublish_builds_correct_envelope(monkeypatch):
     monkeypatch.setenv("OPENINFO_PUBLICATION_BUCKET", "dev-openinfopub")
-    monkeypatch.setenv("PUBLICATION_PUBLIC_BASE_URL", "https://openinfo.gov.bc.ca")
+    monkeypatch.setenv(
+        "PUBLICATION_PUBLIC_BASE_URL",
+        "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages",
+    )
 
     from request_api.services.publication_events.unpublish_service import UnpublishEventService
 
@@ -321,7 +337,10 @@ def test_queue_openinfo_unpublish_builds_correct_envelope(monkeypatch):
     assert envelope["correlation_id"] == "openinfo-unpublish-42"
     assert envelope["payload"]["tenant_id"] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "bcgov:edu"))
     assert envelope["payload"]["publication_id"] == "EDU-2024-12345"
-    assert envelope["payload"]["public_url"] == "https://openinfo.gov.bc.ca/public/EDU-2024-12345.html"
+    assert (
+        envelope["payload"]["public_url"]
+        == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/EDU-2024-12345/openinfo/EDU-2024-12345.html"
+    )
     assert envelope["payload"]["public_repository"]["bucket"] == "dev-openinfopub"
     assert envelope["payload"]["public_repository"]["prefix"] == "openinfo/EDU-2024-12345"
     assert envelope["payload"]["last_modified"] == "2026-04-27"
@@ -332,7 +351,10 @@ def test_queue_openinfo_unpublish_builds_correct_envelope(monkeypatch):
 
 def test_queue_pd_unpublish_builds_correct_envelope(monkeypatch):
     monkeypatch.setenv("OPENINFO_PUBLICATION_BUCKET", "dev-openinfopub")
-    monkeypatch.setenv("PUBLICATION_PUBLIC_BASE_URL", "https://openinfo.gov.bc.ca")
+    monkeypatch.setenv(
+        "PUBLICATION_PUBLIC_BASE_URL",
+        "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages",
+    )
 
     from request_api.services.publication_events.unpublish_service import UnpublishEventService
 
@@ -363,6 +385,10 @@ def test_queue_pd_unpublish_builds_correct_envelope(monkeypatch):
     assert envelope["payload"]["kind"] == "proactivedisclosure"
     assert envelope["correlation_id"] == "proactivedisclosure-unpublish-99"
     assert envelope["payload"]["publication_id"] == "PD-FIN-2026-001"
+    assert (
+        envelope["payload"]["public_url"]
+        == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/PD-FIN-2026-001/openinfo/PD-FIN-2026-001.html"
+    )
     assert envelope["payload"]["public_repository"]["prefix"] == "proactivedisclosure/PD-FIN-2026-001"
 
 


### PR DESCRIPTION
Implemented a log-only consumer path for `publication.unpublish.completed`.

  This now:
  - subscribes to `publication.unpublish.completed`
  - routes by event type and `payload.kind`
  - logs OpenInfo/PD unpublish completion details
  - ACKs after successful logging
  - intentionally avoids DB state changes for now

  Follow-up:
  - `# FIXME: status needs to be updated` once we decide the correct DB/versioning behavior for unpublish completion.
