### PR TITLE
fix(messaging): enforce retry limits before dead-lettering

### DIFF
--- a/publication-service/internal/messaging/consumer.go
+++ b/publication-service/internal/messaging/consumer.go
@@ -44,7 +44,7 @@ type Validator interface {
 type PublishRepo interface {
 	Claim(ctx context.Context, req pub.ClaimRequest) (pub.ClaimResult, error)
 	MarkCompleted(ctx context.Context, eventID string, now time.Time) error
-	MarkRetry(ctx context.Context, eventID, msg, hash string, nextAt time.Time) error
+	MarkRetry(ctx context.Context, eventID, msg, hash string, nextAt time.Time, maxRetries, poisonRepeatThreshold int) (pub.RetryResult, error)
 	MarkDead(ctx context.Context, eventID, msg string, class pub.Class) error
 }
 
@@ -256,10 +256,33 @@ func (c *Consumer) Step(ctx context.Context) error {
 		slog.String("err", cl.Message),
 		slog.String("error_hash", hash),
 		slog.Time("next_retry_at", next))
+	retry, err := c.repo.MarkRetry(
+		ctx,
+		env.EventID,
+		cl.Message,
+		hash,
+		next,
+		c.cfg.MaxRetries,
+		c.cfg.PoisonRepeatThreshold,
+	)
+	if err != nil {
+		return err
+	}
+	if retry.Dead {
+		log.Warn("transient error retry limit reached → dead",
+			slog.String("err", cl.Message),
+			slog.String("error_hash", hash),
+			slog.String("class", string(retry.Class)))
+		if c.metrics != nil {
+			c.metrics.RecordProcessed(ctx, env.EventType, "dead")
+			c.metrics.RecordDeadLetter(ctx, env.EventType, string(retry.Class))
+		}
+		return nil
+	}
 	if c.metrics != nil {
 		c.metrics.RecordProcessed(ctx, env.EventType, "retry")
 	}
-	return c.repo.MarkRetry(ctx, env.EventID, cl.Message, hash, next)
+	return nil
 }
 
 // backoff returns the wait duration for retry attempt n (0-indexed).

--- a/publication-service/internal/messaging/consumer_test.go
+++ b/publication-service/internal/messaging/consumer_test.go
@@ -89,12 +89,14 @@ func (f *failingReadBroker) calls() int {
 }
 
 type fakeRepo struct {
-	mu       sync.Mutex
-	claimed  bool
-	complete bool
-	retry    bool
-	dead     bool
-	bumpHash string
+	mu              sync.Mutex
+	claimed         bool
+	complete        bool
+	retry           bool
+	dead            bool
+	bumpHash        string
+	retryCount      int
+	errorHashRepeat int
 }
 
 func (f *fakeRepo) Claim(_ context.Context, _ pub.ClaimRequest) (pub.ClaimResult, error) {
@@ -114,12 +116,26 @@ func (f *fakeRepo) MarkCompleted(_ context.Context, _ string, _ time.Time) error
 	return nil
 }
 
-func (f *fakeRepo) MarkRetry(_ context.Context, _, _, hash string, _ time.Time) error {
+func (f *fakeRepo) MarkRetry(_ context.Context, _, _, hash string, _ time.Time, maxRetries, poisonRepeatThreshold int) (pub.RetryResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.retry = true
+	repeat := 1
+	if f.bumpHash == hash {
+		repeat = f.errorHashRepeat + 1
+	}
+	f.retryCount++
+	f.errorHashRepeat = repeat
 	f.bumpHash = hash
-	return nil
+	if maxRetries > 0 && f.retryCount >= maxRetries {
+		f.dead = true
+		return pub.RetryResult{Dead: true}, nil
+	}
+	if poisonRepeatThreshold > 0 && repeat >= poisonRepeatThreshold {
+		f.dead = true
+		return pub.RetryResult{Dead: true}, nil
+	}
+	f.retry = true
+	return pub.RetryResult{}, nil
 }
 
 func (f *fakeRepo) MarkDead(_ context.Context, _, _ string, _ pub.Class) error {
@@ -258,6 +274,49 @@ func TestConsumer_TransientErrorSchedulesRetry(t *testing.T) {
 	}
 	if repo.bumpHash == "" {
 		t.Error("expected non-empty error hash")
+	}
+}
+
+func TestConsumer_TransientErrorGoesDeadAfterMaxRetries(t *testing.T) {
+	broker := &fakeReadBroker{messages: []*StreamMessage{
+		{ID: "redis-4", Payload: sampleEnvelope(t)},
+	}}
+	repo := &fakeRepo{retryCount: 4}
+	outbox := &fakeOutbox{}
+	normalizer := &fakeNormalizer{handlerErr: pub.NewTransient("S3 5xx")}
+
+	c := newConsumerForTest(broker, repo, outbox, normalizer)
+	if err := c.Step(context.Background()); err != nil {
+		t.Fatalf("Step: %v", err)
+	}
+	if !repo.dead {
+		t.Error("expected transient error to go dead after max retries")
+	}
+	if repo.retry {
+		t.Error("did not expect another retry after max retries")
+	}
+}
+
+func TestConsumer_TransientErrorGoesDeadAfterPoisonRepeatThreshold(t *testing.T) {
+	broker := &fakeReadBroker{messages: []*StreamMessage{
+		{ID: "redis-5", Payload: sampleEnvelope(t)},
+	}}
+	repo := &fakeRepo{
+		bumpHash:        pub.ErrorHash(pub.ClassTransient, "S3 5xx"),
+		errorHashRepeat: 2,
+	}
+	outbox := &fakeOutbox{}
+	normalizer := &fakeNormalizer{handlerErr: pub.NewTransient("S3 5xx")}
+
+	c := newConsumerForTest(broker, repo, outbox, normalizer)
+	if err := c.Step(context.Background()); err != nil {
+		t.Fatalf("Step: %v", err)
+	}
+	if !repo.dead {
+		t.Error("expected repeated transient error to go dead")
+	}
+	if repo.retry {
+		t.Error("did not expect another retry after poison repeat threshold")
 	}
 }
 

--- a/publication-service/internal/publish/errors.go
+++ b/publication-service/internal/publish/errors.go
@@ -37,6 +37,13 @@ type Classified struct {
 	Message string
 }
 
+// RetryResult reports whether a transient failure was scheduled again or
+// converted to a dead-letter state by retry policy.
+type RetryResult struct {
+	Dead  bool
+	Class Class
+}
+
 // Classify turns any error into a (class, message) decision.
 // Unknown errors default to transient — fail safe.
 func Classify(err error) Classified {

--- a/publication-service/internal/publish/repo.go
+++ b/publication-service/internal/publish/repo.go
@@ -82,20 +82,60 @@ WHERE event_id=$1`
 	return nil
 }
 
-// MarkRetry transitions a claimed row back to pending_retry with backoff.
-func (r *Repo) MarkRetry(ctx context.Context, eventID string, msg string, hash string, nextAt time.Time) error {
+// MarkRetry transitions a claimed row back to pending_retry with backoff, or
+// to dead when retry policy has been exhausted.
+func (r *Repo) MarkRetry(
+	ctx context.Context,
+	eventID string,
+	msg string,
+	hash string,
+	nextAt time.Time,
+	maxRetries int,
+	poisonRepeatThreshold int,
+) (RetryResult, error) {
 	const q = `
+WITH next_values AS (
+    SELECT
+        event_id,
+        retry_count + 1 AS next_retry_count,
+        CASE WHEN error_hash=$4 THEN error_hash_repeat + 1 ELSE 1 END AS next_error_hash_repeat
+    FROM workflow_request
+    WHERE event_id=$1
+),
+decision AS (
+    SELECT
+        event_id,
+        next_retry_count,
+        next_error_hash_repeat,
+        CASE
+            WHEN $5 > 0 AND next_retry_count >= $5 THEN 'dead'
+            WHEN $6 > 0 AND next_error_hash_repeat >= $6 THEN 'dead'
+            ELSE 'pending_retry'
+        END AS next_state,
+        CASE
+            WHEN $6 > 0 AND next_error_hash_repeat >= $6 THEN 'poison'
+            ELSE 'transient'
+        END AS next_error_class
+    FROM next_values
+)
 UPDATE workflow_request
-SET state='pending_retry',
-    retry_count=retry_count+1,
-    next_retry_at=$2,
+SET state=decision.next_state,
+    retry_count=decision.next_retry_count,
+    next_retry_at=CASE WHEN decision.next_state='dead' THEN NULL ELSE $2 END,
     last_error=$3,
-    last_error_class='transient',
-    error_hash_repeat=CASE WHEN error_hash=$4 THEN error_hash_repeat+1 ELSE 1 END,
+    last_error_class=decision.next_error_class,
+    error_hash_repeat=decision.next_error_hash_repeat,
     error_hash=$4
-WHERE event_id=$1`
-	_, err := r.pool.Exec(ctx, q, eventID, nextAt, msg, hash)
-	return err
+FROM decision
+WHERE workflow_request.event_id=decision.event_id
+RETURNING workflow_request.state, workflow_request.last_error_class`
+	var state State
+	var class Class
+	err := r.pool.QueryRow(ctx, q, eventID, nextAt, msg, hash, maxRetries, poisonRepeatThreshold).Scan(&state, &class)
+	if err != nil {
+		return RetryResult{}, err
+	}
+	return RetryResult{Dead: state == StateDead, Class: class}, nil
 }
 
 // MarkDead transitions a row to dead and redacts the payload.


### PR DESCRIPTION
  - Enforces `RETRY_MAX_ATTEMPTS` for transient event-processing failures
  - Moves events to `dead` once retry attempts are exhausted
  - Enforces `POISON_REPEAT_THRESHOLD` for repeated identical transient errors
  - Records dead-letter metrics when retry policy moves an event to `dead`
  - Adds regression tests for max retry and poison-repeat behavior