### PR TITLE
Ticket 5018/5019: Unpublish + Republish Publication Fixes

### DIFF
--- a/request-management-api/request_api/models/FOIOpenInformationRequests.py
+++ b/request-management-api/request_api/models/FOIOpenInformationRequests.py
@@ -209,7 +209,7 @@ class FOIOpenInformationRequests(db.Model):
             db.session.close()
 
     @classmethod
-    def create_published_version_from_openinfo_id(cls, foiopeninforequestid, message, sitemap=None)->DefaultMethodResult:
+    def create_published_version_from_openinfo_id(cls, foiopeninforequestid, message, sitemap)->DefaultMethodResult:
         try:
             current = (
                 db.session.query(cls)

--- a/request-management-api/request_api/models/FOIOpenInformationRequests.py
+++ b/request-management-api/request_api/models/FOIOpenInformationRequests.py
@@ -142,27 +142,60 @@ class FOIOpenInformationRequests(db.Model):
     @classmethod
     def mark_ready_for_crawling(cls, foiministryrequestid, sitemap_page)->DefaultMethodResult:
         try:
-            sql = """
-                UPDATE public."FOIOpenInformationRequests"
-                SET processingstatus = 'ready for crawling',
-                    processingmessage = 'Published',
-                    sitemap_pages = :sitemap_page,
-                    updated_at = now()
-                WHERE foiministryrequest_id = :foiministryrequestid
-                  AND isactive = TRUE
-            """
-            result = db.session.execute(
-                text(sql),
-                {
-                    'foiministryrequestid': foiministryrequestid,
-                    'sitemap_page': sitemap_page,
-                },
+            current = (
+                db.session.query(cls)
+                .filter(cls.foiministryrequest_id == foiministryrequestid)
+                .order_by(cls.version.desc())
+                .first()
             )
-            if result.rowcount == 0:
-                db.session.rollback()
-                return DefaultMethodResult(False, "No active OpenInfo row found to update", foiministryrequestid)
+            if current is None:
+                return DefaultMethodResult(False, "FOIOpenInfo request not found", foiministryrequestid)
+
+            updated_at = datetime2.now().isoformat()
+
+            active_rows = (
+                db.session.query(cls)
+                .filter(cls.foiministryrequest_id == foiministryrequestid)
+                .filter(or_(cls.isactive == True, cls.isactive.is_(None)))
+                .all()
+            )
+            for row in active_rows:
+                row.isactive = False
+                row.updated_at = updated_at
+                row.updatedby = "publishingservice"
+
+            latest = (
+                db.session.query(cls)
+                .filter(cls.foiministryrequest_id == foiministryrequestid)
+                .order_by(cls.version.desc())
+                .first()
+            )
+
+            new_foiopeninforequest = FOIOpenInformationRequests(
+                foiopeninforequestid=latest.foiopeninforequestid,
+                version=latest.version + 1,
+                foiministryrequest_id=latest.foiministryrequest_id,
+                foiministryrequestversion_id=latest.foiministryrequestversion_id,
+                oipublicationstatus_id=latest.oipublicationstatus_id,
+                oiexemption_id=latest.oiexemption_id,
+                oiassignedto=latest.oiassignedto,
+                oiexemptionapproved=latest.oiexemptionapproved,
+                pagereference=latest.pagereference,
+                iaorationale=latest.iaorationale,
+                oifeedback=latest.oifeedback,
+                publicationdate=latest.publicationdate,
+                receiveddate=latest.receiveddate,
+                copyrightsevered=latest.copyrightsevered,
+                created_at=updated_at,
+                createdby="publishingservice",
+                processingstatus="ready for crawling",
+                processingmessage="Published",
+                sitemap_pages=sitemap_page,
+                isactive=True,
+            )
+            db.session.add(new_foiopeninforequest)
             logging.info(
-                "OpenInfo publication row updated for ministry request %s with sitemap page %s",
+                "FOIOpenInfo row updated for ministry request %s with sitemap page %s",
                 foiministryrequestid,
                 sitemap_page,
             )

--- a/request-management-api/request_api/models/FOIOpenInformationRequests.py
+++ b/request-management-api/request_api/models/FOIOpenInformationRequests.py
@@ -145,12 +145,11 @@ class FOIOpenInformationRequests(db.Model):
             sql = """
                 UPDATE public."FOIOpenInformationRequests"
                 SET processingstatus = 'ready for crawling',
-                    processingmessage = 'sitemap ready',
+                    processingmessage = 'Published',
                     sitemap_pages = :sitemap_page,
                     updated_at = now()
                 WHERE foiministryrequest_id = :foiministryrequestid
                   AND isactive = TRUE
-                  AND processingstatus IS NULL;
             """
             result = db.session.execute(
                 text(sql),
@@ -177,7 +176,7 @@ class FOIOpenInformationRequests(db.Model):
             db.session.close()
 
     @classmethod
-    def create_published_version_from_openinfo_id(cls, foiopeninforequestid, message)->DefaultMethodResult:
+    def create_published_version_from_openinfo_id(cls, foiopeninforequestid, message, sitemap=None)->DefaultMethodResult:
         try:
             current = (
                 db.session.query(cls)
@@ -226,9 +225,9 @@ class FOIOpenInformationRequests(db.Model):
                 copyrightsevered=latest.copyrightsevered,
                 created_at=updated_at,
                 createdby="publishingservice",
-                processingstatus="published",
+                processingstatus="ready for crawling",
                 processingmessage=message,
-                sitemap_pages=latest.sitemap_pages,
+                sitemap_pages=sitemap,
                 isactive=True,
             )
             db.session.add(new_foiopeninforequest)
@@ -705,7 +704,7 @@ class FOIOpenInformationRequests(db.Model):
                 INNER JOIN public."OpenInfoPublicationStatuses" oirequesttype on oi.oipublicationstatus_id = oirequesttype.oipublicationstatusid
                 LEFT JOIN public."FOIOpenInfoAdditionalFiles" oifiles on mr.foiministryrequestid = oifiles.ministryrequestid
                 WHERE mr.foiministryrequestid = :foiministryrequestid 
-                  AND oi.processingstatus is NULL 
+                  AND (oi.processingmessage != 'Published' OR oi.processingmessage is NULL)
                   AND mr.isactive = TRUE
                 GROUP BY 
                     oi.foiopeninforequestid,
@@ -779,7 +778,7 @@ class FOIOpenInformationRequests(db.Model):
                 WHERE oistatus.name IN (:ready_status, :published_status)
                   AND oirequesttype.name = :publication_status
                   AND oi.publicationdate < :publication_cutoff
-                  AND oi.processingstatus is NULL
+                  AND (oi.processingmessage != 'Published' OR oi.processingmessage is NULL)
                   AND mr.isactive = TRUE
                 GROUP BY
                     oi.foiopeninforequestid,
@@ -829,7 +828,7 @@ class FOIOpenInformationRequests(db.Model):
                 INNER JOIN public."OpenInformationStatuses" oistatus on mr.oistatus_id = oistatus.oistatusid
                 INNER JOIN public."OpenInfoPublicationStatuses" oirequesttype on oi.oipublicationstatus_id = oirequesttype.oipublicationstatusid
                 WHERE mr.foiministryrequestid = :foiministryrequestid 
-                  AND oi.processingstatus is NULL
+                  AND oi.processingmessage = 'Published'
                   AND oi.isactive = TRUE;
             """
             
@@ -891,7 +890,7 @@ class FOIOpenInformationRequests(db.Model):
                 INNER JOIN public."OpenInfoPublicationStatuses" oirequesttype on pd.oipublicationstatus_id = oirequesttype.oipublicationstatusid
                 LEFT JOIN public."FOIOpenInfoAdditionalFiles" oifiles on mr.foiministryrequestid = oifiles.ministryrequestid
                 WHERE mr.foiministryrequestid = :foiministryrequestid 
-                  AND pd.processingstatus is NULL 
+                  AND (pd.processingmessage != 'Published' OR pd.processingmessage is NULL) 
                   AND mr.isactive = TRUE
                 GROUP BY 
                     pd.proactivedisclosureid,
@@ -938,7 +937,7 @@ class FOIOpenInformationRequests(db.Model):
                 INNER JOIN public."OpenInformationStatuses" oistatus on mr.oistatus_id = oistatus.oistatusid
                 INNER JOIN public."OpenInfoPublicationStatuses" oirequesttype on pd.oipublicationstatus_id = oirequesttype.oipublicationstatusid
                 WHERE mr.foiministryrequestid = :foiministryrequestid 
-                  AND pd.processingstatus != 'unpublished'
+                  AND pd.processingmessage = 'Published'
                   AND pd.isactive = TRUE;
             """
             

--- a/request-management-api/request_api/models/FOIProactiveDisclosureRequests.py
+++ b/request-management-api/request_api/models/FOIProactiveDisclosureRequests.py
@@ -119,12 +119,11 @@ class FOIProactiveDisclosureRequests(db.Model):
             sql = """
                 UPDATE public."FOIProactiveDisclosureRequests"
                 SET processingstatus = 'ready for crawling',
-                    processingmessage = 'sitemap ready',
+                    processingmessage = 'Published',
                     sitemap_pages = :sitemap_page,
                     updated_at = now()
                 WHERE foiministryrequest_id = :foiministryrequestid
                   AND isactive = TRUE
-                  AND processingstatus IS NULL;
             """
             result = db.session.execute(
                 text(sql),
@@ -166,7 +165,7 @@ class FOIProactiveDisclosureRequests(db.Model):
             db.session.close()
 
     @classmethod
-    def create_published_version_from_proactive_id(cls, proactivedisclosureid, message)->DefaultMethodResult:
+    def create_published_version_from_proactive_id(cls, proactivedisclosureid, message, sitemap=None)->DefaultMethodResult:
         try:
             current = (
                 db.session.query(cls)
@@ -215,9 +214,9 @@ class FOIProactiveDisclosureRequests(db.Model):
                 created_at=updated_at,
                 createdby="publishingservice",
                 oipublicationstatus_id=latest.oipublicationstatus_id,
-                processingstatus="published",
-                processingmessage=message,
-                sitemap_pages=latest.sitemap_pages,
+                processingstatus="ready for crawling",
+                processingmessage=message, 
+                sitemap_pages=sitemap
             )
             db.session.add(new_proactive)
             db.session.commit()
@@ -293,7 +292,7 @@ class FOIProactiveDisclosureRequests(db.Model):
                 WHERE oistatus.name IN (:ready_status, :published_status)
                   AND oirequesttype.name = :publication_status
                   AND pd.publicationdate < :publication_cutoff
-                  AND pd.processingstatus IS NULL
+                  AND (pd.processingmessage != 'Published' OR pd.processingmessage is NULL) 
                   AND mr.isactive = TRUE
                 GROUP BY
                     pd.proactivedisclosureid,

--- a/request-management-api/request_api/models/FOIProactiveDisclosureRequests.py
+++ b/request-management-api/request_api/models/FOIProactiveDisclosureRequests.py
@@ -197,7 +197,7 @@ class FOIProactiveDisclosureRequests(db.Model):
             db.session.close()
 
     @classmethod
-    def create_published_version_from_proactive_id(cls, proactivedisclosureid, message, sitemap=None)->DefaultMethodResult:
+    def create_published_version_from_proactive_id(cls, proactivedisclosureid, message, sitemap)->DefaultMethodResult:
         try:
             current = (
                 db.session.query(cls)

--- a/request-management-api/request_api/models/FOIProactiveDisclosureRequests.py
+++ b/request-management-api/request_api/models/FOIProactiveDisclosureRequests.py
@@ -116,27 +116,59 @@ class FOIProactiveDisclosureRequests(db.Model):
     @classmethod
     def mark_ready_for_crawling(cls, foiministryrequestid, sitemap_page)->DefaultMethodResult:
         try:
-            sql = """
-                UPDATE public."FOIProactiveDisclosureRequests"
-                SET processingstatus = 'ready for crawling',
-                    processingmessage = 'Published',
-                    sitemap_pages = :sitemap_page,
-                    updated_at = now()
-                WHERE foiministryrequest_id = :foiministryrequestid
-                  AND isactive = TRUE
-            """
-            result = db.session.execute(
-                text(sql),
-                {
-                    'foiministryrequestid': foiministryrequestid,
-                    'sitemap_page': sitemap_page,
-                },
+            current = (
+                db.session.query(cls)
+                .filter(cls.foiministryrequest_id == foiministryrequestid)
+                .order_by(cls.version.desc())
+                .first()
             )
-            if result.rowcount == 0:
-                db.session.rollback()
-                return DefaultMethodResult(False, "No active Proactive Disclosure row found to update", foiministryrequestid)
+            if current is None:
+                return DefaultMethodResult(
+                    False,
+                    "FOI Proactive Disclosure request not found",
+                    foiministryrequestid,
+                )
+
+            updated_at = datetime2.now().isoformat()
+
+            active_rows = (
+                db.session.query(cls)
+                .filter(cls.foiministryrequest_id == foiministryrequestid)
+                .filter(or_(cls.isactive == True, cls.isactive.is_(None)))
+                .all()
+            )
+            for row in active_rows:
+                row.isactive = False
+                row.updated_at = updated_at
+                row.updatedby = "publishingservice"
+
+            latest = (
+                db.session.query(cls)
+                .filter(cls.foiministryrequest_id == foiministryrequestid)
+                .order_by(cls.version.desc())
+                .first()
+            )
+
+            new_proactive = FOIProactiveDisclosureRequests(
+                proactivedisclosureid=latest.proactivedisclosureid,
+                version=latest.version + 1,
+                foiministryrequest_id=latest.foiministryrequest_id,
+                foiministryrequestversion_id=latest.foiministryrequestversion_id,
+                proactivedisclosurecategoryid=latest.proactivedisclosurecategoryid,
+                reportperiod=latest.reportperiod,
+                publicationdate=latest.publicationdate,
+                earliesteligiblepublicationdate=latest.earliesteligiblepublicationdate,
+                isactive=True,
+                created_at=updated_at,
+                createdby="publishingservice",
+                oipublicationstatus_id=latest.oipublicationstatus_id,
+                processingstatus="ready for crawling",
+                processingmessage="Published", 
+                sitemap_pages=sitemap_page
+            )
+            db.session.add(new_proactive)
             logging.info(
-                "Proactive Disclosure publication row updated for ministry request %s with sitemap page %s",
+                "FOIProactiveDisclsoure row updated for ministry request %s with sitemap page %s",
                 foiministryrequestid,
                 sitemap_page,
             )

--- a/request-management-api/request_api/services/publication_events/completed_stream_consumer.py
+++ b/request-management-api/request_api/services/publication_events/completed_stream_consumer.py
@@ -11,10 +11,8 @@ import time
 import redis
 
 from request_api.services.publication_events.consumer import (
-    OpenInfoPublishCompletedConsumer,
-    OpenInfoUnpublishCompletedConsumer,
-    ProactiveDisclosurePublishCompletedConsumer,
-    ProactiveDisclosureUnpublishCompletedConsumer,
+    OpenInfoPublicationCompletedConsumer,
+    ProactiveDisclosurePublicationCompletedConsumer,
 )
 from request_api.services.publication_events.types import PublicationEventType
 
@@ -42,14 +40,8 @@ class PublicationCompletedStreamConsumer:
         self.group_name = group_name
         self.consumer_name = consumer_name
         self.handlers = handlers or {
-            PublicationEventType.PUBLISH_COMPLETED: {
-                "openinfo": OpenInfoPublishCompletedConsumer(),
-                "proactivedisclosure": ProactiveDisclosurePublishCompletedConsumer(),
-            },
-            PublicationEventType.UNPUBLISH_COMPLETED: {
-                "openinfo": OpenInfoUnpublishCompletedConsumer(),
-                "proactivedisclosure": ProactiveDisclosureUnpublishCompletedConsumer(),
-            },
+            "openinfo": OpenInfoPublicationCompletedConsumer(),
+            "proactivedisclosure": ProactiveDisclosurePublicationCompletedConsumer(),
         }
         self.app = app
         self.count = count
@@ -175,10 +167,10 @@ class PublicationCompletedStreamConsumer:
         return None
 
     def _resolve_handler(self, envelope, kind):
-        event_type = envelope.get("event_type")
-        handlers_for_event = self.handlers.get(event_type)
-        if isinstance(handlers_for_event, dict):
-            return handlers_for_event.get(kind)
+        # event_type = envelope.get("event_type")
+        # handlers_for_event = self.handlers.get(event_type)
+        # if isinstance(handlers_for_event, dict):
+        #     return handlers_for_event.get(kind)
         return self.handlers.get(kind)
 
     def _handle_message(self, stream_name, message_id, fields):

--- a/request-management-api/request_api/services/publication_events/consumer.py
+++ b/request-management-api/request_api/services/publication_events/consumer.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from pathlib import PurePosixPath
 
 from request_api.models.FOIOpenInformationRequests import FOIOpenInformationRequests
 from request_api.models.FOIProactiveDisclosureRequests import FOIProactiveDisclosureRequests
@@ -80,7 +81,8 @@ class OpenInfoPublishCompletedConsumer:
             return DefaultMethodResult(False, "Invalid OpenInfo publish correlation_id")
 
         openinfo_id = int(match.group("openinfo_id"))
-        message = payload.get("message") or "Publication completed"
+        message = payload.get("message") or "Published"
+        sitemap_page_key = payload.get("sitemap_page_key")
 
         logging.info(
             "Handling OpenInfo publish completed event | "
@@ -94,14 +96,17 @@ class OpenInfoPublishCompletedConsumer:
         if update_result.success is False:
             return update_result
         
-        return self.openinfo_model.create_published_version_from_openinfo_id(openinfo_id, message)
+        return self.openinfo_model.create_published_version_from_openinfo_id(openinfo_id, message, PurePosixPath(sitemap_page_key).name)
 
 
 class OpenInfoUnpublishCompletedConsumer:
     """Logs completed unpublish events for OpenInfo records."""
 
-    def __init__(self, section_updater=None):
+    _CORRELATION_ID_PATTERN = re.compile(r"^openinfo-publish-(?P<openinfo_id>\d+)$")
+
+    def __init__(self, openinfo_model=None, section_updater=None):
         self.section_updater = section_updater or FOIRequestUpdateBySection()
+        self.openinfo_model = openinfo_model or FOIOpenInformationRequests
 
     def _handle_foiministryrequest_update(self, payload):
         return handle_foiministryrequest_update(
@@ -116,6 +121,18 @@ class OpenInfoUnpublishCompletedConsumer:
             return DefaultMethodResult(False, "Unsupported event type")
 
         payload = envelope.get("payload") or {}
+        missing = [field for field in ("tenant_id", "request_event_id") if not payload.get(field)]
+        if missing:
+            return DefaultMethodResult(False, f"Missing required payload fields: {', '.join(missing)}")
+
+        correlation_id = envelope.get("correlation_id")
+        match = self._CORRELATION_ID_PATTERN.match(correlation_id or "")
+        if not match:
+            return DefaultMethodResult(False, "Invalid OpenInfo publish correlation_id")
+
+        openinfo_id = int(match.group("openinfo_id"))
+        message = payload.get("message") or "Unpublished"
+        
         logging.info(
             "Handling OpenInfo unpublish completed event | "
             f"event_id={envelope.get('event_id')} "
@@ -131,7 +148,7 @@ class OpenInfoUnpublishCompletedConsumer:
         if update_result.success is False:
             return update_result
     
-        return DefaultMethodResult(True, "Unpublish completion logged")
+        return self.openinfo_model.create_published_version_from_openinfo_id(openinfo_id, message, None)
 
 
 class ProactiveDisclosurePublishCompletedConsumer:
@@ -168,7 +185,8 @@ class ProactiveDisclosurePublishCompletedConsumer:
             return DefaultMethodResult(False, "Invalid Proactive Disclosure publish correlation_id")
 
         proactive_id = int(match.group("proactive_id"))
-        message = payload.get("message") or "Publication completed"
+        message = payload.get("message") or "Published"
+        sitemap_page_key = payload.get("sitemap_page_key")
 
         logging.info(
             "Handling Proactive Disclosure publish completed event | "
@@ -185,14 +203,20 @@ class ProactiveDisclosurePublishCompletedConsumer:
         return self.proactive_model.create_published_version_from_proactive_id(
             proactive_id,
             message,
+            PurePosixPath(sitemap_page_key).name
         )
 
 
 class ProactiveDisclosureUnpublishCompletedConsumer:
     """Logs completed unpublish events for Proactive Disclosure records."""
 
-    def __init__(self, section_updater=None):
+    _CORRELATION_ID_PATTERN = re.compile(
+        r"^proactivedisclosure-publish-(?P<proactive_id>\d+)$"
+    )
+
+    def __init__(self, proactive_model=None, section_updater=None):
         self.section_updater = section_updater or FOIRequestUpdateBySection()
+        self.proactive_model = proactive_model or FOIProactiveDisclosureRequests
 
     def _handle_foiministryrequest_update(self, payload):
         return handle_foiministryrequest_update(
@@ -205,7 +229,19 @@ class ProactiveDisclosureUnpublishCompletedConsumer:
         """Validate and log a publication.unpublish.completed event for Proactive Disclosure."""
         if envelope.get("event_type") != PublicationEventType.UNPUBLISH_COMPLETED:
             return DefaultMethodResult(False, "Unsupported event type")
+        
         payload = envelope.get("payload") or {}
+        missing = [field for field in ("tenant_id", "request_event_id") if not payload.get(field)]
+        if missing:
+            return DefaultMethodResult(False, f"Missing required payload fields: {', '.join(missing)}")
+
+        correlation_id = envelope.get("correlation_id")
+        match = self._CORRELATION_ID_PATTERN.match(correlation_id or "")
+        if not match:
+            return DefaultMethodResult(False, "Invalid Proactive Disclosure publish correlation_id")
+
+        proactive_id = int(match.group("proactive_id"))
+        message = payload.get("message") or "Unpublished"
 
         logging.info(
             "Handling Proactive Disclosure unpublish completed event | "
@@ -222,4 +258,8 @@ class ProactiveDisclosureUnpublishCompletedConsumer:
         if update_result.success is False:
             return update_result
 
-        return DefaultMethodResult(True, "Unpublish completion logged")
+        return self.proactive_model.create_published_version_from_proactive_id(
+            proactive_id,
+            message,
+            None
+        )

--- a/request-management-api/request_api/services/publication_events/consumer.py
+++ b/request-management-api/request_api/services/publication_events/consumer.py
@@ -49,7 +49,7 @@ def handle_foiministryrequest_update(payload, oistatus_id, section_updater):
     return DefaultMethodResult(False, message)
 
 
-class OpenInfoPublishCompletedConsumer:
+class OpenInfoPublicationCompletedConsumer:
     """Handles completed publication events for OpenInfo records."""
 
     _CORRELATION_ID_PATTERN = re.compile(r"^openinfo-publish-(?P<openinfo_id>\d+)$")
@@ -58,67 +58,26 @@ class OpenInfoPublishCompletedConsumer:
         self.openinfo_model = openinfo_model or FOIOpenInformationRequests
         self.section_updater = section_updater or FOIRequestUpdateBySection()
 
-    def _handle_foiministryrequest_update(self, payload):
+    def _handle_foiministryrequest_update(self, payload, oistatusid):
         return handle_foiministryrequest_update(
             payload,
-            OIStatusEnum.PUBLISHED.value,
-            self.section_updater,
-        )
-        
-    def handle(self, envelope):
-        """Validate and apply a publication.publish.completed event for OpenInfo."""
-        if envelope.get("event_type") != PublicationEventType.PUBLISH_COMPLETED:
-            return DefaultMethodResult(False, "Unsupported event type")
-
-        payload = envelope.get("payload") or {}
-        missing = [field for field in ("tenant_id", "request_event_id") if not payload.get(field)]
-        if missing:
-            return DefaultMethodResult(False, f"Missing required payload fields: {', '.join(missing)}")
-
-        correlation_id = envelope.get("correlation_id")
-        match = self._CORRELATION_ID_PATTERN.match(correlation_id or "")
-        if not match:
-            return DefaultMethodResult(False, "Invalid OpenInfo publish correlation_id")
-
-        openinfo_id = int(match.group("openinfo_id"))
-        message = payload.get("message") or "Published"
-        sitemap_page_key = payload.get("sitemap_page_key")
-
-        logging.info(
-            "Handling OpenInfo publish completed event | "
-            f"event_id={envelope.get('event_id')} "
-            f"correlation_id={correlation_id} "
-            f"openinfo_id={openinfo_id} "
-            f"request_event_id={payload.get('request_event_id')}"
-        )
-        update_result = self._handle_foiministryrequest_update(payload)
-
-        if update_result.success is False:
-            return update_result
-        
-        return self.openinfo_model.create_published_version_from_openinfo_id(openinfo_id, message, PurePosixPath(sitemap_page_key).name)
-
-
-class OpenInfoUnpublishCompletedConsumer:
-    """Logs completed unpublish events for OpenInfo records."""
-
-    _CORRELATION_ID_PATTERN = re.compile(r"^openinfo-publish-(?P<openinfo_id>\d+)$")
-
-    def __init__(self, openinfo_model=None, section_updater=None):
-        self.section_updater = section_updater or FOIRequestUpdateBySection()
-        self.openinfo_model = openinfo_model or FOIOpenInformationRequests
-
-    def _handle_foiministryrequest_update(self, payload):
-        return handle_foiministryrequest_update(
-            payload,
-            OIStatusEnum.UNPUBLISHED.value,
+            oistatusid,
             self.section_updater,
         )
     
+    def _get_sitemap(self, payload):
+        sitemap_page_key = payload.get("sitemap_page_key")
+        if not sitemap_page_key:
+            raise ValueError("Publication API payload did not include sitemap_page_key")
+        return PurePosixPath(sitemap_page_key).name
+
     def handle(self, envelope):
-        """Validate and log a publication.unpublish.completed event for OpenInfo."""
-        if envelope.get("event_type") != PublicationEventType.UNPUBLISH_COMPLETED:
+        """Validate publication event for OpenInfo."""
+        event_type = envelope.get("event_type")
+        if event_type != PublicationEventType.PUBLISH_COMPLETED or event_type != PublicationEventType.UNPUBLISH_COMPLETED:
             return DefaultMethodResult(False, "Unsupported event type")
+        print("LOG:payload", envelope.get("payload"))
+        print("LOG:eventtype", event_type)
 
         payload = envelope.get("payload") or {}
         missing = [field for field in ("tenant_id", "request_event_id") if not payload.get(field)]
@@ -131,27 +90,32 @@ class OpenInfoUnpublishCompletedConsumer:
             return DefaultMethodResult(False, "Invalid OpenInfo publish correlation_id")
 
         openinfo_id = int(match.group("openinfo_id"))
-        message = payload.get("message") or "Unpublished"
-        
+        if event_type == PublicationEventType.PUBLISH_COMPLETED:
+            message = "Published"
+            sitemap = self._get_sitemap(payload)
+            oistatusid = OIStatusEnum.PUBLISHED.value
+        else:
+            message = "Unpublished"
+            sitemap = None
+            oistatusid = OIStatusEnum.UNPUBLISHED.value
+
         logging.info(
-            "Handling OpenInfo unpublish completed event | "
+            "Handling OpenInfo publication completed event | "
             f"event_id={envelope.get('event_id')} "
             f"correlation_id={envelope.get('correlation_id')} "
             f"kind={payload.get('kind')} "
             f"publication_id={payload.get('publication_id')} "
-            f"status={payload.get('status')} "
-            f"objects_deleted={payload.get('objects_deleted')} "
-            f"sitemap_result={payload.get('sitemap_result')}"
+            f"status={payload.get('status')}"
         )
-        update_result = self._handle_foiministryrequest_update(payload)
 
+        update_result = self._handle_foiministryrequest_update(payload, oistatusid)
         if update_result.success is False:
             return update_result
-    
-        return self.openinfo_model.create_published_version_from_openinfo_id(openinfo_id, message, None)
+        
+        return self.openinfo_model.create_published_version_from_openinfo_id(openinfo_id, message, sitemap)
 
 
-class ProactiveDisclosurePublishCompletedConsumer:
+class ProactiveDisclosurePublicationCompletedConsumer:
     """Handles completed publication events for Proactive Disclosure records."""
 
     _CORRELATION_ID_PATTERN = re.compile(
@@ -162,74 +126,27 @@ class ProactiveDisclosurePublishCompletedConsumer:
         self.proactive_model = proactive_model or FOIProactiveDisclosureRequests
         self.section_updater = section_updater or FOIRequestUpdateBySection()
     
-    def _handle_foiministryrequest_update(self, payload):
+    def _handle_foiministryrequest_update(self, payload, oistatusid):
         return handle_foiministryrequest_update(
             payload,
-            OIStatusEnum.PUBLISHED.value,
-            self.section_updater,
-        )
-
-    def handle(self, envelope):
-        """Validate and apply a publication.publish.completed event for Proactive Disclosure."""
-        if envelope.get("event_type") != PublicationEventType.PUBLISH_COMPLETED:
-            return DefaultMethodResult(False, "Unsupported event type")
-
-        payload = envelope.get("payload") or {}
-        missing = [field for field in ("tenant_id", "request_event_id") if not payload.get(field)]
-        if missing:
-            return DefaultMethodResult(False, f"Missing required payload fields: {', '.join(missing)}")
-
-        correlation_id = envelope.get("correlation_id")
-        match = self._CORRELATION_ID_PATTERN.match(correlation_id or "")
-        if not match:
-            return DefaultMethodResult(False, "Invalid Proactive Disclosure publish correlation_id")
-
-        proactive_id = int(match.group("proactive_id"))
-        message = payload.get("message") or "Published"
-        sitemap_page_key = payload.get("sitemap_page_key")
-
-        logging.info(
-            "Handling Proactive Disclosure publish completed event | "
-            f"event_id={envelope.get('event_id')} "
-            f"correlation_id={correlation_id} "
-            f"proactive_id={proactive_id} "
-            f"request_event_id={payload.get('request_event_id')}"
-        )
-        update_result = self._handle_foiministryrequest_update(payload)
-
-        if update_result.success is False:
-            return update_result
-        
-        return self.proactive_model.create_published_version_from_proactive_id(
-            proactive_id,
-            message,
-            PurePosixPath(sitemap_page_key).name
-        )
-
-
-class ProactiveDisclosureUnpublishCompletedConsumer:
-    """Logs completed unpublish events for Proactive Disclosure records."""
-
-    _CORRELATION_ID_PATTERN = re.compile(
-        r"^proactivedisclosure-publish-(?P<proactive_id>\d+)$"
-    )
-
-    def __init__(self, proactive_model=None, section_updater=None):
-        self.section_updater = section_updater or FOIRequestUpdateBySection()
-        self.proactive_model = proactive_model or FOIProactiveDisclosureRequests
-
-    def _handle_foiministryrequest_update(self, payload):
-        return handle_foiministryrequest_update(
-            payload,
-            OIStatusEnum.UNPUBLISHED.value,
+            oistatusid,
             self.section_updater,
         )
     
+    def _get_sitemap(self, payload):
+        sitemap_page_key = payload.get("sitemap_page_key")
+        if not sitemap_page_key:
+            raise ValueError("Publication API payload did not include sitemap_page_key")
+        return PurePosixPath(sitemap_page_key).name
+
     def handle(self, envelope):
-        """Validate and log a publication.unpublish.completed event for Proactive Disclosure."""
-        if envelope.get("event_type") != PublicationEventType.UNPUBLISH_COMPLETED:
+        """Validate publication event for Proactive Disclosure."""
+        event_type = envelope.get("event_type")
+        if event_type != PublicationEventType.PUBLISH_COMPLETED or event_type != PublicationEventType.UNPUBLISH_COMPLETED:
             return DefaultMethodResult(False, "Unsupported event type")
-        
+        print("LOG:payload", envelope.get("payload"))
+        print("LOG:eventtype", event_type)
+
         payload = envelope.get("payload") or {}
         missing = [field for field in ("tenant_id", "request_event_id") if not payload.get(field)]
         if missing:
@@ -241,25 +158,30 @@ class ProactiveDisclosureUnpublishCompletedConsumer:
             return DefaultMethodResult(False, "Invalid Proactive Disclosure publish correlation_id")
 
         proactive_id = int(match.group("proactive_id"))
-        message = payload.get("message") or "Unpublished"
-
+        if event_type == PublicationEventType.PUBLISH_COMPLETED:
+            message = "Published"
+            sitemap = self._get_sitemap(payload)
+            oistatusid = OIStatusEnum.PUBLISHED.value
+        else:
+            message = "Unpublished"
+            sitemap = None
+            oistatusid = OIStatusEnum.UNPUBLISHED.value
+        
         logging.info(
-            "Handling Proactive Disclosure unpublish completed event | "
+            "Handling Proactive Disclosure publication completed event | "
             f"event_id={envelope.get('event_id')} "
             f"correlation_id={envelope.get('correlation_id')} "
             f"kind={payload.get('kind')} "
             f"publication_id={payload.get('publication_id')} "
-            f"status={payload.get('status')} "
-            f"objects_deleted={payload.get('objects_deleted')} "
-            f"sitemap_result={payload.get('sitemap_result')}"
+            f"status={payload.get('status')}"
         )
-        update_result = self._handle_foiministryrequest_update(payload)
 
+        update_result = self._handle_foiministryrequest_update(payload, oistatusid)
         if update_result.success is False:
             return update_result
-
+        
         return self.proactive_model.create_published_version_from_proactive_id(
             proactive_id,
             message,
-            None
+            sitemap
         )

--- a/request-management-api/request_api/services/publication_events/service.py
+++ b/request-management-api/request_api/services/publication_events/service.py
@@ -12,6 +12,7 @@ from request_api.services.publication_events.mappers import (
 from request_api.services.publication_events.publisher import PublicationEventPublisher
 from request_api.services.publication_events.types import PublicationEventType
 
+# Currently, we are not using this right now (Publish Now is hanlded by rest_service/api) but in the future we may move Publish Now to the event service (via redis)
 
 class PublishNowEventService:
     """Builds and publishes production event envelopes for publish-now endpoints."""


### PR DESCRIPTION
This PR does the following in regards to our publication event flow:

1. Adds logic to create OI/PD when unpublish event is completed (was missing before) (first commit)

2. Revised processing messages to audit/track event flow process for completion of publications (first commit)

3. Updated db logic (mark for crawling) so that when publish now event is completed for PD/OI, that a new version for OI/PD record is created (before it was just updating the same version and not versioning a new record) (second commit)

4. Refactored publication completed classes of unpublish and publish into one (the code was nearly identical so I just made the two classes into one to handle both unpublish and publish when a publication service is completed" (third commit)