### PR TITLE
feat: allow metadata fields in publish requested payload schema

### DIFF
--- a/publication-service/internal/events/schema/publication.publish.requested.v1.json
+++ b/publication-service/internal/events/schema/publication.publish.requested.v1.json
@@ -25,7 +25,12 @@
       "type": "array",
       "items": { "$ref": "#/$defs/additional_file" }
     },
-    "openinfo_id":                  { "type": "integer" }
+    "openinfo_id":                  { "type": "integer" },
+    "high_level_subject":           { "type": "string" },
+    "subject":                      { "type": "string" },
+    "year":                         { "type": "string" },
+    "month":                        { "type": "string" },
+    "title":                        { "type": "string" }
   },
   "$defs": {
     "additional_file": {


### PR DESCRIPTION
Add high_level_subject, subject, year, month, and title as optional string properties to the publication.publish.requested.v1 JSON schema. These fields are already supported by the Go structs in normalize.go and used in template_vars.go but were rejected by schema validation.