### PR TITLE
feat(publication): add configurable publishing time window for scheduler

### DIFF
--- a/request-management-api/request_api/services/publication_events/scheduler.py
+++ b/request-management-api/request_api/services/publication_events/scheduler.py
@@ -12,7 +12,7 @@ class PublicationPrePublishingScheduler:
     """Runs the OpenInfo and PD publishing job on a fixed interval."""
 
     def __init__(self, job=None, interval_seconds=300, app=None, stop_event=None,
-                 window_start=time(13, 0), window_end=time(13, 30)):
+                 window_start=time(13, 0), window_end=time(15, 00)):
         self.job = job or ScheduledPublicationService().publish_all_due_records
         self.interval_seconds = interval_seconds
         self.app = app

--- a/request-management-api/request_api/services/publication_events/scheduler.py
+++ b/request-management-api/request_api/services/publication_events/scheduler.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import threading
+from datetime import datetime, time
 
 from request_api.services.publication_events.scheduled_service import ScheduledPublicationService
 
@@ -10,20 +11,33 @@ from request_api.services.publication_events.scheduled_service import ScheduledP
 class PublicationPrePublishingScheduler:
     """Runs the OpenInfo and PD publishing job on a fixed interval."""
 
-    def __init__(self, job=None, interval_seconds=300, app=None, stop_event=None):
+    def __init__(self, job=None, interval_seconds=300, app=None, stop_event=None,
+                 window_start=time(13, 0), window_end=time(13, 30)):
         self.job = job or ScheduledPublicationService().publish_all_due_records
         self.interval_seconds = interval_seconds
         self.app = app
         self._stop_event = stop_event or threading.Event()
         self.thread = None
+        self.window_start = window_start
+        self.window_end = window_end
 
     @classmethod
     def from_env(cls, app=None, job=None):
+        raw_start = os.getenv("PUBLICATION_WINDOW_START", "13:00")
+        raw_end = os.getenv("PUBLICATION_WINDOW_END", "15:00")
+        window_start = time.fromisoformat(raw_start)
+        window_end = time.fromisoformat(raw_end)
         return cls(
             job=job,
             app=app,
             interval_seconds=int(os.getenv("PUBLICATION_PREPUBLISHING_INTERVAL_SECONDS", 300)),
+            window_start=window_start,
+            window_end=window_end,
         )
+
+    def _is_within_window(self):
+        now = datetime.now().time()
+        return self.window_start <= now <= self.window_end
 
     def start(self):
         self.thread = threading.Thread(
@@ -44,6 +58,13 @@ class PublicationPrePublishingScheduler:
             self.thread.join(timeout=1)
 
     def run_once(self):
+        if not self._is_within_window():
+            logging.debug(
+                "Outside publishing window (%s–%s), skipping",
+                self.window_start.strftime("%H:%M"),
+                self.window_end.strftime("%H:%M"),
+            )
+            return None
         if self.app is None:
             return self.job()
         with self.app.app_context():

--- a/request-management-api/tests/services/test_publication_scheduler.py
+++ b/request-management-api/tests/services/test_publication_scheduler.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import datetime, time
+from unittest.mock import patch
 import importlib
 
 import request_api.models.FOIOpenInformationRequests as openinfo_module
@@ -171,12 +172,63 @@ def test_scheduler_runs_job_then_waits_configured_interval():
         job=lambda: calls.append("ran"),
         interval_seconds=300,
         stop_event=stop_event,
+        window_start=time(0, 0),
+        window_end=time(23, 59),
     )
 
     scheduler.run_forever()
 
     assert calls == ["ran"]
     assert stop_event.waits == [300]
+
+
+def test_scheduler_skips_job_outside_window():
+    calls = []
+    stop_event = FakeStopEvent()
+    scheduler = PublicationPrePublishingScheduler(
+        job=lambda: calls.append("ran"),
+        interval_seconds=300,
+        stop_event=stop_event,
+        window_start=time(13, 0),
+        window_end=time(13, 30),
+    )
+
+    with patch(
+        "request_api.services.publication_events.scheduler.datetime"
+    ) as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 5, 8, 10, 0, 0)
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        result = scheduler.run_once()
+
+    assert calls == []
+    assert result is None
+
+
+def test_scheduler_runs_job_inside_window():
+    calls = []
+    scheduler = PublicationPrePublishingScheduler(
+        job=lambda: calls.append("ran"),
+        interval_seconds=300,
+        window_start=time(13, 0),
+        window_end=time(13, 30),
+    )
+
+    with patch(
+        "request_api.services.publication_events.scheduler.datetime"
+    ) as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 5, 8, 13, 15, 0)
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        scheduler.run_once()
+
+    assert calls == ["ran"]
+
+
+def test_from_env_reads_window_env_vars(monkeypatch):
+    monkeypatch.setenv("PUBLICATION_WINDOW_START", "14:00")
+    monkeypatch.setenv("PUBLICATION_WINDOW_END", "14:45")
+    scheduler = PublicationPrePublishingScheduler.from_env(job=lambda: None)
+    assert scheduler.window_start == time(14, 0)
+    assert scheduler.window_end == time(14, 45)
 
 
 def test_getpdrecordsforprepublishing_filters_publishable_rows(monkeypatch):


### PR DESCRIPTION
Add support for restricting the publication pre-publishing scheduler to a configurable execution window using PUBLICATION_WINDOW_START and PUBLICATION_WINDOW_END environment variables.

The scheduler now skips execution outside the configured time range and logs a debug message when the current time is outside the window.



The current approach, the scheduler runs based on the application start time plus the configured interval (`PUBLICATION_PREPUBLISHING_INTERVAL_SECONDS`). This keeps the implementation simple and lightweight, which works well for the current publication flow.

One thing to note is that executions are not aligned to exact wall-clock times. For example, if the app starts at `13:07` with `PUBLICATION_PREPUBLISHING_INTERVAL_SECONDS=1200` (20 minutes), executions will happen at `13:07`, `13:27`, `13:47`, etc., instead of exact boundaries like `13:00`, `13:20`, `13:40`.

If we later need stricter scheduling guarantees or exact business-time alignment, we can revisit this and move to a cron-like scheduling strategy or a dedicated scheduler solution.
