### PR TITLE
feat: sanitize publication file names by replacing spaces with underscores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ testing/foi-qa-automation/Test Attachments/Book17.pdf
 testing/foi-qa-automation/Test Attachments/Book20.pdf
 
 .codex
+.worktrees/

--- a/publication-service/internal/app/eventflow.go
+++ b/publication-service/internal/app/eventflow.go
@@ -68,7 +68,10 @@ func RunEventFlow(ctx context.Context, cfg *config.Config, logger *slog.Logger) 
 	}
 
 	// Unified publish consumer
-	pubService := pubpub.NewService(s3Client, s3Client, cfg.S3.PublicURL, logger, pubpub.WithFileCopier(s3Client), pubpub.WithDeleter(s3Client))
+	pubService, err := pubpub.NewService(s3Client, s3Client, cfg.S3.PublicURL, logger, pubpub.WithFileCopier(s3Client), pubpub.WithDeleter(s3Client))
+	if err != nil {
+		return fmt.Errorf("publish service: %w", err)
+	}
 	pubNormalizer := pubpub.NewCompletionAdapter(pubService, sitemapWriter)
 	pubValidator, err := pubpub.NewValidator(events.TypePublicationPublishRequested, cfg.SourceAllowlist)
 	if err != nil {

--- a/publication-service/internal/app/eventflow.go
+++ b/publication-service/internal/app/eventflow.go
@@ -68,7 +68,7 @@ func RunEventFlow(ctx context.Context, cfg *config.Config, logger *slog.Logger) 
 	}
 
 	// Unified publish consumer
-	pubService := pubpub.NewService(s3Client, s3Client, cfg.S3.PublicURL, logger, pubpub.WithFileCopier(s3Client))
+	pubService := pubpub.NewService(s3Client, s3Client, cfg.S3.PublicURL, logger, pubpub.WithFileCopier(s3Client), pubpub.WithDeleter(s3Client))
 	pubNormalizer := pubpub.NewCompletionAdapter(pubService, sitemapWriter)
 	pubValidator, err := pubpub.NewValidator(events.TypePublicationPublishRequested, cfg.SourceAllowlist)
 	if err != nil {

--- a/publication-service/internal/app/http.go
+++ b/publication-service/internal/app/http.go
@@ -40,7 +40,11 @@ func NewHTTPOptions(ctx context.Context, cfg *config.Config, logger *slog.Logger
 		return httpserver.Options{}, nil, fmt.Errorf("s3 client: %w", err)
 	}
 
-	pubService := pubpub.NewService(s3Client, s3Client, cfg.S3.PublicURL, logger, pubpub.WithFileCopier(s3Client), pubpub.WithDeleter(s3Client))
+	pubService, err := pubpub.NewService(s3Client, s3Client, cfg.S3.PublicURL, logger, pubpub.WithFileCopier(s3Client), pubpub.WithDeleter(s3Client))
+	if err != nil {
+		cleanup()
+		return httpserver.Options{}, nil, fmt.Errorf("publish service: %w", err)
+	}
 	sitemapRepo := sitemapping.NewRequestRepo(pool)
 	workflowRepo := pub.NewRepo(pool)
 	sitemapWriter := sitemapping.NewWriter(s3Client, sitemapRepo, SitemapTargets(cfg))

--- a/publication-service/internal/app/http.go
+++ b/publication-service/internal/app/http.go
@@ -40,7 +40,7 @@ func NewHTTPOptions(ctx context.Context, cfg *config.Config, logger *slog.Logger
 		return httpserver.Options{}, nil, fmt.Errorf("s3 client: %w", err)
 	}
 
-	pubService := pubpub.NewService(s3Client, s3Client, cfg.S3.PublicURL, logger, pubpub.WithFileCopier(s3Client))
+	pubService := pubpub.NewService(s3Client, s3Client, cfg.S3.PublicURL, logger, pubpub.WithFileCopier(s3Client), pubpub.WithDeleter(s3Client))
 	sitemapRepo := sitemapping.NewRequestRepo(pool)
 	workflowRepo := pub.NewRepo(pool)
 	sitemapWriter := sitemapping.NewWriter(s3Client, sitemapRepo, SitemapTargets(cfg))

--- a/publication-service/internal/events/schema/publication.publish.requested.v1.json
+++ b/publication-service/internal/events/schema/publication.publish.requested.v1.json
@@ -25,7 +25,7 @@
       "type": "array",
       "items": { "$ref": "#/$defs/additional_file" }
     },
-    "openinfo_id":                  { "type": "integer" },
+    "openinfo_id":                  { "type": ["integer", "null"] },
     "high_level_subject":           { "type": "string" },
     "subject":                      { "type": "string" },
     "year":                         { "type": "string" },

--- a/publication-service/internal/messaging/e2e_integration_test.go
+++ b/publication-service/internal/messaging/e2e_integration_test.go
@@ -158,7 +158,10 @@ func TestEndToEnd_PublishedRequestProducesCompleted(t *testing.T) {
 		t.Fatalf("s3 client: %v", err)
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	svc := pubpub.NewService(s3Client, s3Client, "", logger, pubpub.WithFileCopier(s3Client))
+	svc, err := pubpub.NewService(s3Client, s3Client, "", logger, pubpub.WithFileCopier(s3Client), pubpub.WithDeleter(s3Client))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 	sitemapWriter := sitemapping.NewWriter(s3Client, sitemapping.NewRequestRepo(pool), map[pub.Kind]sitemapping.Target{
 		pub.KindOpenInfoSitemap: {
 			Bucket:          "published",

--- a/publication-service/internal/messaging/pd_e2e_integration_test.go
+++ b/publication-service/internal/messaging/pd_e2e_integration_test.go
@@ -158,7 +158,10 @@ func TestEndToEnd_PD_PublishedRequestProducesCompleted(t *testing.T) {
 		t.Fatalf("s3 client: %v", err)
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	svc := pubpub.NewService(s3Client, s3Client, "", logger, pubpub.WithFileCopier(s3Client))
+	svc, err := pubpub.NewService(s3Client, s3Client, "", logger, pubpub.WithFileCopier(s3Client), pubpub.WithDeleter(s3Client))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 	sitemapWriter := sitemapping.NewWriter(s3Client, sitemapping.NewRequestRepo(pool), map[pub.Kind]sitemapping.Target{
 		pub.KindProactiveDisclosureSitemap: {
 			Bucket:          "pd-published",

--- a/publication-service/internal/publication/publish/sanitize.go
+++ b/publication-service/internal/publication/publish/sanitize.go
@@ -1,0 +1,24 @@
+package publish
+
+import "strings"
+
+// sanitizeFileName replaces spaces with underscores in the file-name
+// portion (last path segment) of an S3 key. Directory segments are
+// left unchanged.
+func sanitizeFileName(key string) string {
+	if key == "" {
+		return key
+	}
+	slashIdx := strings.LastIndex(key, "/")
+	if slashIdx == len(key)-1 {
+		// Key ends with "/" — it's a directory marker, return as-is.
+		return key
+	}
+	dir := ""
+	name := key
+	if slashIdx >= 0 {
+		dir = key[:slashIdx+1]
+		name = key[slashIdx+1:]
+	}
+	return dir + strings.ReplaceAll(name, " ", "_")
+}

--- a/publication-service/internal/publication/publish/sanitize_test.go
+++ b/publication-service/internal/publication/publish/sanitize_test.go
@@ -1,0 +1,30 @@
+package publish
+
+import "testing"
+
+func TestSanitizeFileName(t *testing.T) {
+	cases := []struct {
+		name string
+		key  string
+		want string
+	}{
+		{name: "no spaces", key: "file.pdf", want: "file.pdf"},
+		{name: "space in filename", key: "ABC-summary 1.pdf", want: "ABC-summary_1.pdf"},
+		{name: "space in filename with path", key: "path/to/ABC-summary 1.pdf", want: "path/to/ABC-summary_1.pdf"},
+		{name: "multiple spaces", key: "a  b  c.pdf", want: "a__b__c.pdf"},
+		{name: "leading space", key: " leading.pdf", want: "_leading.pdf"},
+		{name: "trailing space before ext", key: "trailing .pdf", want: "trailing_.pdf"},
+		{name: "dir with space untouched", key: "dir with space/file.pdf", want: "dir with space/file.pdf"},
+		{name: "empty string", key: "", want: ""},
+		{name: "no filename just slash", key: "path/", want: "path/"},
+		{name: "path with space in dir and file", key: "dir name/my file.pdf", want: "dir name/my_file.pdf"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeFileName(tc.key)
+			if got != tc.want {
+				t.Errorf("sanitizeFileName(%q) = %q, want %q", tc.key, got, tc.want)
+			}
+		})
+	}
+}

--- a/publication-service/internal/publication/publish/service.go
+++ b/publication-service/internal/publication/publish/service.go
@@ -39,12 +39,15 @@ type Service struct {
 }
 
 // NewService constructs a handler backed by the given Copier, Uploader, and public S3 base URL.
-func NewService(c pub.Copier, u pub.Uploader, publicURL string, log *slog.Logger, opts ...Option) *Service {
+func NewService(c pub.Copier, u pub.Uploader, publicURL string, log *slog.Logger, opts ...Option) (*Service, error) {
 	svc := &Service{copier: c, uploader: u, publicURL: publicURL, log: log}
 	for _, opt := range opts {
 		opt(svc)
 	}
-	return svc
+	if (svc.fileCopier == nil) != (svc.deleter == nil) {
+		return nil, fmt.Errorf("publish: WithFileCopier and WithDeleter must both be provided or both omitted")
+	}
+	return svc, nil
 }
 
 // Handle copies source files, renders the HTML index, uploads it, and returns publication metadata.

--- a/publication-service/internal/publication/publish/service.go
+++ b/publication-service/internal/publication/publish/service.go
@@ -21,11 +21,19 @@ func WithFileCopier(fc pub.FileCopier) Option {
 	}
 }
 
+// WithDeleter sets the Deleter used to remove original objects after renaming.
+func WithDeleter(d pub.Deleter) Option {
+	return func(s *Service) {
+		s.deleter = d
+	}
+}
+
 // Service handles publication.publish.requested events for all kinds.
 type Service struct {
 	copier     pub.Copier
 	uploader   pub.Uploader
 	fileCopier pub.FileCopier
+	deleter    pub.Deleter
 	publicURL  string
 	log        *slog.Logger
 }
@@ -46,6 +54,27 @@ func (s *Service) Handle(ctx context.Context, d *Domain) (pub.PublishResult, err
 		return pub.PublishResult{}, err
 	}
 
+	// Rename bulk-copied files that have spaces in their names.
+	if s.fileCopier != nil && s.deleter != nil {
+		for i := range res.Objects {
+			original := res.Objects[i].Key
+			sanitized := sanitizeFileName(original)
+			if sanitized == original {
+				continue
+			}
+			srcKey := d.Destination.Prefix + original
+			dstKey := d.Destination.Prefix + sanitized
+			_, copyErr := s.fileCopier.CopyFile(ctx, d.Destination.Bucket, srcKey, d.Destination.Bucket, dstKey)
+			if copyErr != nil {
+				return pub.PublishResult{}, fmt.Errorf("publish: rename %q to %q: %w", original, sanitized, copyErr)
+			}
+			if err := s.deleter.Delete(ctx, d.Destination.Bucket, srcKey); err != nil {
+				return pub.PublishResult{}, fmt.Errorf("publish: delete original %q after rename: %w", original, err)
+			}
+			res.Objects[i].Key = sanitized
+		}
+	}
+
 	// Copy additional files to destination.
 	if s.fileCopier != nil {
 		for _, af := range d.AdditionalFiles {
@@ -53,12 +82,13 @@ func (s *Service) Handle(ctx context.Context, d *Domain) (pub.PublishResult, err
 			if parseErr != nil {
 				return pub.PublishResult{}, parseErr
 			}
-			dstKey := d.Destination.Prefix + af.Filename
+			sanitizedName := sanitizeFileName(af.Filename)
+			dstKey := d.Destination.Prefix + sanitizedName
 			size, copyErr := s.fileCopier.CopyFile(ctx, srcBucket, srcKey, d.Destination.Bucket, dstKey)
 			if copyErr != nil {
 				return pub.PublishResult{}, fmt.Errorf("publish: copy additional file %q: %w", af.Filename, copyErr)
 			}
-			res.Objects = append(res.Objects, pub.CopiedObject{Key: af.Filename, Size: size})
+			res.Objects = append(res.Objects, pub.CopiedObject{Key: sanitizedName, Size: size})
 			res.ObjectsCopied++
 			res.BytesCopied += size
 		}

--- a/publication-service/internal/publication/publish/service_test.go
+++ b/publication-service/internal/publication/publish/service_test.go
@@ -98,6 +98,20 @@ func (f *fakeFileCopier) CopyFile(_ context.Context, srcBucket, srcKey, dstBucke
 	return 2048, f.err
 }
 
+type fakeDeleter struct {
+	deleted []deleteCall
+	err     error
+}
+
+type deleteCall struct {
+	bucket, key string
+}
+
+func (f *fakeDeleter) Delete(_ context.Context, bucket, key string) error {
+	f.deleted = append(f.deleted, deleteCall{bucket, key})
+	return f.err
+}
+
 func TestService_Handle_CopiesAdditionalFiles(t *testing.T) {
 	copier := &fakeCopier{result: pub.CopyResult{
 		ObjectsCopied: 1, BytesCopied: 100,
@@ -157,5 +171,134 @@ func TestService_Handle_AdditionalFileError_FailsPublish(t *testing.T) {
 	_, err := svc.Handle(context.Background(), d)
 	if err == nil {
 		t.Fatal("expected error when additional file copy fails")
+	}
+}
+
+func TestService_Handle_SanitizesBulkCopiedFileNames(t *testing.T) {
+	copier := &fakeCopier{result: pub.CopyResult{
+		ObjectsCopied: 2, BytesCopied: 300,
+		Objects: []pub.CopiedObject{
+			{Key: "ABC-summary 1.pdf", Size: 200},
+			{Key: "clean.pdf", Size: 100},
+		},
+	}}
+	uploader := &fakeUploader{}
+	fileCopier := &fakeFileCopier{}
+	deleter := &fakeDeleter{}
+	svc := NewService(copier, uploader, "https://public.example", discardLogger(),
+		WithFileCopier(fileCopier), WithDeleter(deleter))
+
+	d := &Domain{
+		Kind:        pub.KindOpenInfo,
+		RequestID:   "HTH-002",
+		Source:      pub.S3Location{Bucket: "raw", Prefix: "in/"},
+		Destination: pub.S3Location{Bucket: "pub", Prefix: "out/"},
+	}
+	result, err := svc.Handle(context.Background(), d)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	// Verify the file with spaces was renamed.
+	if len(fileCopier.copies) != 1 {
+		t.Fatalf("expected 1 rename copy, got %d", len(fileCopier.copies))
+	}
+	cp := fileCopier.copies[0]
+	if cp.srcBucket != "pub" || cp.srcKey != "out/ABC-summary 1.pdf" {
+		t.Errorf("rename src = %s/%s", cp.srcBucket, cp.srcKey)
+	}
+	if cp.dstBucket != "pub" || cp.dstKey != "out/ABC-summary_1.pdf" {
+		t.Errorf("rename dst = %s/%s", cp.dstBucket, cp.dstKey)
+	}
+
+	// Verify original was deleted.
+	if len(deleter.deleted) != 1 {
+		t.Fatalf("expected 1 delete, got %d", len(deleter.deleted))
+	}
+	del := deleter.deleted[0]
+	if del.bucket != "pub" || del.key != "out/ABC-summary 1.pdf" {
+		t.Errorf("delete = %s/%s", del.bucket, del.key)
+	}
+
+	_ = result
+
+	// Check via uploaded HTML that contains the sanitized filename.
+	html := uploader.uploaded["pub/out/HTH-002.html"]
+	if html == nil {
+		t.Fatal("HTML not uploaded")
+	}
+	htmlStr := string(html)
+	if strings.Contains(htmlStr, "ABC-summary 1.pdf") {
+		t.Error("HTML still contains original filename with space")
+	}
+	if !strings.Contains(htmlStr, "ABC-summary_1.pdf") {
+		t.Error("HTML does not contain sanitized filename")
+	}
+}
+
+func TestService_Handle_SanitizesAdditionalFileNames(t *testing.T) {
+	copier := &fakeCopier{result: pub.CopyResult{
+		ObjectsCopied: 1, BytesCopied: 100,
+		Objects: []pub.CopiedObject{{Key: "doc.pdf", Size: 100}},
+	}}
+	uploader := &fakeUploader{}
+	fileCopier := &fakeFileCopier{}
+	svc := NewService(copier, uploader, "https://public.example", discardLogger(),
+		WithFileCopier(fileCopier))
+
+	d := &Domain{
+		Kind:        pub.KindOpenInfo,
+		RequestID:   "HTH-003",
+		Source:      pub.S3Location{Bucket: "raw", Prefix: "in/"},
+		Destination: pub.S3Location{Bucket: "pub", Prefix: "out/"},
+		AdditionalFiles: []AdditionalFile{
+			{ID: 1, Filename: "extra file.pdf", S3URI: "https://store.example/src-bucket/path/to/extra file.pdf"},
+		},
+	}
+	result, err := svc.Handle(context.Background(), d)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	// Verify the additional file was copied with sanitized name.
+	if len(fileCopier.copies) != 1 {
+		t.Fatalf("expected 1 file copy, got %d", len(fileCopier.copies))
+	}
+	cp := fileCopier.copies[0]
+	if cp.dstKey != "out/extra_file.pdf" {
+		t.Errorf("dstKey = %q, want %q", cp.dstKey, "out/extra_file.pdf")
+	}
+
+	_ = result
+}
+
+func TestService_Handle_NoSpaces_NoRename(t *testing.T) {
+	copier := &fakeCopier{result: pub.CopyResult{
+		ObjectsCopied: 1, BytesCopied: 100,
+		Objects: []pub.CopiedObject{{Key: "clean.pdf", Size: 100}},
+	}}
+	uploader := &fakeUploader{}
+	fileCopier := &fakeFileCopier{}
+	deleter := &fakeDeleter{}
+	svc := NewService(copier, uploader, "https://public.example", discardLogger(),
+		WithFileCopier(fileCopier), WithDeleter(deleter))
+
+	d := &Domain{
+		Kind:        pub.KindOpenInfo,
+		RequestID:   "HTH-004",
+		Source:      pub.S3Location{Bucket: "raw", Prefix: "in/"},
+		Destination: pub.S3Location{Bucket: "pub", Prefix: "out/"},
+	}
+	_, err := svc.Handle(context.Background(), d)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	// No rename copies or deletes should have occurred.
+	if len(fileCopier.copies) != 0 {
+		t.Errorf("expected 0 rename copies, got %d", len(fileCopier.copies))
+	}
+	if len(deleter.deleted) != 0 {
+		t.Errorf("expected 0 deletes, got %d", len(deleter.deleted))
 	}
 }

--- a/publication-service/internal/publication/publish/service_test.go
+++ b/publication-service/internal/publication/publish/service_test.go
@@ -43,7 +43,10 @@ func TestService_Handle_CopiesAndUploadsHTML(t *testing.T) {
 		Objects: []pub.CopiedObject{{Key: "doc.pdf", Size: 100}},
 	}}
 	uploader := &fakeUploader{}
-	svc := NewService(copier, uploader, "https://public.example", discardLogger())
+	svc, err := NewService(copier, uploader, "https://public.example", discardLogger())
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 
 	d := &Domain{
 		Kind:        pub.KindOpenInfo,
@@ -71,14 +74,17 @@ func TestService_Handle_CopiesAndUploadsHTML(t *testing.T) {
 
 func TestService_Handle_CopierError(t *testing.T) {
 	copier := &fakeCopier{err: context.DeadlineExceeded}
-	svc := NewService(copier, &fakeUploader{}, "https://x", discardLogger())
+	svc, err := NewService(copier, &fakeUploader{}, "https://x", discardLogger())
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 
 	d := &Domain{
 		Kind:        pub.KindOpenInfo,
 		Source:      pub.S3Location{Bucket: "a", Prefix: "b/"},
 		Destination: pub.S3Location{Bucket: "c", Prefix: "d/"},
 	}
-	_, err := svc.Handle(context.Background(), d)
+	_, err = svc.Handle(context.Background(), d)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -119,7 +125,11 @@ func TestService_Handle_CopiesAdditionalFiles(t *testing.T) {
 	}}
 	uploader := &fakeUploader{}
 	fileCopier := &fakeFileCopier{}
-	svc := NewService(copier, uploader, "https://public.example", discardLogger(), WithFileCopier(fileCopier))
+	deleter := &fakeDeleter{}
+	svc, err := NewService(copier, uploader, "https://public.example", discardLogger(), WithFileCopier(fileCopier), WithDeleter(deleter))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 
 	d := &Domain{
 		Kind:        pub.KindOpenInfo,
@@ -157,7 +167,11 @@ func TestService_Handle_AdditionalFileError_FailsPublish(t *testing.T) {
 	copier := &fakeCopier{result: pub.CopyResult{ObjectsCopied: 1, BytesCopied: 100,
 		Objects: []pub.CopiedObject{{Key: "doc.pdf", Size: 100}}}}
 	fileCopier := &fakeFileCopier{err: fmt.Errorf("not found")}
-	svc := NewService(copier, &fakeUploader{}, "https://x", discardLogger(), WithFileCopier(fileCopier))
+	deleter := &fakeDeleter{}
+	svc, err := NewService(copier, &fakeUploader{}, "https://x", discardLogger(), WithFileCopier(fileCopier), WithDeleter(deleter))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 
 	d := &Domain{
 		Kind:        pub.KindOpenInfo,
@@ -168,7 +182,7 @@ func TestService_Handle_AdditionalFileError_FailsPublish(t *testing.T) {
 			{ID: 67, Filename: "fail.pdf", S3URI: "https://store.example/bucket/key.pdf"},
 		},
 	}
-	_, err := svc.Handle(context.Background(), d)
+	_, err = svc.Handle(context.Background(), d)
 	if err == nil {
 		t.Fatal("expected error when additional file copy fails")
 	}
@@ -185,8 +199,11 @@ func TestService_Handle_SanitizesBulkCopiedFileNames(t *testing.T) {
 	uploader := &fakeUploader{}
 	fileCopier := &fakeFileCopier{}
 	deleter := &fakeDeleter{}
-	svc := NewService(copier, uploader, "https://public.example", discardLogger(),
+	svc, err := NewService(copier, uploader, "https://public.example", discardLogger(),
 		WithFileCopier(fileCopier), WithDeleter(deleter))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 
 	d := &Domain{
 		Kind:        pub.KindOpenInfo,
@@ -243,8 +260,12 @@ func TestService_Handle_SanitizesAdditionalFileNames(t *testing.T) {
 	}}
 	uploader := &fakeUploader{}
 	fileCopier := &fakeFileCopier{}
-	svc := NewService(copier, uploader, "https://public.example", discardLogger(),
-		WithFileCopier(fileCopier))
+	deleter := &fakeDeleter{}
+	svc, err := NewService(copier, uploader, "https://public.example", discardLogger(),
+		WithFileCopier(fileCopier), WithDeleter(deleter))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 
 	d := &Domain{
 		Kind:        pub.KindOpenInfo,
@@ -280,8 +301,11 @@ func TestService_Handle_NoSpaces_NoRename(t *testing.T) {
 	uploader := &fakeUploader{}
 	fileCopier := &fakeFileCopier{}
 	deleter := &fakeDeleter{}
-	svc := NewService(copier, uploader, "https://public.example", discardLogger(),
+	svc, err := NewService(copier, uploader, "https://public.example", discardLogger(),
 		WithFileCopier(fileCopier), WithDeleter(deleter))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 
 	d := &Domain{
 		Kind:        pub.KindOpenInfo,
@@ -289,7 +313,7 @@ func TestService_Handle_NoSpaces_NoRename(t *testing.T) {
 		Source:      pub.S3Location{Bucket: "raw", Prefix: "in/"},
 		Destination: pub.S3Location{Bucket: "pub", Prefix: "out/"},
 	}
-	_, err := svc.Handle(context.Background(), d)
+	_, err = svc.Handle(context.Background(), d)
 	if err != nil {
 		t.Fatalf("Handle: %v", err)
 	}
@@ -300,5 +324,48 @@ func TestService_Handle_NoSpaces_NoRename(t *testing.T) {
 	}
 	if len(deleter.deleted) != 0 {
 		t.Errorf("expected 0 deletes, got %d", len(deleter.deleted))
+	}
+}
+
+func TestNewService_ErrorWhenFileCopierWithoutDeleter(t *testing.T) {
+	copier := &fakeCopier{}
+	uploader := &fakeUploader{}
+	_, err := NewService(copier, uploader, "https://x", discardLogger(), WithFileCopier(&fakeFileCopier{}))
+	if err == nil {
+		t.Fatal("expected error when fileCopier set without deleter")
+	}
+}
+
+func TestNewService_ErrorWhenDeleterWithoutFileCopier(t *testing.T) {
+	copier := &fakeCopier{}
+	uploader := &fakeUploader{}
+	_, err := NewService(copier, uploader, "https://x", discardLogger(), WithDeleter(&fakeDeleter{}))
+	if err == nil {
+		t.Fatal("expected error when deleter set without fileCopier")
+	}
+}
+
+func TestNewService_OKWhenBothNil(t *testing.T) {
+	copier := &fakeCopier{}
+	uploader := &fakeUploader{}
+	svc, err := NewService(copier, uploader, "https://x", discardLogger())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("service is nil")
+	}
+}
+
+func TestNewService_OKWhenBothSet(t *testing.T) {
+	copier := &fakeCopier{}
+	uploader := &fakeUploader{}
+	svc, err := NewService(copier, uploader, "https://x", discardLogger(),
+		WithFileCopier(&fakeFileCopier{}), WithDeleter(&fakeDeleter{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("service is nil")
 	}
 }

--- a/publication-service/internal/publish/interfaces.go
+++ b/publication-service/internal/publish/interfaces.go
@@ -16,3 +16,8 @@ type Uploader interface {
 type FileCopier interface {
 	CopyFile(ctx context.Context, srcBucket, srcKey, dstBucket, dstKey string) (int64, error)
 }
+
+// Deleter removes a single object from an S3 bucket.
+type Deleter interface {
+	Delete(ctx context.Context, bucket, key string) error
+}

--- a/publication-service/internal/publishnow/publications_e2e_integration_test.go
+++ b/publication-service/internal/publishnow/publications_e2e_integration_test.go
@@ -98,7 +98,7 @@ func (s *memoryResultStore) MarkSucceeded(_ context.Context, _ string, result si
 func TestPublish_OpenInfoEndToEndWithoutRedis(t *testing.T) {
 	store := newMemoryObjectStore()
 	store.put("foi-raw", "incoming/a/Response_Letter_HTH-2025-52023.pdf", []byte("letter"))
-	orchestrator := newTestOrchestrator(store)
+	orchestrator := newTestOrchestrator(t, store)
 
 	resp, err := orchestrator.Publish(context.Background(), wrapperJSON(PublicationTypeOpenInfo, openInfoPayload()))
 	if err != nil {
@@ -125,7 +125,7 @@ func TestPublish_OpenInfoEndToEndWithoutRedis(t *testing.T) {
 func TestPublish_ProactiveDisclosureEndToEndWithoutRedis(t *testing.T) {
 	store := newMemoryObjectStore()
 	store.put("foi-raw", "incoming/a/notes.pdf", []byte("notes"))
-	orchestrator := newTestOrchestrator(store)
+	orchestrator := newTestOrchestrator(t, store)
 
 	resp, err := orchestrator.Publish(context.Background(), wrapperJSON(PublicationTypeProactiveDisclosure, pdPayload()))
 	if err != nil {
@@ -149,7 +149,7 @@ func TestPublish_ProactiveDisclosureEndToEndWithoutRedis(t *testing.T) {
 	}
 }
 
-func newTestOrchestrator(store *memoryObjectStore) *Orchestrator {
+func newTestOrchestrator(t *testing.T, store *memoryObjectStore) *Orchestrator {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	targets := map[pub.Kind]sitemapping.Target{
 		pub.KindOpenInfoSitemap: {
@@ -170,7 +170,10 @@ func newTestOrchestrator(store *memoryObjectStore) *Orchestrator {
 		},
 	}
 	writer := sitemapping.NewWriter(store, newMemoryResultStore(), targets)
-	svc := pubpub.NewService(store, store, "https://objects.example", logger, pubpub.WithFileCopier(store))
+	svc, err := pubpub.NewService(store, store, "https://objects.example", logger, pubpub.WithFileCopier(store), pubpub.WithDeleter(store))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
 	orchestrator := New(svc, writer)
 	orchestrator.now = func() time.Time { return time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC) }
 	return orchestrator


### PR DESCRIPTION
## Summary

This PR adds filename sanitization to the publication flow to ensure generated public artifacts do not contain spaces in object names.

### Changes Included

* Added `sanitizeFileName` handling in `Handle`
* Replaces spaces with underscores in file names
* Sanitizes:

  * Bulk-copied publication files
  * Additional files before copy/upload

### Behavior

For bulk-copied files:

* Files with spaces are renamed using a copy-and-delete operation
* The original object is removed after the sanitized version is created

Example:

```text
ABC-summary 1.pdf
↓
ABC-summary_1.pdf
```

### Why

Some downstream systems and public URLs behave inconsistently with spaces in object names. Standardizing filenames improves:

* Public URL consistency
* HTML link generation
* Compatibility with crawlers and external consumers
* Predictability of published artifacts

### Testing

* Verified files with spaces are renamed correctly
* Verified original objects are deleted after sanitization
* Verified generated HTML references sanitized filenames only
* Verified files without spaces remain unchanged
