### PR TITLE
feat: propagate correlation ID through publish-now REST flow

### DIFF
--- a/request-management-api/request_api/resources/fee.py
+++ b/request-management-api/request_api/resources/fee.py
@@ -14,7 +14,6 @@
 """API endpoints for managing a Feee resource."""
 
 from datetime import datetime
-from re import template
 
 from flask import request, send_file, Response
 from flask_cors import cross_origin

--- a/request-management-api/request_api/services/foirequest/requestservicebuilder.py
+++ b/request-management-api/request_api/services/foirequest/requestservicebuilder.py
@@ -1,5 +1,4 @@
 
-from re import T
 from request_api.models.FOIMinistryRequests import FOIMinistryRequest
 from request_api.models.FOIMinistryRequestDivisions import FOIMinistryRequestDivision
 from request_api.models.RequestorType import RequestorType

--- a/request-management-api/request_api/services/foirequest/requestserviceconfigurator.py
+++ b/request-management-api/request_api/services/foirequest/requestserviceconfigurator.py
@@ -1,5 +1,4 @@
 
-from re import T
 from request_api.models.ProgramAreas import ProgramArea
 from request_api.models.ContactTypes import ContactType
 from request_api.models.DeliveryModes import DeliveryMode

--- a/request-management-api/request_api/services/foirequest/requestservicecreate.py
+++ b/request-management-api/request_api/services/foirequest/requestservicecreate.py
@@ -1,5 +1,4 @@
 
-from re import T
 from request_api.models.FOIRequests import FOIRequest
 from request_api.models.ContactTypes import ContactType
 from request_api.models.PersonalInformationAttributes import PersonalInformationAttribute

--- a/request-management-api/request_api/services/foirequest/requestservicegetter.py
+++ b/request-management-api/request_api/services/foirequest/requestservicegetter.py
@@ -1,5 +1,4 @@
 
-from re import T
 from request_api.models.FOIRequests import FOIRequest
 from request_api.models.FOIMinistryRequests import FOIMinistryRequest
 from request_api.models.FOIMinistryRequestDivisions import FOIMinistryRequestDivision

--- a/request-management-api/request_api/services/foirequest/requestserviceministrybuilder.py
+++ b/request-management-api/request_api/services/foirequest/requestserviceministrybuilder.py
@@ -1,5 +1,4 @@
 
-from re import T
 from request_api.models.FOIRequests import FOIRequest
 from request_api.models.FOIMinistryRequests import FOIMinistryRequest
 from request_api.models.FOIRequestContactInformation import FOIRequestContactInformation

--- a/request-management-api/request_api/services/foirequest/requestserviceupdate.py
+++ b/request-management-api/request_api/services/foirequest/requestserviceupdate.py
@@ -1,5 +1,4 @@
 
-from re import T
 from request_api.models.FOIRequests import FOIRequest
 from request_api.models.FOIMinistryRequests import FOIMinistryRequest
 from request_api.models.FOIRequestStatus import FOIRequestStatus

--- a/request-management-api/request_api/services/publication_events/rest_client.py
+++ b/request-management-api/request_api/services/publication_events/rest_client.py
@@ -1,6 +1,7 @@
 """REST client for the publication service."""
 
 import os
+import uuid
 
 import requests
 from requests.exceptions import HTTPError
@@ -18,9 +19,12 @@ class PublicationRestClient:
         self.timeout = timeout or int(os.getenv("PUBLICATION_API_TIMEOUT", "30"))
         self.http_client = http_client or requests
 
-    def publish(self, publication_type, payload):
+    def publish(self, publication_type, payload, correlation_id=None):
         if not self.base_url:
             raise ValueError("PUBLICATION_API_BASE_URL is not configured")
+
+        if correlation_id is None:
+            correlation_id = str(uuid.uuid4())
 
         response = self.http_client.post(
             f"{self.base_url}/publications",
@@ -28,7 +32,10 @@ class PublicationRestClient:
                 "publication_type": publication_type,
                 "payload": payload,
             },
-            headers={"Content-Type": "application/json"},
+            headers={
+                "Content-Type": "application/json",
+                "X-Correlation-ID": correlation_id,
+            },
             timeout=self.timeout,
         )
         try:

--- a/request-management-api/request_api/services/publication_events/rest_service.py
+++ b/request-management-api/request_api/services/publication_events/rest_service.py
@@ -12,7 +12,6 @@ from request_api.services.publication_events.mappers import (
     ProactiveDisclosurePublishRequestedMapper,
 )
 from request_api.services.publication_events.rest_client import PublicationRestClient
-from request_api.resources.foirequest import FOIRequestUpdateBySection
 from request_api.utils.enums import OIStatusEnum
 
 
@@ -84,23 +83,26 @@ class PublishNowRestService:
     def _rest_payload(payload):
         return {key: value for key, value in payload.items() if key in REST_PAYLOAD_FIELDS}
 
-    def _publish_and_update(self, publication_type, row, payload, update_status):
+    def _publish_and_update(self, publication_type, row, payload, update_status, correlation_id):
         try:
             logging.info(
-                "Publication REST request payload publication_type=%s payload=%s",
+                "Publication REST request payload publication_type=%s correlation_id=%s payload=%s",
                 publication_type,
+                correlation_id,
                 payload,
             )
-            response = self.publication_client.publish(publication_type, payload)
+            response = self.publication_client.publish(publication_type, payload, correlation_id=correlation_id)
             logging.info(
-                "Publication REST response publication_type=%s response=%s",
+                "Publication REST response publication_type=%s correlation_id=%s response=%s",
                 publication_type,
+                correlation_id,
                 response,
             )
             self._validate_completed(response)
             sitemap_page = self._sitemap_page_name(response)
             
             from request_api.services.publication_events.consumer import handle_foiministryrequest_update
+            from request_api.resources.foirequest import FOIRequestUpdateBySection
             foiministry_update_result = handle_foiministryrequest_update(payload, OIStatusEnum.PUBLISHED.value, FOIRequestUpdateBySection())
             if foiministry_update_result.success is False:
                 return foiministry_update_result
@@ -116,8 +118,9 @@ class PublishNowRestService:
             )
         except Exception as exception:
             logging.exception(
-                "Publication REST integration failed publication_type=%s foiministryrequestid=%s axisrequestid=%s error=%s",
+                "Publication REST integration failed publication_type=%s correlation_id=%s foiministryrequestid=%s axisrequestid=%s error=%s",
                 publication_type,
+                correlation_id,
                 row.get("foiministryrequestid"),
                 row.get("axisrequestid"),
                 exception,
@@ -132,6 +135,7 @@ class PublishNowRestService:
 
         row = rows[0]
         payload = self.openinfo_mapper.map(row).to_dict()
+        correlation_id = self.openinfo_mapper.correlation_id(row)
         return self._publish_and_update(
             "openinfo",
             row,
@@ -140,6 +144,7 @@ class PublishNowRestService:
                 foiministryrequestid,
                 sitemap_page,
             ),
+            correlation_id,
         )
 
     def publish_proactive_disclosure_now(self, foiministryrequestid):
@@ -149,6 +154,7 @@ class PublishNowRestService:
             return DefaultMethodResult(True, "No data found to publish for this request")
 
         payload = self._rest_payload(self.proactive_disclosure_mapper.map(row).to_dict())
+        correlation_id = self.proactive_disclosure_mapper.correlation_id(row)
         return self._publish_and_update(
             "proactivedisclosure",
             row,
@@ -157,4 +163,5 @@ class PublishNowRestService:
                 foiministryrequestid,
                 sitemap_page,
             ),
+            correlation_id,
         )

--- a/request-management-api/request_api/services/requestservice.py
+++ b/request-management-api/request_api/services/requestservice.py
@@ -1,4 +1,3 @@
-from re import T
 
 from request_api.services.documentservice import documentservice
 from request_api.services.workflowservice import workflowservice

--- a/request-management-api/tests/services/test_publishnow_rest_service.py
+++ b/request-management-api/tests/services/test_publishnow_rest_service.py
@@ -28,13 +28,13 @@ class FakePublicationClient:
         self.response = response
         self.calls = []
 
-    def publish(self, publication_type, payload):
-        self.calls.append((publication_type, payload))
+    def publish(self, publication_type, payload, correlation_id=None):
+        self.calls.append((publication_type, payload, correlation_id))
         return self.response
 
 
 class FailingPublicationClient:
-    def publish(self, publication_type, payload):
+    def publish(self, publication_type, payload, correlation_id=None):
         raise RuntimeError("publication service unavailable")
 
 
@@ -269,8 +269,15 @@ def test_publish_failure_log_includes_context_in_message(caplog):
                 "foiministryrequestid": 22318,
                 "axisrequestid": "PD-FIN-2026-047533",
                 "bcgovcode": "fin",
+                "contributor": "Ministry of Finance",
                 "proactivedisclosurecategory": "Calendars",
                 "reportperiod": "Quarter 1 2026-27",
+                "published_date": "2026-04-20",
+                "fees": 0,
+                "applicant_type": None,
+                "sitemap_pages": "",
+                "additionalfiles": [],
+                "openinfoid": 0,
             }
         ),
         publication_client=FailingPublicationClient(),
@@ -284,6 +291,43 @@ def test_publish_failure_log_includes_context_in_message(caplog):
     assert "publication_type=proactivedisclosure" in caplog.text
     assert "foiministryrequestid=22318" in caplog.text
     assert "axisrequestid=PD-FIN-2026-047533" in caplog.text
+    assert "correlation_id=proactivedisclosure-publish-71" in caplog.text
+
+
+def test_publication_rest_client_generates_uuid_when_no_correlation_id():
+    http_client = FakeHttpClient(
+        FakeHttpResponse(status_code=200, payload={"status": "completed"})
+    )
+    client = PublicationRestClient(
+        base_url="http://localhost:9085",
+        timeout=5,
+        http_client=http_client,
+    )
+
+    client.publish("openinfo", {"axis_request_id": "FIN-2026-001"})
+
+    headers = http_client.calls[0]["headers"]
+    correlation_id = headers["X-Correlation-ID"]
+    parsed = uuid.UUID(correlation_id)
+    assert str(parsed) == correlation_id
+
+
+def test_publication_rest_client_sends_correlation_id_header():
+    http_client = FakeHttpClient(
+        FakeHttpResponse(status_code=200, payload={"status": "completed"})
+    )
+    client = PublicationRestClient(
+        base_url="http://localhost:9085",
+        timeout=5,
+        http_client=http_client,
+    )
+
+    client.publish("openinfo", {"axis_request_id": "FIN-2026-001"}, correlation_id="openinfo-publish-345")
+
+    assert len(http_client.calls) == 1
+    headers = http_client.calls[0]["headers"]
+    assert headers["X-Correlation-ID"] == "openinfo-publish-345"
+    assert headers["Content-Type"] == "application/json"
 
 
 def test_publication_rest_client_includes_upstream_error_body():
@@ -350,3 +394,78 @@ def test_proactive_ready_for_crawling_fails_when_ministry_status_not_updated(mon
     assert "FOIMinistryRequests" in result.message
     assert session.committed is False
     assert session.rolled_back is True
+
+
+def test_publish_openinfo_passes_correlation_id_to_client(monkeypatch):
+    monkeypatch.setenv("OPENINFO_PUBLICATION_BUCKET", "dev-openinfopub")
+    monkeypatch.setenv("OPENINFO_SOURCE_BUCKET_SUFFIX", "dev-e")
+    monkeypatch.setenv("FLASK_ENV", "production")
+    client = FakePublicationClient(
+        {
+            "status": "completed",
+            "publication_id": "FIN-2026-047533",
+            "sitemap_page_key": "openinfopub/sitemap/sitemap_pages_1.xml",
+        }
+    )
+    service = PublishNowRestService(
+        openinfo_service=FakeOpenInfoService(
+            openinfo_rows=[
+                {
+                    "openinfoid": 345,
+                    "axisrequestid": "FIN-2026-047533",
+                    "description": "Budget briefing records",
+                    "published_date": "2026-04-20",
+                    "contributor": "Ministry of Finance",
+                    "fees": 0,
+                    "applicant_type": "Media",
+                    "bcgovcode": "fin",
+                }
+            ]
+        ),
+        publication_client=client,
+        publication_status_updater=FakePublicationStatusUpdater(),
+    )
+
+    service.publish_openinfo_now(22318)
+
+    assert client.calls[0][2] == "openinfo-publish-345"
+
+
+def test_publish_proactive_disclosure_passes_correlation_id_to_client(monkeypatch):
+    monkeypatch.setenv("OPENINFO_PUBLICATION_BUCKET", "dev-openinfopub")
+    monkeypatch.setenv("OPENINFO_SOURCE_BUCKET_SUFFIX", "dev-e")
+    monkeypatch.setenv("FLASK_ENV", "production")
+    client = FakePublicationClient(
+        {
+            "status": "completed",
+            "publication_id": "PD-FIN-2026-047533",
+            "sitemap_page_key": "pdpublishing/sitemap/sitemap_pages_2.xml",
+        }
+    )
+    service = PublishNowRestService(
+        openinfo_service=FakeOpenInfoService(
+            proactive_row={
+                "proactivedisclosureid": 71,
+                "foiministryrequestid": 22318,
+                "foirequestid": 22318,
+                "axisrequestid": "PD-FIN-2026-047533",
+                "description": "Ministerial Directive",
+                "published_date": "2026-04-20",
+                "contributor": "Ministry of Finance",
+                "fees": 0,
+                "applicant_type": None,
+                "bcgovcode": "fin",
+                "sitemap_pages": "",
+                "proactivedisclosurecategory": "Calendars",
+                "reportperiod": "Quarter 1 2026-27",
+                "additionalfiles": [],
+                "openinfoid": 0,
+            }
+        ),
+        publication_client=client,
+        publication_status_updater=FakePublicationStatusUpdater(),
+    )
+
+    service.publish_proactive_disclosure_now(22318)
+
+    assert client.calls[0][2] == "proactivedisclosure-publish-71"


### PR DESCRIPTION
Pass mapper-generated correlation IDs through PublishNowRestService to PublicationRestClient via X-Correlation-ID header. Add correlation ID logging for request, response, and error flows, and update tests and fake clients to support correlation_id propagation.