### PR TITLE
fix: use package root for unpublish repository prefix

### DIFF
--- a/request-management-api/request_api/services/publication_events/mappers.py
+++ b/request-management-api/request_api/services/publication_events/mappers.py
@@ -59,6 +59,12 @@ class PublicationPathResolver:
             prefix=f"packages/{row.get('axisrequestid')}/openinfo/",
         )
 
+    def build_public_repository_prefix(self, row):
+        return S3Location(
+            bucket=self.openinfo_publication_bucket,
+            prefix=f"packages/{row.get('axisrequestid')}/",
+        )
+
 
 class OpenInfoPublishRequestedMapper:
     """Maps OI query rows to requested-event payloads."""
@@ -228,7 +234,7 @@ class UnpublishRequestedMapper:
 
     def map(self, row, publication_type="openinfo"):
         axis_request_id = row.get("axisrequestid")
-        public_repository = self.path_resolver.build_destination(row)
+        public_repository = self.path_resolver.build_public_repository_prefix(row)
         return UnpublishRequestedPayload(
             tenant_id=self.path_resolver.resolve_tenant_id(row),
             publication_id=axis_request_id,

--- a/request-management-api/tests/services/test_publishnow_event_service.py
+++ b/request-management-api/tests/services/test_publishnow_event_service.py
@@ -103,6 +103,9 @@ def test_proactive_disclosure_mapper_sets_kind(monkeypatch):
         "proactivedisclosureid": 1,
         "axisrequestid": "PD-001",
         "bcgovcode": "fin",
+        "contributor": "Ministry of Finance",
+        "proactivedisclosurecategory": "Calendars",
+        "reportperiod": "Quarter 1 2026-27",
     }
     payload = mapper.map(row)
     assert payload.kind == "proactivedisclosure"
@@ -125,6 +128,7 @@ def test_queue_openinfo_publishnow_builds_openinfo_envelope(monkeypatch):
                     "fees": 0,
                     "applicant_type": "Media",
                     "bcgovcode": "fin",
+                    "created_at": "2026-04-20 10:30:00.000000",
                     "additionalfiles": [
                         {
                             "additionalfileid": 99,
@@ -146,7 +150,7 @@ def test_queue_openinfo_publishnow_builds_openinfo_envelope(monkeypatch):
     envelope = publisher.published_envelopes[0].to_dict()
     assert envelope["event_type"] == PublicationEventType.PUBLISH_REQUESTED
     assert envelope["payload"]["kind"] == "openinfo"
-    assert envelope["correlation_id"] == "openinfo-publish-345"
+    assert envelope["correlation_id"] == "openinfo-publish-345-1776681000.0"
     assert envelope["payload"]["tenant_id"] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "bcgov:fin"))
     assert envelope["payload"]["axis_request_id"] == "FIN-2026-047533"
     assert envelope["payload"]["source"]["bucket"] == "fin-dev-e"
@@ -176,6 +180,7 @@ def test_queue_proactive_disclosure_publishnow_builds_pd_envelope(monkeypatch):
                 "fees": 0,
                 "applicant_type": None,
                 "bcgovcode": "fin",
+                "created_at": "2026-04-20 10:30:00.000000",
                 "sitemap_pages": "",
                 "type": "publishnow",
                 "proactivedisclosurecategory": "Calendars",
@@ -201,7 +206,7 @@ def test_queue_proactive_disclosure_publishnow_builds_pd_envelope(monkeypatch):
     envelope = publisher.published_envelopes[0].to_dict()
     assert envelope["event_type"] == PublicationEventType.PUBLISH_REQUESTED
     assert envelope["payload"]["kind"] == "proactivedisclosure"
-    assert envelope["correlation_id"] == "proactivedisclosure-publish-71"
+    assert envelope["correlation_id"] == "proactivedisclosure-publish-71-1776681000.0"
     assert envelope["payload"]["tenant_id"] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "bcgov:fin"))
     assert envelope["payload"]["proactivedisclosure_category"] == "Calendars"
     assert envelope["payload"]["report_period"] == "Quarter 1 2026-27"

--- a/request-management-api/tests/services/test_publishnow_rest_service.py
+++ b/request-management-api/tests/services/test_publishnow_rest_service.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from types import SimpleNamespace
 
 import requests
 
@@ -90,12 +91,21 @@ class FakeDbResult:
 
 
 class FakeDbSession:
-    def __init__(self, rowcounts=None):
+    def __init__(self, rowcounts=None, current=None, active_rows=None):
         self.calls = []
         self.rowcounts = rowcounts or []
+        self.current = current
+        self.active_rows = active_rows if active_rows is not None else ([current] if current is not None else [])
+        self.added = []
         self.committed = False
         self.rolled_back = False
         self.closed = False
+
+    def query(self, model):
+        return FakeQuery(self)
+
+    def add(self, row):
+        self.added.append(row)
 
     def execute(self, sql, params):
         self.calls.append((str(sql), params))
@@ -112,10 +122,31 @@ class FakeDbSession:
         self.closed = True
 
 
+class FakeQuery:
+    def __init__(self, session):
+        self.session = session
+
+    def filter(self, *args):
+        return self
+
+    def order_by(self, *args):
+        return self
+
+    def first(self):
+        return self.session.current
+
+    def all(self):
+        return self.session.active_rows
+
+
 def test_publish_openinfo_posts_rest_wrapper_and_updates_sitemap_page(monkeypatch):
     monkeypatch.setenv("OPENINFO_PUBLICATION_BUCKET", "dev-openinfopub")
     monkeypatch.setenv("OPENINFO_SOURCE_BUCKET_SUFFIX", "dev-e")
     monkeypatch.setenv("FLASK_ENV", "production")
+    monkeypatch.setattr(
+        "request_api.services.publication_events.consumer.handle_foiministryrequest_update",
+        lambda payload, oistatus_id, section_updater: DefaultMethodResult(True, "Updated", payload.get("foiministryrequest_id")),
+    )
     updater = FakePublicationStatusUpdater()
     client = FakePublicationClient(
         {
@@ -137,6 +168,7 @@ def test_publish_openinfo_posts_rest_wrapper_and_updates_sitemap_page(monkeypatc
                     "fees": 0,
                     "applicant_type": "Media",
                     "bcgovcode": "fin",
+                    "created_at": "2026-04-20 10:30:00.000000",
                 }
             ]
         ),
@@ -163,6 +195,10 @@ def test_publish_proactive_disclosure_posts_rest_wrapper_and_updates_sitemap_pag
     monkeypatch.setenv("OPENINFO_PUBLICATION_BUCKET", "dev-openinfopub")
     monkeypatch.setenv("OPENINFO_SOURCE_BUCKET_SUFFIX", "dev-e")
     monkeypatch.setenv("FLASK_ENV", "production")
+    monkeypatch.setattr(
+        "request_api.services.publication_events.consumer.handle_foiministryrequest_update",
+        lambda payload, oistatus_id, section_updater: DefaultMethodResult(True, "Updated", payload.get("foiministryrequest_id")),
+    )
     updater = FakePublicationStatusUpdater()
     client = FakePublicationClient(
         {
@@ -185,6 +221,7 @@ def test_publish_proactive_disclosure_posts_rest_wrapper_and_updates_sitemap_pag
                 "fees": 0,
                 "applicant_type": None,
                 "bcgovcode": "fin",
+                "created_at": "2026-04-20 10:30:00.000000",
                 "sitemap_pages": "",
                 "proactivedisclosurecategory": "Calendars",
                 "reportperiod": "Quarter 1 2026-27",
@@ -209,9 +246,9 @@ def test_publish_proactive_disclosure_posts_rest_wrapper_and_updates_sitemap_pag
     assert payload["source"]["prefix"] == "PD-FIN-2026-047533/responsepackage/"
     assert payload["destination"]["bucket"] == "dev-openinfopub"
     assert payload["destination"]["prefix"] == "packages/PD-FIN-2026-047533/openinfo/"
-    assert "foiministryrequest_id" not in payload
-    assert "additionalfiles" not in payload
-    assert "sitemap_pages" not in payload
+    assert payload["foiministryrequest_id"] == 22318
+    assert payload["foirequest_id"] == 22318
+    assert payload["additionalfiles"] == []
     assert updater.proactive_updates == [(22318, "sitemap_pages_2.xml")]
 
 
@@ -224,6 +261,7 @@ def test_publish_openinfo_does_not_update_when_response_is_not_completed():
                     "openinfoid": 345,
                     "axisrequestid": "FIN-2026-047533",
                     "bcgovcode": "fin",
+                    "created_at": "2026-04-20 10:30:00.000000",
                 }
             ]
         ),
@@ -247,6 +285,7 @@ def test_publish_openinfo_requires_sitemap_page_key():
                     "openinfoid": 345,
                     "axisrequestid": "FIN-2026-047533",
                     "bcgovcode": "fin",
+                    "created_at": "2026-04-20 10:30:00.000000",
                 }
             ]
         ),
@@ -269,6 +308,7 @@ def test_publish_failure_log_includes_context_in_message(caplog):
                 "foiministryrequestid": 22318,
                 "axisrequestid": "PD-FIN-2026-047533",
                 "bcgovcode": "fin",
+                "created_at": "2026-04-20 10:30:00.000000",
                 "contributor": "Ministry of Finance",
                 "proactivedisclosurecategory": "Calendars",
                 "reportperiod": "Quarter 1 2026-27",
@@ -291,7 +331,7 @@ def test_publish_failure_log_includes_context_in_message(caplog):
     assert "publication_type=proactivedisclosure" in caplog.text
     assert "foiministryrequestid=22318" in caplog.text
     assert "axisrequestid=PD-FIN-2026-047533" in caplog.text
-    assert "correlation_id=proactivedisclosure-publish-71" in caplog.text
+    assert "correlation_id=proactivedisclosure-publish-71-1776681000.0" in caplog.text
 
 
 def test_publication_rest_client_generates_uuid_when_no_correlation_id():
@@ -355,45 +395,78 @@ def test_publication_rest_client_includes_upstream_error_body():
 
 
 def test_openinfo_ready_for_crawling_updates_ministry_oi_status(monkeypatch):
-    session = FakeDbSession()
+    current = SimpleNamespace(
+        foiopeninforequestid=11,
+        version=3,
+        foiministryrequest_id=22318,
+        foiministryrequestversion_id=7,
+        oipublicationstatus_id=2,
+        oiexemption_id=None,
+        oiassignedto=None,
+        oiexemptionapproved=False,
+        pagereference="1-2",
+        iaorationale=None,
+        oifeedback=None,
+        publicationdate=None,
+        receiveddate=None,
+        copyrightsevered=False,
+        isactive=True,
+    )
+    session = FakeDbSession(current=current)
     monkeypatch.setattr(db, "session", session)
 
     result = FOIOpenInformationRequests.mark_ready_for_crawling(22318, "sitemap_pages_1.xml")
 
     assert result.success is True
     assert session.committed is True
-    assert any('"FOIOpenInformationRequests"' in call[0] for call in session.calls)
-    ministry_update = [call for call in session.calls if '"FOIMinistryRequests"' in call[0]][0]
-    assert "oistatus_id = :oistatus_id" in ministry_update[0]
-    assert ministry_update[1]["foiministryrequestid"] == 22318
-    assert ministry_update[1]["oistatus_id"] == 4
+    assert current.isactive is False
+    assert len(session.added) == 1
+    new_row = session.added[0]
+    assert new_row.version == 4
+    assert new_row.processingstatus == "ready for crawling"
+    assert new_row.processingmessage == "Published"
+    assert new_row.sitemap_pages == "sitemap_pages_1.xml"
 
 
 def test_proactive_ready_for_crawling_updates_ministry_oi_status(monkeypatch):
-    session = FakeDbSession()
+    current = SimpleNamespace(
+        proactivedisclosureid=71,
+        version=2,
+        foiministryrequest_id=22318,
+        foiministryrequestversion_id=7,
+        proactivedisclosurecategoryid=3,
+        reportperiod="Quarter 1 2026-27",
+        publicationdate=None,
+        earliesteligiblepublicationdate=None,
+        oipublicationstatus_id=2,
+        isactive=True,
+    )
+    session = FakeDbSession(current=current)
     monkeypatch.setattr(db, "session", session)
 
     result = FOIProactiveDisclosureRequests.mark_ready_for_crawling(22318, "sitemap_pages_2.xml")
 
     assert result.success is True
     assert session.committed is True
-    assert any('"FOIProactiveDisclosureRequests"' in call[0] for call in session.calls)
-    ministry_update = [call for call in session.calls if '"FOIMinistryRequests"' in call[0]][0]
-    assert "oistatus_id = :oistatus_id" in ministry_update[0]
-    assert ministry_update[1]["foiministryrequestid"] == 22318
-    assert ministry_update[1]["oistatus_id"] == 4
+    assert current.isactive is False
+    assert len(session.added) == 1
+    new_row = session.added[0]
+    assert new_row.version == 3
+    assert new_row.processingstatus == "ready for crawling"
+    assert new_row.processingmessage == "Published"
+    assert new_row.sitemap_pages == "sitemap_pages_2.xml"
 
 
-def test_proactive_ready_for_crawling_fails_when_ministry_status_not_updated(monkeypatch):
-    session = FakeDbSession(rowcounts=[1, 0])
+def test_proactive_ready_for_crawling_fails_when_request_not_found(monkeypatch):
+    session = FakeDbSession(current=None)
     monkeypatch.setattr(db, "session", session)
 
     result = FOIProactiveDisclosureRequests.mark_ready_for_crawling(22318, "sitemap_pages_2.xml")
 
     assert result.success is False
-    assert "FOIMinistryRequests" in result.message
+    assert result.message == "FOI Proactive Disclosure request not found"
     assert session.committed is False
-    assert session.rolled_back is True
+    assert session.closed is True
 
 
 def test_publish_openinfo_passes_correlation_id_to_client(monkeypatch):
@@ -419,6 +492,7 @@ def test_publish_openinfo_passes_correlation_id_to_client(monkeypatch):
                     "fees": 0,
                     "applicant_type": "Media",
                     "bcgovcode": "fin",
+                    "created_at": "2026-04-20 10:30:00.000000",
                 }
             ]
         ),
@@ -428,7 +502,7 @@ def test_publish_openinfo_passes_correlation_id_to_client(monkeypatch):
 
     service.publish_openinfo_now(22318)
 
-    assert client.calls[0][2] == "openinfo-publish-345"
+    assert client.calls[0][2] == "openinfo-publish-345-1776681000.0"
 
 
 def test_publish_proactive_disclosure_passes_correlation_id_to_client(monkeypatch):
@@ -455,6 +529,7 @@ def test_publish_proactive_disclosure_passes_correlation_id_to_client(monkeypatc
                 "fees": 0,
                 "applicant_type": None,
                 "bcgovcode": "fin",
+                "created_at": "2026-04-20 10:30:00.000000",
                 "sitemap_pages": "",
                 "proactivedisclosurecategory": "Calendars",
                 "reportperiod": "Quarter 1 2026-27",
@@ -468,4 +543,4 @@ def test_publish_proactive_disclosure_passes_correlation_id_to_client(monkeypatc
 
     service.publish_proactive_disclosure_now(22318)
 
-    assert client.calls[0][2] == "proactivedisclosure-publish-71"
+    assert client.calls[0][2] == "proactivedisclosure-publish-71-1776681000.0"

--- a/request-management-api/tests/services/test_unpublish_event_service.py
+++ b/request-management-api/tests/services/test_unpublish_event_service.py
@@ -173,7 +173,7 @@ def test_unpublish_mapper_maps_openinfo_row(monkeypatch):
         == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/EDU-2024-12345/openinfo/EDU-2024-12345.html"
     )
     assert payload.public_repository.bucket == "dev-openinfopub"
-    assert payload.public_repository.prefix == "packages/EDU-2024-12345/openinfo/"
+    assert payload.public_repository.prefix == "packages/EDU-2024-12345/"
     assert payload.last_modified == "2026-04-27"
 
 
@@ -200,18 +200,21 @@ def test_unpublish_mapper_maps_pd_row(monkeypatch):
         payload.public_url
         == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/PD-FIN-2026-001/openinfo/PD-FIN-2026-001.html"
     )
-    assert payload.public_repository.prefix == "packages/PD-FIN-2026-001/openinfo/"
+    assert payload.public_repository.prefix == "packages/PD-FIN-2026-001/"
     assert payload.last_modified == "2026-04-20"
 
 
 def test_unpublish_mapper_correlation_id_openinfo():
-    row = {"openinfoid": 42}
-    assert UnpublishRequestedMapper.correlation_id(row, "openinfo") == "openinfo-unpublish-42"
+    row = {"openinfoid": 42, "created_at": "2026-04-27 08:15:00.000000"}
+    assert UnpublishRequestedMapper.correlation_id(row, "openinfo") == "openinfo-unpublish-42-1777277700.0"
 
 
 def test_unpublish_mapper_correlation_id_pd():
-    row = {"proactivedisclosureid": 99}
-    assert UnpublishRequestedMapper.correlation_id(row, "proactivedisclosure") == "proactivedisclosure-unpublish-99"
+    row = {"proactivedisclosureid": 99, "created_at": "2026-04-20 10:30:00.000000"}
+    assert (
+        UnpublishRequestedMapper.correlation_id(row, "proactivedisclosure")
+        == "proactivedisclosure-unpublish-99-1776681000.0"
+    )
 
 
 def test_unpublish_mapper_handles_missing_publicationdate(monkeypatch):
@@ -325,6 +328,7 @@ def test_queue_openinfo_unpublish_builds_correct_envelope(monkeypatch):
                     "type": "unpublish",
                     "bcgovcode": "edu",
                     "publicationdate": "2026-04-27",
+                    "created_at": "2026-04-27 08:15:00.000000",
                 }
             ]
         ),
@@ -338,7 +342,7 @@ def test_queue_openinfo_unpublish_builds_correct_envelope(monkeypatch):
     envelope = publisher.published_envelopes[0].to_dict()
     assert envelope["event_type"] == PublicationEventType.UNPUBLISH_REQUESTED
     assert envelope["payload"]["kind"] == "openinfo"
-    assert envelope["correlation_id"] == "openinfo-unpublish-42"
+    assert envelope["correlation_id"] == "openinfo-unpublish-42-1777277700.0"
     assert envelope["payload"]["tenant_id"] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "bcgov:edu"))
     assert envelope["payload"]["publication_id"] == "EDU-2024-12345"
     assert (
@@ -346,7 +350,7 @@ def test_queue_openinfo_unpublish_builds_correct_envelope(monkeypatch):
         == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/EDU-2024-12345/openinfo/EDU-2024-12345.html"
     )
     assert envelope["payload"]["public_repository"]["bucket"] == "dev-openinfopub"
-    assert envelope["payload"]["public_repository"]["prefix"] == "packages/EDU-2024-12345/openinfo/"
+    assert envelope["payload"]["public_repository"]["prefix"] == "packages/EDU-2024-12345/"
     assert envelope["payload"]["last_modified"] == "2026-04-27"
     assert envelope["payload"]["foirequest_id"] == 200
     assert envelope["payload"]["foiministryrequest_id"] == 100
@@ -377,6 +381,7 @@ def test_queue_pd_unpublish_builds_correct_envelope(monkeypatch):
                     "type": "unpublish",
                     "bcgovcode": "fin",
                     "publicationdate": "2026-04-20",
+                    "created_at": "2026-04-20 10:30:00.000000",
                 }
             ]
         ),
@@ -389,13 +394,13 @@ def test_queue_pd_unpublish_builds_correct_envelope(monkeypatch):
     envelope = publisher.published_envelopes[0].to_dict()
     assert envelope["event_type"] == PublicationEventType.UNPUBLISH_REQUESTED
     assert envelope["payload"]["kind"] == "proactivedisclosure"
-    assert envelope["correlation_id"] == "proactivedisclosure-unpublish-99"
+    assert envelope["correlation_id"] == "proactivedisclosure-unpublish-99-1776681000.0"
     assert envelope["payload"]["publication_id"] == "PD-FIN-2026-001"
     assert (
         envelope["payload"]["public_url"]
         == "https://citz-foi-prod.objectstore.gov.bc.ca/dev-openinfopub/packages/PD-FIN-2026-001/openinfo/PD-FIN-2026-001.html"
     )
-    assert envelope["payload"]["public_repository"]["prefix"] == "packages/PD-FIN-2026-001/openinfo/"
+    assert envelope["payload"]["public_repository"]["prefix"] == "packages/PD-FIN-2026-001/"
     assert envelope["payload"]["foirequest_id"] == 400
     assert envelope["payload"]["foiministryrequest_id"] == 300
 
@@ -446,6 +451,7 @@ def test_queue_openinfo_unpublish_publisher_failure(monkeypatch):
                     "axisrequestid": "EDU-2024-12345",
                     "bcgovcode": "edu",
                     "publicationdate": "2026-04-27",
+                    "created_at": "2026-04-27 08:15:00.000000",
                 }
             ]
         ),


### PR DESCRIPTION
  - Updated unpublish payload mapping so `public_repository.prefix` targets the package root, e.g. `packages/EDU-2024-12345/`, instead of `packages/EDU-2024-12345/openinfo/`.
  - Kept publish destination behavior unchanged at `packages/{axisrequestid}/openinfo/`.
  - Updated publish/unpublish tests to use the current timestamped correlation ID format.
  - Refreshed REST/status updater unit test fixtures to match current mapper and model behavior.