### PR TITLE
fix: align unpublish repository prefix with publish destination

### DIFF
--- a/request-management-api/request_api/services/publication_events/mappers.py
+++ b/request-management-api/request_api/services/publication_events/mappers.py
@@ -220,16 +220,14 @@ class UnpublishRequestedMapper:
 
     def map(self, row, publication_type="openinfo"):
         axis_request_id = row.get("axisrequestid")
+        public_repository = self.path_resolver.build_destination(row)
         return UnpublishRequestedPayload(
             tenant_id=self.path_resolver.resolve_tenant_id(row),
             publication_id=axis_request_id,
             public_url=(
                 f"{self.public_base_url}/{axis_request_id}/openinfo/{axis_request_id}.html"
             ),
-            public_repository=S3Location(
-                bucket=self.path_resolver.openinfo_publication_bucket,
-                prefix=f"{publication_type}/{axis_request_id}",
-            ),
+            public_repository=public_repository,
             last_modified=row.get("publicationdate", ""),
             foirequest_id=row.get("foirequest_id"),
             foiministryrequest_id=row.get("foiministryrequestid"),

--- a/request-management-api/tests/services/test_unpublish_event_service.py
+++ b/request-management-api/tests/services/test_unpublish_event_service.py
@@ -173,7 +173,7 @@ def test_unpublish_mapper_maps_openinfo_row(monkeypatch):
         == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/EDU-2024-12345/openinfo/EDU-2024-12345.html"
     )
     assert payload.public_repository.bucket == "dev-openinfopub"
-    assert payload.public_repository.prefix == "openinfo/EDU-2024-12345"
+    assert payload.public_repository.prefix == "packages/EDU-2024-12345/openinfo/"
     assert payload.last_modified == "2026-04-27"
 
 
@@ -200,7 +200,7 @@ def test_unpublish_mapper_maps_pd_row(monkeypatch):
         payload.public_url
         == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/PD-FIN-2026-001/openinfo/PD-FIN-2026-001.html"
     )
-    assert payload.public_repository.prefix == "proactivedisclosure/PD-FIN-2026-001"
+    assert payload.public_repository.prefix == "packages/PD-FIN-2026-001/openinfo/"
     assert payload.last_modified == "2026-04-20"
 
 
@@ -346,7 +346,7 @@ def test_queue_openinfo_unpublish_builds_correct_envelope(monkeypatch):
         == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/EDU-2024-12345/openinfo/EDU-2024-12345.html"
     )
     assert envelope["payload"]["public_repository"]["bucket"] == "dev-openinfopub"
-    assert envelope["payload"]["public_repository"]["prefix"] == "openinfo/EDU-2024-12345"
+    assert envelope["payload"]["public_repository"]["prefix"] == "packages/EDU-2024-12345/openinfo/"
     assert envelope["payload"]["last_modified"] == "2026-04-27"
     assert envelope["payload"]["foirequest_id"] == 200
     assert envelope["payload"]["foiministryrequest_id"] == 100
@@ -395,7 +395,7 @@ def test_queue_pd_unpublish_builds_correct_envelope(monkeypatch):
         envelope["payload"]["public_url"]
         == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/PD-FIN-2026-001/openinfo/PD-FIN-2026-001.html"
     )
-    assert envelope["payload"]["public_repository"]["prefix"] == "proactivedisclosure/PD-FIN-2026-001"
+    assert envelope["payload"]["public_repository"]["prefix"] == "packages/PD-FIN-2026-001/openinfo/"
     assert envelope["payload"]["foirequest_id"] == 400
     assert envelope["payload"]["foiministryrequest_id"] == 300
 


### PR DESCRIPTION
Fixes unpublish cleanup using the wrong S3 prefix. The unpublish mapper now uses the same destination resolver as publish, so public_repository points to the actual published artifact location:

  packages/{axisrequestid}/openinfo/

  instead of kind-based prefixes like:

  proactivedisclosure/{axisrequestid}