### PR TITLE
fix: support publishing requests without applicant category and propagate additionalfiles across all publication flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ testing/foi-qa-automation/Test Attachments/Book17.pdf
 testing/foi-qa-automation/Test Attachments/Book20.pdf
 
 .codex
+.worktrees/

--- a/request-management-api/request_api/models/FOIProactiveDisclosureRequests.py
+++ b/request-management-api/request_api/models/FOIProactiveDisclosureRequests.py
@@ -290,7 +290,7 @@ class FOIProactiveDisclosureRequests(db.Model):
                     ON mr.foirequest_id = r.foirequestid AND mr.foirequestversion_id = r.version
                 INNER JOIN public."ProgramAreas" pa
                     ON mr.programareaid = pa.programareaid
-                INNER JOIN public."ApplicantCategories" ac
+                LEFT JOIN public."ApplicantCategories" ac
                     ON r.applicantcategoryid = ac.applicantcategoryid
                 LEFT JOIN (
                     SELECT ministryrequestid, MAX(version) as max_version

--- a/request-management-api/request_api/services/publication_events/mappers.py
+++ b/request-management-api/request_api/services/publication_events/mappers.py
@@ -13,6 +13,20 @@ from request_api.services.publication_events.payloads import (
 )
 
 
+def _map_additional_files(row):
+    """Map additional file entries from a database row."""
+    items = row.get("additionalfiles") or []
+    return [
+        AdditionalFilePayload(
+            additionalfileid=item.get("additionalfileid"),
+            filename=item.get("filename"),
+            s3uripath=item.get("s3uripath"),
+            isactive=bool(item.get("isactive")),
+        )
+        for item in items
+    ]
+
+
 class PublicationPathResolver:
     """Resolves publication S3 locations."""
 
@@ -69,6 +83,7 @@ class OpenInfoPublishRequestedMapper:
             high_level_subject="FOI Request",
             month=datetime.now().strftime("%m"),
             year=datetime.now().strftime("%Y"),
+            additionalfiles=_map_additional_files(row),
         )
 
     @staticmethod
@@ -81,19 +96,6 @@ class ProactiveDisclosurePublishRequestedMapper:
 
     def __init__(self, path_resolver=None):
         self.path_resolver = path_resolver or PublicationPathResolver()
-
-    @staticmethod
-    def _map_additional_files(row):
-        items = row.get("additionalfiles") or []
-        return [
-            AdditionalFilePayload(
-                additionalfileid=item.get("additionalfileid"),
-                filename=item.get("filename"),
-                s3uripath=item.get("s3uripath"),
-                isactive=bool(item.get("isactive")),
-            )
-            for item in items
-        ]
 
     def map(self, row):
         category = row.get("proactivedisclosurecategory")
@@ -110,7 +112,7 @@ class ProactiveDisclosurePublishRequestedMapper:
             foiministryrequest_id=row.get("foiministryrequestid"),
             foirequest_id=row.get("foirequestid"),
             sitemap_pages=row.get("sitemap_pages"),
-            additionalfiles=self._map_additional_files(row),
+            additionalfiles=_map_additional_files(row),
             openinfo_id=row.get("openinfoid"),
             source=self.path_resolver.build_source(row),
             destination=self.path_resolver.build_destination(row),

--- a/request-management-api/request_api/services/publication_events/payloads.py
+++ b/request-management-api/request_api/services/publication_events/payloads.py
@@ -13,6 +13,16 @@ class S3Location:
 
 
 @dataclass
+class AdditionalFilePayload:
+    """Additional file metadata included in publication events."""
+
+    additionalfileid: int
+    filename: str
+    s3uripath: str
+    isactive: bool
+
+
+@dataclass
 class OpenInfoPublishRequestedPayload:
     """Payload for open information publish requested events."""
 
@@ -31,19 +41,10 @@ class OpenInfoPublishRequestedPayload:
     month: Optional[str] = None
     year: Optional[str] = None
     subject: Optional[str] = None
+    additionalfiles: list[AdditionalFilePayload] = field(default_factory=list)
 
     def to_dict(self):
         return asdict(self)
-
-
-@dataclass
-class AdditionalFilePayload:
-    """Additional file metadata included in publication events."""
-
-    additionalfileid: int
-    filename: str
-    s3uripath: str
-    isactive: bool
 
 
 @dataclass

--- a/request-management-api/request_api/services/publication_events/rest_service.py
+++ b/request-management-api/request_api/services/publication_events/rest_service.py
@@ -31,7 +31,8 @@ REST_PAYLOAD_FIELDS = {
     "high_level_subject",
     "subject",
     "month",
-    "year"
+    "year",
+    "additionalfiles",
 }
 
 


### PR DESCRIPTION
## Summary

This PR fixes two publication flow issues affecting OpenInfo and Proactive Disclosure requests.

### Changes Included

#### 1. Allow requests without Applicant Category to be published

Updated the publication query to use a `LEFT JOIN` for `ApplicantCategories` instead of an `INNER JOIN`.

Previously, requests missing an Applicant Category were silently excluded from the publishing query and never picked up by the scheduler/process.

This change ensures those requests are still included in the publishing flow.

#### 2. Propagate `additionalfiles` across all publication flows

Added support for propagating `additionalfiles` through:

* Event-driven publication flows
* REST-based publication flows

This applies to both:

* OpenInfo
* Proactive Disclosure

### Why

Some publication requests were being skipped due to incomplete metadata, while additional files attached to requests were not consistently propagated across all publication paths.

These fixes improve reliability and consistency of the publication pipeline.

### Testing

* Verified requests without Applicant Category are now returned by the publication query.
* Verified `additionalfiles` are propagated correctly through both REST and event-driven flows.
* Verified generated publication artifacts include sanitized additional file references when applicable.
