### PR TITLE
Fix sitemap and unpublish lookup by correlation ID

### DIFF
--- a/publication-service/internal/publishnow/publications_e2e_integration_test.go
+++ b/publication-service/internal/publishnow/publications_e2e_integration_test.go
@@ -75,23 +75,32 @@ func (s *memoryObjectStore) CopyFile(_ context.Context, srcBucket, srcKey, dstBu
 }
 
 type memoryResultStore struct {
-	results map[string]sitemapping.Result
+	results     map[string]sitemapping.Result
+	lastFindKey string
 }
 
 func newMemoryResultStore() *memoryResultStore {
 	return &memoryResultStore{results: map[string]sitemapping.Result{}}
 }
 
-func (s *memoryResultStore) FindCompleted(_ context.Context, kind pub.Kind, publicationID string) (sitemapping.Result, bool, error) {
-	result, ok := s.results[string(kind)+":"+publicationID]
+func (s *memoryResultStore) FindCompleted(_ context.Context, kind pub.Kind, tenantID string, correlationID string) (sitemapping.Result, bool, error) {
+	key := string(kind) + ":" + tenantID + ":" + correlationID
+	s.lastFindKey = key
+	result, ok := s.results[key]
 	return result, ok, nil
 }
 
 func (s *memoryResultStore) MarkSucceeded(_ context.Context, _ string, result sitemapping.Result) error {
+	if result.TenantID == "" {
+		return errors.New("tenant id required")
+	}
 	if result.PublicationID == "" {
 		return errors.New("publication id required")
 	}
-	s.results[string(result.Kind)+":"+result.PublicationID] = result
+	if s.lastFindKey == "" {
+		return errors.New("find completed must be called before mark succeeded")
+	}
+	s.results[s.lastFindKey] = result
 	return nil
 }
 

--- a/publication-service/internal/sitemapping/request_repo.go
+++ b/publication-service/internal/sitemapping/request_repo.go
@@ -1,82 +1,31 @@
 package sitemapping
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	pub "publication-service/internal/publish"
+	"publication-service/internal/workflowresult"
 )
 
 // RequestRepo stores sitemap-specific completion results in workflow_request.
 type RequestRepo struct {
-	pool *pgxpool.Pool
+	*workflowresult.Repo[Result]
 }
 
 // NewRequestRepo constructs a RequestRepo around a pgxpool.
 func NewRequestRepo(pool *pgxpool.Pool) *RequestRepo {
-	return &RequestRepo{pool: pool}
+	return &RequestRepo{Repo: workflowresult.NewRepo[Result](
+		pool,
+		"sitemapping.RequestRepo",
+		workflowresult.CompletedAt[Result]{Get: sitemapCompletedAt, Set: setSitemapCompletedAt},
+	)}
 }
 
-// FindCompleted returns a previous successful sitemap result for a workflow correlation.
-func (r *RequestRepo) FindCompleted(ctx context.Context, kind pub.Kind, tenantID string, correlationID string) (Result, bool, error) {
-	const q = `
-SELECT result
-FROM workflow_request
-WHERE state='completed'
-  AND kind=$1
-  AND tenant_id=$2
-  AND correlation_id=$3
-  AND result IS NOT NULL
-ORDER BY completed_at DESC NULLS LAST
-LIMIT 1`
-	var raw []byte
-	err := r.pool.QueryRow(ctx, q, string(kind), tenantID, correlationID).Scan(&raw)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return Result{}, false, nil
-	}
-	if err != nil {
-		return Result{}, false, fmt.Errorf("sitemapping.RequestRepo.FindCompleted: %w", err)
-	}
-	var result Result
-	if err := json.Unmarshal(raw, &result); err != nil {
-		return Result{}, false, fmt.Errorf("sitemapping.RequestRepo.FindCompleted: unmarshal result: %w", err)
-	}
-	return result, true, nil
+func sitemapCompletedAt(result *Result) time.Time {
+	return result.CompletedAt
 }
 
-// MarkSucceeded records a sitemap result and completes the claimed workflow row.
-func (r *RequestRepo) MarkSucceeded(ctx context.Context, eventID string, result Result) error {
-	completedAt := result.CompletedAt
-	if completedAt.IsZero() {
-		completedAt = time.Now().UTC()
-		result.CompletedAt = completedAt
-	}
-	raw, err := json.Marshal(result)
-	if err != nil {
-		return fmt.Errorf("sitemapping.RequestRepo.MarkSucceeded: marshal result: %w", err)
-	}
-	const q = `
-UPDATE workflow_request
-SET state='completed',
-    completed_at=$2,
-    last_error=NULL,
-    last_error_class=NULL,
-    error_hash=NULL,
-    error_hash_repeat=0,
-    result=$3
-WHERE event_id=$1`
-	tag, err := r.pool.Exec(ctx, q, eventID, completedAt, raw)
-	if err != nil {
-		return fmt.Errorf("sitemapping.RequestRepo.MarkSucceeded: %w", err)
-	}
-	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("sitemapping.RequestRepo.MarkSucceeded: %s not found", eventID)
-	}
-	return nil
+func setSitemapCompletedAt(result *Result, completedAt time.Time) {
+	result.CompletedAt = completedAt
 }

--- a/publication-service/internal/sitemapping/request_repo.go
+++ b/publication-service/internal/sitemapping/request_repo.go
@@ -23,19 +23,20 @@ func NewRequestRepo(pool *pgxpool.Pool) *RequestRepo {
 	return &RequestRepo{pool: pool}
 }
 
-// FindCompleted returns a previous successful sitemap result for a publication.
-func (r *RequestRepo) FindCompleted(ctx context.Context, kind pub.Kind, publicationID string) (Result, bool, error) {
+// FindCompleted returns a previous successful sitemap result for a workflow correlation.
+func (r *RequestRepo) FindCompleted(ctx context.Context, kind pub.Kind, tenantID string, correlationID string) (Result, bool, error) {
 	const q = `
 SELECT result
 FROM workflow_request
 WHERE state='completed'
   AND kind=$1
-  AND payload->>'publication_id'=$2
+  AND tenant_id=$2
+  AND correlation_id=$3
   AND result IS NOT NULL
 ORDER BY completed_at DESC NULLS LAST
 LIMIT 1`
 	var raw []byte
-	err := r.pool.QueryRow(ctx, q, string(kind), publicationID).Scan(&raw)
+	err := r.pool.QueryRow(ctx, q, string(kind), tenantID, correlationID).Scan(&raw)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Result{}, false, nil
 	}

--- a/publication-service/internal/sitemapping/request_repo_integration_test.go
+++ b/publication-service/internal/sitemapping/request_repo_integration_test.go
@@ -3,54 +3,35 @@
 package sitemapping
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"publication-service/internal/events"
 	pub "publication-service/internal/publish"
-	pg "publication-service/internal/storage/postgres"
+	"publication-service/internal/workflowtest"
 )
 
-func setupRequestRepo(t *testing.T) (*RequestRepo, *pub.Repo, *pgxpool.Pool) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-	c, err := tcpostgres.Run(ctx, "postgres:16-alpine",
-		tcpostgres.WithDatabase("foi"),
-		tcpostgres.WithUsername("foi"),
-		tcpostgres.WithPassword("foi"),
-		tcpostgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
-	dsn, err := c.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	if err := pg.Migrate(ctx, dsn); err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return NewRequestRepo(pool), pub.NewRepo(pool), pool
+const testTenantID = "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10"
+
+func TestRequestRepo(t *testing.T) {
+	workflowtest.RunRequestRepoSuite(t, workflowtest.RequestRepoSuite[Result]{
+		NewRepo:      func(pool *pgxpool.Pool) workflowtest.RequestRepo[Result] { return NewRequestRepo(pool) },
+		ClaimRequest: claimSitemapRequest,
+		SampleResult: sampleSitemapResult,
+		Kind:         pub.KindOpenInfoSitemap,
+		OtherKind:    pub.KindProactiveDisclosureSitemap,
+		TenantID:     testTenantID,
+	})
 }
 
-func claimSitemapRequest(t *testing.T, repo *pub.Repo, eventID string, correlationID string) {
-	t.Helper()
-	_, err := repo.Claim(context.Background(), pub.ClaimRequest{
+func claimSitemapRequest(eventID string, correlationID string) pub.ClaimRequest {
+	return pub.ClaimRequest{
 		EventID:       eventID,
 		EventType:     events.TypePublicationSitemappingRequested,
-		TenantID:      "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		TenantID:      testTenantID,
 		CorrelationID: correlationID,
 		SchemaVersion: events.SchemaVersionV1,
 		Payload: json.RawMessage(`{
@@ -60,18 +41,14 @@ func claimSitemapRequest(t *testing.T, repo *pub.Repo, eventID string, correlati
 			"last_modified":"2026-04-01",
 			"publication_result_ref":"018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
 		}`),
-		Now:  time.Now().UTC(),
 		Kind: pub.KindOpenInfoSitemap,
-	})
-	if err != nil {
-		t.Fatalf("Claim: %v", err)
 	}
 }
 
 func sampleSitemapResult() Result {
 	return Result{
 		Kind:                 pub.KindOpenInfoSitemap,
-		TenantID:             "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		TenantID:             testTenantID,
 		PublicationID:        "HTH-2025-52023:v1",
 		PublicURL:            "https://example.gov.bc.ca/openinfopub/packages/HTH-2025-52023/openinfo/HTH-2025-52023.html",
 		LastModified:         time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
@@ -82,124 +59,5 @@ func sampleSitemapResult() Result {
 		IndexUpdated:         false,
 		PublicationResultRef: "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90",
 		CompletedAt:          time.Date(2026, 4, 21, 12, 30, 0, 0, time.UTC),
-	}
-}
-
-func TestRequestRepo_FindCompletedFalseBeforeSuccess(t *testing.T) {
-	repo, pubRepo, _ := setupRequestRepo(t)
-	claimSitemapRequest(t, pubRepo, "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90", "corr-1")
-
-	_, ok, err := repo.FindCompleted(
-		context.Background(),
-		pub.KindOpenInfoSitemap,
-		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
-		"corr-1",
-	)
-	if err != nil {
-		t.Fatalf("FindCompleted: %v", err)
-	}
-	if ok {
-		t.Fatal("FindCompleted returned true before success")
-	}
-}
-
-func TestRequestRepo_MarkSucceededStoresFullResult(t *testing.T) {
-	repo, pubRepo, pool := setupRequestRepo(t)
-	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimSitemapRequest(t, pubRepo, eventID, "corr-1")
-	result := sampleSitemapResult()
-
-	if err := repo.MarkSucceeded(context.Background(), eventID, result); err != nil {
-		t.Fatalf("MarkSucceeded: %v", err)
-	}
-
-	var state string
-	var raw []byte
-	if err := pool.QueryRow(context.Background(),
-		`SELECT state, result FROM workflow_request WHERE event_id=$1`, eventID,
-	).Scan(&state, &raw); err != nil {
-		t.Fatalf("query stored result: %v", err)
-	}
-	if state != "completed" {
-		t.Fatalf("state = %q, want completed", state)
-	}
-	var stored Result
-	if err := json.Unmarshal(raw, &stored); err != nil {
-		t.Fatalf("unmarshal stored result: %v", err)
-	}
-	if stored != result {
-		t.Fatalf("stored result mismatch:\n got: %#v\nwant: %#v", stored, result)
-	}
-}
-
-func TestRequestRepo_FindCompletedReturnsStoredResultByKindTenantAndCorrelationID(t *testing.T) {
-	repo, pubRepo, _ := setupRequestRepo(t)
-	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimSitemapRequest(t, pubRepo, eventID, "corr-1")
-	want := sampleSitemapResult()
-	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
-		t.Fatalf("MarkSucceeded: %v", err)
-	}
-
-	got, ok, err := repo.FindCompleted(
-		context.Background(),
-		pub.KindOpenInfoSitemap,
-		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
-		"corr-1",
-	)
-	if err != nil {
-		t.Fatalf("FindCompleted: %v", err)
-	}
-	if !ok {
-		t.Fatal("FindCompleted returned false after success")
-	}
-	if got != want {
-		t.Fatalf("FindCompleted result mismatch:\n got: %#v\nwant: %#v", got, want)
-	}
-}
-
-func TestRequestRepo_FindCompletedDoesNotMatchDifferentCorrelationID(t *testing.T) {
-	repo, pubRepo, _ := setupRequestRepo(t)
-	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimSitemapRequest(t, pubRepo, eventID, "corr-original")
-	want := sampleSitemapResult()
-	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
-		t.Fatalf("MarkSucceeded: %v", err)
-	}
-
-	_, ok, err := repo.FindCompleted(
-		context.Background(),
-		pub.KindOpenInfoSitemap,
-		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
-		"corr-new",
-	)
-	if err != nil {
-		t.Fatalf("FindCompleted: %v", err)
-	}
-	if ok {
-		t.Fatal("FindCompleted returned true for a different correlation ID")
-	}
-}
-
-func TestRequestRepo_FindCompletedDoesNotMatchDifferentKind(t *testing.T) {
-	repo, pubRepo, _ := setupRequestRepo(t)
-	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimSitemapRequest(t, pubRepo, eventID, "corr-1")
-	want := sampleSitemapResult()
-	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
-		t.Fatalf("MarkSucceeded: %v", err)
-	}
-
-	_, ok, err := repo.FindCompleted(
-		context.Background(),
-		pub.KindProactiveDisclosureSitemap,
-		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
-		"corr-1",
-	)
-	if err != nil {
-		t.Fatalf("FindCompleted: %v", err)
-	}
-	if ok {
-		t.Fatal("FindCompleted returned true for a different sitemap kind")
 	}
 }

--- a/publication-service/internal/sitemapping/request_repo_integration_test.go
+++ b/publication-service/internal/sitemapping/request_repo_integration_test.go
@@ -45,13 +45,13 @@ func setupRequestRepo(t *testing.T) (*RequestRepo, *pub.Repo, *pgxpool.Pool) {
 	return NewRequestRepo(pool), pub.NewRepo(pool), pool
 }
 
-func claimSitemapRequest(t *testing.T, repo *pub.Repo, eventID string) {
+func claimSitemapRequest(t *testing.T, repo *pub.Repo, eventID string, correlationID string) {
 	t.Helper()
 	_, err := repo.Claim(context.Background(), pub.ClaimRequest{
 		EventID:       eventID,
 		EventType:     events.TypePublicationSitemappingRequested,
 		TenantID:      "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
-		CorrelationID: eventID,
+		CorrelationID: correlationID,
 		SchemaVersion: events.SchemaVersionV1,
 		Payload: json.RawMessage(`{
 			"tenant_id":"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
@@ -87,9 +87,14 @@ func sampleSitemapResult() Result {
 
 func TestRequestRepo_FindCompletedFalseBeforeSuccess(t *testing.T) {
 	repo, pubRepo, _ := setupRequestRepo(t)
-	claimSitemapRequest(t, pubRepo, "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90")
+	claimSitemapRequest(t, pubRepo, "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90", "corr-1")
 
-	_, ok, err := repo.FindCompleted(context.Background(), pub.KindOpenInfoSitemap, "HTH-2025-52023:v1")
+	_, ok, err := repo.FindCompleted(
+		context.Background(),
+		pub.KindOpenInfoSitemap,
+		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"corr-1",
+	)
 	if err != nil {
 		t.Fatalf("FindCompleted: %v", err)
 	}
@@ -101,7 +106,7 @@ func TestRequestRepo_FindCompletedFalseBeforeSuccess(t *testing.T) {
 func TestRequestRepo_MarkSucceededStoresFullResult(t *testing.T) {
 	repo, pubRepo, pool := setupRequestRepo(t)
 	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimSitemapRequest(t, pubRepo, eventID)
+	claimSitemapRequest(t, pubRepo, eventID, "corr-1")
 	result := sampleSitemapResult()
 
 	if err := repo.MarkSucceeded(context.Background(), eventID, result); err != nil {
@@ -127,16 +132,21 @@ func TestRequestRepo_MarkSucceededStoresFullResult(t *testing.T) {
 	}
 }
 
-func TestRequestRepo_FindCompletedReturnsStoredResultByKindAndPublicationID(t *testing.T) {
+func TestRequestRepo_FindCompletedReturnsStoredResultByKindTenantAndCorrelationID(t *testing.T) {
 	repo, pubRepo, _ := setupRequestRepo(t)
 	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimSitemapRequest(t, pubRepo, eventID)
+	claimSitemapRequest(t, pubRepo, eventID, "corr-1")
 	want := sampleSitemapResult()
 	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
 		t.Fatalf("MarkSucceeded: %v", err)
 	}
 
-	got, ok, err := repo.FindCompleted(context.Background(), pub.KindOpenInfoSitemap, "HTH-2025-52023:v1")
+	got, ok, err := repo.FindCompleted(
+		context.Background(),
+		pub.KindOpenInfoSitemap,
+		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"corr-1",
+	)
 	if err != nil {
 		t.Fatalf("FindCompleted: %v", err)
 	}
@@ -145,5 +155,51 @@ func TestRequestRepo_FindCompletedReturnsStoredResultByKindAndPublicationID(t *t
 	}
 	if got != want {
 		t.Fatalf("FindCompleted result mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestRequestRepo_FindCompletedDoesNotMatchDifferentCorrelationID(t *testing.T) {
+	repo, pubRepo, _ := setupRequestRepo(t)
+	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
+	claimSitemapRequest(t, pubRepo, eventID, "corr-original")
+	want := sampleSitemapResult()
+	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
+		t.Fatalf("MarkSucceeded: %v", err)
+	}
+
+	_, ok, err := repo.FindCompleted(
+		context.Background(),
+		pub.KindOpenInfoSitemap,
+		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"corr-new",
+	)
+	if err != nil {
+		t.Fatalf("FindCompleted: %v", err)
+	}
+	if ok {
+		t.Fatal("FindCompleted returned true for a different correlation ID")
+	}
+}
+
+func TestRequestRepo_FindCompletedDoesNotMatchDifferentKind(t *testing.T) {
+	repo, pubRepo, _ := setupRequestRepo(t)
+	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
+	claimSitemapRequest(t, pubRepo, eventID, "corr-1")
+	want := sampleSitemapResult()
+	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
+		t.Fatalf("MarkSucceeded: %v", err)
+	}
+
+	_, ok, err := repo.FindCompleted(
+		context.Background(),
+		pub.KindProactiveDisclosureSitemap,
+		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"corr-1",
+	)
+	if err != nil {
+		t.Fatalf("FindCompleted: %v", err)
+	}
+	if ok {
+		t.Fatal("FindCompleted returned true for a different sitemap kind")
 	}
 }

--- a/publication-service/internal/sitemapping/service.go
+++ b/publication-service/internal/sitemapping/service.go
@@ -12,7 +12,7 @@ import (
 )
 
 type ResultStore interface {
-	FindCompleted(ctx context.Context, kind pub.Kind, publicationID string) (Result, bool, error)
+	FindCompleted(ctx context.Context, kind pub.Kind, tenantID string, correlationID string) (Result, bool, error)
 	MarkSucceeded(ctx context.Context, eventID string, result Result) error
 }
 
@@ -33,7 +33,7 @@ func NewWriter(store ObjectStore, repo ResultStore, targets map[pub.Kind]Target)
 }
 
 func (w *Writer) Handle(ctx context.Context, req Request) (Result, error) {
-	if existing, ok, err := w.repo.FindCompleted(ctx, req.Kind, req.PublicationID); err != nil || ok {
+	if existing, ok, err := w.repo.FindCompleted(ctx, req.Kind, req.TenantID, req.CorrelationID); err != nil || ok {
 		return existing, err
 	}
 	target, ok := w.targets[req.Kind]

--- a/publication-service/internal/sitemapping/service_test.go
+++ b/publication-service/internal/sitemapping/service_test.go
@@ -37,12 +37,20 @@ func (f *fakeStore) Delete(_ context.Context, bucket, key string) error {
 }
 
 type fakeResultStore struct {
-	completed   Result
-	completedOK bool
-	marked      []Result
+	completed           Result
+	completedOK         bool
+	marked              []Result
+	findCompletedKind   pub.Kind
+	findCompletedTenant string
+	findCompletedCorrID string
+	findCompletedCalls  int
 }
 
-func (f *fakeResultStore) FindCompleted(_ context.Context, _ pub.Kind, _ string) (Result, bool, error) {
+func (f *fakeResultStore) FindCompleted(_ context.Context, kind pub.Kind, tenantID string, correlationID string) (Result, bool, error) {
+	f.findCompletedKind = kind
+	f.findCompletedTenant = tenantID
+	f.findCompletedCorrID = correlationID
+	f.findCompletedCalls++
 	return f.completed, f.completedOK, nil
 }
 
@@ -118,6 +126,28 @@ func TestWriter_WritesFirstURLAndIndex(t *testing.T) {
 	}
 	if len(repo.marked) != 1 {
 		t.Fatalf("MarkSucceeded calls = %d, want 1", len(repo.marked))
+	}
+}
+
+func TestWriter_FindsCompletedByKindTenantAndCorrelationID(t *testing.T) {
+	store := &fakeStore{objects: map[string][]byte{}}
+	repo := &fakeResultStore{}
+	w := NewWriter(store, repo, map[pub.Kind]Target{pub.KindOpenInfoSitemap: testTarget()})
+
+	if _, err := w.Handle(context.Background(), testRequest()); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if repo.findCompletedCalls != 1 {
+		t.Fatalf("FindCompleted calls = %d, want 1", repo.findCompletedCalls)
+	}
+	if repo.findCompletedKind != testRequest().Kind {
+		t.Fatalf("FindCompleted kind = %q, want %q", repo.findCompletedKind, testRequest().Kind)
+	}
+	if repo.findCompletedTenant != testRequest().TenantID {
+		t.Fatalf("FindCompleted tenant = %q, want %q", repo.findCompletedTenant, testRequest().TenantID)
+	}
+	if repo.findCompletedCorrID != testRequest().CorrelationID {
+		t.Fatalf("FindCompleted correlation = %q, want %q", repo.findCompletedCorrID, testRequest().CorrelationID)
 	}
 }
 

--- a/publication-service/internal/unpublish/repo.go
+++ b/publication-service/internal/unpublish/repo.go
@@ -1,79 +1,21 @@
 package unpublish
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	pub "publication-service/internal/publish"
+	"publication-service/internal/workflowresult"
 )
 
 type RequestRepo struct {
-	pool *pgxpool.Pool
+	*workflowresult.Repo[Result]
 }
 
 func NewRequestRepo(pool *pgxpool.Pool) *RequestRepo {
-	return &RequestRepo{pool: pool}
-}
-
-// FindCompleted returns a previous successful unpublish result for a workflow correlation.
-func (r *RequestRepo) FindCompleted(ctx context.Context, kind pub.Kind, tenantID string, correlationID string) (Result, bool, error) {
-	const q = `
-SELECT result
-FROM workflow_request
-WHERE state='completed'
-  AND kind=$1
-  AND tenant_id=$2
-  AND correlation_id=$3
-  AND result IS NOT NULL
-ORDER BY completed_at DESC NULLS LAST
-LIMIT 1`
-	var raw []byte
-	err := r.pool.QueryRow(ctx, q, string(kind), tenantID, correlationID).Scan(&raw)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return Result{}, false, nil
+	completedAt := workflowresult.CompletedAt[Result]{
+		Get: func(result *Result) time.Time { return result.CompletedAt },
+		Set: func(result *Result, completedAt time.Time) { result.CompletedAt = completedAt },
 	}
-	if err != nil {
-		return Result{}, false, fmt.Errorf("unpublish.RequestRepo.FindCompleted: %w", err)
-	}
-	var result Result
-	if err := json.Unmarshal(raw, &result); err != nil {
-		return Result{}, false, fmt.Errorf("unpublish.RequestRepo.FindCompleted: unmarshal result: %w", err)
-	}
-	return result, true, nil
-}
-
-func (r *RequestRepo) MarkSucceeded(ctx context.Context, eventID string, result Result) error {
-	completedAt := result.CompletedAt
-	if completedAt.IsZero() {
-		completedAt = time.Now().UTC()
-		result.CompletedAt = completedAt
-	}
-	raw, err := json.Marshal(result)
-	if err != nil {
-		return fmt.Errorf("unpublish.RequestRepo.MarkSucceeded: marshal result: %w", err)
-	}
-	const q = `
-UPDATE workflow_request
-SET state='completed',
-    completed_at=$2,
-    last_error=NULL,
-    last_error_class=NULL,
-    error_hash=NULL,
-    error_hash_repeat=0,
-    result=$3
-WHERE event_id=$1`
-	tag, err := r.pool.Exec(ctx, q, eventID, completedAt, raw)
-	if err != nil {
-		return fmt.Errorf("unpublish.RequestRepo.MarkSucceeded: %w", err)
-	}
-	if tag.RowsAffected() != 1 {
-		return fmt.Errorf("unpublish.RequestRepo.MarkSucceeded: %s not found", eventID)
-	}
-	return nil
+	return &RequestRepo{Repo: workflowresult.NewRepo[Result](pool, "unpublish.RequestRepo", completedAt)}
 }

--- a/publication-service/internal/unpublish/repo.go
+++ b/publication-service/internal/unpublish/repo.go
@@ -21,18 +21,20 @@ func NewRequestRepo(pool *pgxpool.Pool) *RequestRepo {
 	return &RequestRepo{pool: pool}
 }
 
-func (r *RequestRepo) FindCompleted(ctx context.Context, kind pub.Kind, publicationID string) (Result, bool, error) {
+// FindCompleted returns a previous successful unpublish result for a workflow correlation.
+func (r *RequestRepo) FindCompleted(ctx context.Context, kind pub.Kind, tenantID string, correlationID string) (Result, bool, error) {
 	const q = `
 SELECT result
 FROM workflow_request
 WHERE state='completed'
   AND kind=$1
-  AND payload->>'publication_id'=$2
+  AND tenant_id=$2
+  AND correlation_id=$3
   AND result IS NOT NULL
 ORDER BY completed_at DESC NULLS LAST
 LIMIT 1`
 	var raw []byte
-	err := r.pool.QueryRow(ctx, q, string(kind), publicationID).Scan(&raw)
+	err := r.pool.QueryRow(ctx, q, string(kind), tenantID, correlationID).Scan(&raw)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Result{}, false, nil
 	}

--- a/publication-service/internal/unpublish/request_repo_integration_test.go
+++ b/publication-service/internal/unpublish/request_repo_integration_test.go
@@ -1,0 +1,203 @@
+//go:build integration
+
+package unpublish
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	"publication-service/internal/events"
+	pub "publication-service/internal/publish"
+	pg "publication-service/internal/storage/postgres"
+)
+
+func setupRequestRepo(t *testing.T) (*RequestRepo, *pub.Repo, *pgxpool.Pool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	c, err := tcpostgres.Run(ctx, "postgres:16-alpine",
+		tcpostgres.WithDatabase("foi"),
+		tcpostgres.WithUsername("foi"),
+		tcpostgres.WithPassword("foi"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Fatalf("postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
+	dsn, err := c.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	if err := pg.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return NewRequestRepo(pool), pub.NewRepo(pool), pool
+}
+
+func claimUnpublishRequest(t *testing.T, repo *pub.Repo, eventID string, correlationID string) {
+	t.Helper()
+	_, err := repo.Claim(context.Background(), pub.ClaimRequest{
+		EventID:       eventID,
+		EventType:     events.TypePublicationUnpublishRequested,
+		TenantID:      "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		CorrelationID: correlationID,
+		SchemaVersion: events.SchemaVersionV1,
+		Payload: json.RawMessage(`{
+			"tenant_id":"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+			"publication_id":"HTH-2025-52023:v1",
+			"public_url":"https://example.gov.bc.ca/openinfopub/packages/HTH-2025-52023/openinfo/HTH-2025-52023.html",
+			"public_repository":{"bucket":"public","prefix":"openinfo/HTH-2025-52023"}
+		}`),
+		Now:  time.Now().UTC(),
+		Kind: pub.KindOpenInfoUnpublish,
+	})
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+}
+
+func sampleUnpublishResult() Result {
+	return Result{
+		Kind:                   pub.KindOpenInfoUnpublish,
+		TenantID:               "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		PublicationID:          "HTH-2025-52023:v1",
+		PublicURL:              "https://example.gov.bc.ca/openinfopub/packages/HTH-2025-52023/openinfo/HTH-2025-52023.html",
+		PublicRepositoryBucket: "public",
+		PublicRepositoryPrefix: "openinfo/HTH-2025-52023",
+		ObjectsDeleted:         3,
+		SitemapIndexKey:        "openinfopub/sitemap/sitemap_index.xml",
+		SitemapPageKey:         "openinfopub/sitemap/sitemap_pages_1.xml",
+		SitemapResult:          "removed",
+		CompletedAt:            time.Date(2026, 4, 21, 12, 30, 0, 0, time.UTC),
+	}
+}
+
+func TestRequestRepo_FindCompletedFalseBeforeSuccess(t *testing.T) {
+	repo, pubRepo, _ := setupRequestRepo(t)
+	claimUnpublishRequest(t, pubRepo, "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90", "corr-1")
+
+	_, ok, err := repo.FindCompleted(
+		context.Background(),
+		pub.KindOpenInfoUnpublish,
+		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"corr-1",
+	)
+	if err != nil {
+		t.Fatalf("FindCompleted: %v", err)
+	}
+	if ok {
+		t.Fatal("FindCompleted returned true before success")
+	}
+}
+
+func TestRequestRepo_MarkSucceededStoresFullResult(t *testing.T) {
+	repo, pubRepo, pool := setupRequestRepo(t)
+	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
+	claimUnpublishRequest(t, pubRepo, eventID, "corr-1")
+	result := sampleUnpublishResult()
+
+	if err := repo.MarkSucceeded(context.Background(), eventID, result); err != nil {
+		t.Fatalf("MarkSucceeded: %v", err)
+	}
+
+	var state string
+	var raw []byte
+	if err := pool.QueryRow(context.Background(),
+		`SELECT state, result FROM workflow_request WHERE event_id=$1`, eventID,
+	).Scan(&state, &raw); err != nil {
+		t.Fatalf("query stored result: %v", err)
+	}
+	if state != "completed" {
+		t.Fatalf("state = %q, want completed", state)
+	}
+	var stored Result
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("unmarshal stored result: %v", err)
+	}
+	if stored != result {
+		t.Fatalf("stored result mismatch:\n got: %#v\nwant: %#v", stored, result)
+	}
+}
+
+func TestRequestRepo_FindCompletedReturnsStoredResultByKindTenantAndCorrelationID(t *testing.T) {
+	repo, pubRepo, _ := setupRequestRepo(t)
+	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
+	claimUnpublishRequest(t, pubRepo, eventID, "corr-1")
+	want := sampleUnpublishResult()
+	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
+		t.Fatalf("MarkSucceeded: %v", err)
+	}
+
+	got, ok, err := repo.FindCompleted(
+		context.Background(),
+		pub.KindOpenInfoUnpublish,
+		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"corr-1",
+	)
+	if err != nil {
+		t.Fatalf("FindCompleted: %v", err)
+	}
+	if !ok {
+		t.Fatal("FindCompleted returned false after success")
+	}
+	if got != want {
+		t.Fatalf("FindCompleted result mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestRequestRepo_FindCompletedDoesNotMatchDifferentCorrelationID(t *testing.T) {
+	repo, pubRepo, _ := setupRequestRepo(t)
+	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
+	claimUnpublishRequest(t, pubRepo, eventID, "corr-original")
+	want := sampleUnpublishResult()
+	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
+		t.Fatalf("MarkSucceeded: %v", err)
+	}
+
+	_, ok, err := repo.FindCompleted(
+		context.Background(),
+		pub.KindOpenInfoUnpublish,
+		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"corr-new",
+	)
+	if err != nil {
+		t.Fatalf("FindCompleted: %v", err)
+	}
+	if ok {
+		t.Fatal("FindCompleted returned true for a different correlation ID")
+	}
+}
+
+func TestRequestRepo_FindCompletedDoesNotMatchDifferentKind(t *testing.T) {
+	repo, pubRepo, _ := setupRequestRepo(t)
+	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
+	claimUnpublishRequest(t, pubRepo, eventID, "corr-1")
+	want := sampleUnpublishResult()
+	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
+		t.Fatalf("MarkSucceeded: %v", err)
+	}
+
+	_, ok, err := repo.FindCompleted(
+		context.Background(),
+		pub.KindProactiveDisclosureUnpublish,
+		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"corr-1",
+	)
+	if err != nil {
+		t.Fatalf("FindCompleted: %v", err)
+	}
+	if ok {
+		t.Fatal("FindCompleted returned true for a different unpublish kind")
+	}
+}

--- a/publication-service/internal/unpublish/request_repo_integration_test.go
+++ b/publication-service/internal/unpublish/request_repo_integration_test.go
@@ -3,54 +3,35 @@
 package unpublish
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"publication-service/internal/events"
 	pub "publication-service/internal/publish"
-	pg "publication-service/internal/storage/postgres"
+	"publication-service/internal/workflowtest"
 )
 
-func setupRequestRepo(t *testing.T) (*RequestRepo, *pub.Repo, *pgxpool.Pool) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-	c, err := tcpostgres.Run(ctx, "postgres:16-alpine",
-		tcpostgres.WithDatabase("foi"),
-		tcpostgres.WithUsername("foi"),
-		tcpostgres.WithPassword("foi"),
-		tcpostgres.BasicWaitStrategies(),
-	)
-	if err != nil {
-		t.Fatalf("postgres: %v", err)
-	}
-	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
-	dsn, err := c.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("connection string: %v", err)
-	}
-	if err := pg.Migrate(ctx, dsn); err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	pool, err := pgxpool.New(ctx, dsn)
-	if err != nil {
-		t.Fatalf("pool: %v", err)
-	}
-	t.Cleanup(pool.Close)
-	return NewRequestRepo(pool), pub.NewRepo(pool), pool
+const testTenantID = "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10"
+
+func TestRequestRepo(t *testing.T) {
+	workflowtest.RunRequestRepoSuite(t, workflowtest.RequestRepoSuite[Result]{
+		NewRepo:      func(pool *pgxpool.Pool) workflowtest.RequestRepo[Result] { return NewRequestRepo(pool) },
+		ClaimRequest: claimUnpublishRequest,
+		SampleResult: sampleUnpublishResult,
+		Kind:         pub.KindOpenInfoUnpublish,
+		OtherKind:    pub.KindProactiveDisclosureUnpublish,
+		TenantID:     testTenantID,
+	})
 }
 
-func claimUnpublishRequest(t *testing.T, repo *pub.Repo, eventID string, correlationID string) {
-	t.Helper()
-	_, err := repo.Claim(context.Background(), pub.ClaimRequest{
+func claimUnpublishRequest(eventID string, correlationID string) pub.ClaimRequest {
+	return pub.ClaimRequest{
 		EventID:       eventID,
 		EventType:     events.TypePublicationUnpublishRequested,
-		TenantID:      "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		TenantID:      testTenantID,
 		CorrelationID: correlationID,
 		SchemaVersion: events.SchemaVersionV1,
 		Payload: json.RawMessage(`{
@@ -59,18 +40,14 @@ func claimUnpublishRequest(t *testing.T, repo *pub.Repo, eventID string, correla
 			"public_url":"https://example.gov.bc.ca/openinfopub/packages/HTH-2025-52023/openinfo/HTH-2025-52023.html",
 			"public_repository":{"bucket":"public","prefix":"openinfo/HTH-2025-52023"}
 		}`),
-		Now:  time.Now().UTC(),
 		Kind: pub.KindOpenInfoUnpublish,
-	})
-	if err != nil {
-		t.Fatalf("Claim: %v", err)
 	}
 }
 
 func sampleUnpublishResult() Result {
 	return Result{
 		Kind:                   pub.KindOpenInfoUnpublish,
-		TenantID:               "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		TenantID:               testTenantID,
 		PublicationID:          "HTH-2025-52023:v1",
 		PublicURL:              "https://example.gov.bc.ca/openinfopub/packages/HTH-2025-52023/openinfo/HTH-2025-52023.html",
 		PublicRepositoryBucket: "public",
@@ -80,124 +57,5 @@ func sampleUnpublishResult() Result {
 		SitemapPageKey:         "openinfopub/sitemap/sitemap_pages_1.xml",
 		SitemapResult:          "removed",
 		CompletedAt:            time.Date(2026, 4, 21, 12, 30, 0, 0, time.UTC),
-	}
-}
-
-func TestRequestRepo_FindCompletedFalseBeforeSuccess(t *testing.T) {
-	repo, pubRepo, _ := setupRequestRepo(t)
-	claimUnpublishRequest(t, pubRepo, "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90", "corr-1")
-
-	_, ok, err := repo.FindCompleted(
-		context.Background(),
-		pub.KindOpenInfoUnpublish,
-		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
-		"corr-1",
-	)
-	if err != nil {
-		t.Fatalf("FindCompleted: %v", err)
-	}
-	if ok {
-		t.Fatal("FindCompleted returned true before success")
-	}
-}
-
-func TestRequestRepo_MarkSucceededStoresFullResult(t *testing.T) {
-	repo, pubRepo, pool := setupRequestRepo(t)
-	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimUnpublishRequest(t, pubRepo, eventID, "corr-1")
-	result := sampleUnpublishResult()
-
-	if err := repo.MarkSucceeded(context.Background(), eventID, result); err != nil {
-		t.Fatalf("MarkSucceeded: %v", err)
-	}
-
-	var state string
-	var raw []byte
-	if err := pool.QueryRow(context.Background(),
-		`SELECT state, result FROM workflow_request WHERE event_id=$1`, eventID,
-	).Scan(&state, &raw); err != nil {
-		t.Fatalf("query stored result: %v", err)
-	}
-	if state != "completed" {
-		t.Fatalf("state = %q, want completed", state)
-	}
-	var stored Result
-	if err := json.Unmarshal(raw, &stored); err != nil {
-		t.Fatalf("unmarshal stored result: %v", err)
-	}
-	if stored != result {
-		t.Fatalf("stored result mismatch:\n got: %#v\nwant: %#v", stored, result)
-	}
-}
-
-func TestRequestRepo_FindCompletedReturnsStoredResultByKindTenantAndCorrelationID(t *testing.T) {
-	repo, pubRepo, _ := setupRequestRepo(t)
-	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimUnpublishRequest(t, pubRepo, eventID, "corr-1")
-	want := sampleUnpublishResult()
-	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
-		t.Fatalf("MarkSucceeded: %v", err)
-	}
-
-	got, ok, err := repo.FindCompleted(
-		context.Background(),
-		pub.KindOpenInfoUnpublish,
-		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
-		"corr-1",
-	)
-	if err != nil {
-		t.Fatalf("FindCompleted: %v", err)
-	}
-	if !ok {
-		t.Fatal("FindCompleted returned false after success")
-	}
-	if got != want {
-		t.Fatalf("FindCompleted result mismatch:\n got: %#v\nwant: %#v", got, want)
-	}
-}
-
-func TestRequestRepo_FindCompletedDoesNotMatchDifferentCorrelationID(t *testing.T) {
-	repo, pubRepo, _ := setupRequestRepo(t)
-	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimUnpublishRequest(t, pubRepo, eventID, "corr-original")
-	want := sampleUnpublishResult()
-	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
-		t.Fatalf("MarkSucceeded: %v", err)
-	}
-
-	_, ok, err := repo.FindCompleted(
-		context.Background(),
-		pub.KindOpenInfoUnpublish,
-		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
-		"corr-new",
-	)
-	if err != nil {
-		t.Fatalf("FindCompleted: %v", err)
-	}
-	if ok {
-		t.Fatal("FindCompleted returned true for a different correlation ID")
-	}
-}
-
-func TestRequestRepo_FindCompletedDoesNotMatchDifferentKind(t *testing.T) {
-	repo, pubRepo, _ := setupRequestRepo(t)
-	eventID := "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
-	claimUnpublishRequest(t, pubRepo, eventID, "corr-1")
-	want := sampleUnpublishResult()
-	if err := repo.MarkSucceeded(context.Background(), eventID, want); err != nil {
-		t.Fatalf("MarkSucceeded: %v", err)
-	}
-
-	_, ok, err := repo.FindCompleted(
-		context.Background(),
-		pub.KindProactiveDisclosureUnpublish,
-		"a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
-		"corr-1",
-	)
-	if err != nil {
-		t.Fatalf("FindCompleted: %v", err)
-	}
-	if ok {
-		t.Fatal("FindCompleted returned true for a different unpublish kind")
 	}
 }

--- a/publication-service/internal/unpublish/service.go
+++ b/publication-service/internal/unpublish/service.go
@@ -28,7 +28,7 @@ func (s *Service) Handle(ctx context.Context, req Request) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	if existing, ok, err := s.store.FindCompleted(ctx, req.Kind, req.PublicationID); err != nil {
+	if existing, ok, err := s.store.FindCompleted(ctx, req.Kind, req.TenantID, req.CorrelationID); err != nil {
 		return Result{}, err
 	} else if ok {
 		// Close out the current claim so it doesn't stay in 'processing'

--- a/publication-service/internal/unpublish/service_test.go
+++ b/publication-service/internal/unpublish/service_test.go
@@ -41,10 +41,18 @@ func (f *fakeSitemapRemover) Remove(_ context.Context, req sitemapping.RemovalRe
 }
 
 type fakeResultStore struct {
-	marked Result
+	marked              Result
+	findCompletedKind   pub.Kind
+	findCompletedTenant string
+	findCompletedCorrID string
+	findCompletedCalls  int
 }
 
-func (f *fakeResultStore) FindCompleted(context.Context, pub.Kind, string) (Result, bool, error) {
+func (f *fakeResultStore) FindCompleted(_ context.Context, kind pub.Kind, tenantID string, correlationID string) (Result, bool, error) {
+	f.findCompletedKind = kind
+	f.findCompletedTenant = tenantID
+	f.findCompletedCorrID = correlationID
+	f.findCompletedCalls++
 	return Result{}, false, nil
 }
 
@@ -81,6 +89,41 @@ func TestService_HandleDeletesPrefixThenRemovesSitemap(t *testing.T) {
 	}
 	if store.marked.PublicationID != "pub" {
 		t.Fatalf("result not stored: %#v", store.marked)
+	}
+}
+
+func TestService_HandleFindsCompletedByKindTenantAndCorrelationID(t *testing.T) {
+	repo := &fakePublicRepo{count: 2}
+	sitemap := &fakeSitemapRemover{}
+	store := &fakeResultStore{}
+	svc := NewService(repo, sitemap, store)
+
+	req := Request{
+		Kind:          pub.KindOpenInfoUnpublish,
+		TenantID:      "tenant",
+		PublicationID: "pub",
+		PublicURL:     "https://example/pub.html",
+		PublicRepository: PublicRepositoryLocation{
+			Bucket: "public",
+			Prefix: "openinfo/pub",
+		},
+		SourceEventID: "event-1",
+		CorrelationID: "corr-1",
+	}
+	if _, err := svc.Handle(context.Background(), req); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if store.findCompletedCalls != 1 {
+		t.Fatalf("FindCompleted calls = %d, want 1", store.findCompletedCalls)
+	}
+	if store.findCompletedKind != req.Kind {
+		t.Fatalf("FindCompleted kind = %q, want %q", store.findCompletedKind, req.Kind)
+	}
+	if store.findCompletedTenant != req.TenantID {
+		t.Fatalf("FindCompleted tenant = %q, want %q", store.findCompletedTenant, req.TenantID)
+	}
+	if store.findCompletedCorrID != req.CorrelationID {
+		t.Fatalf("FindCompleted correlation = %q, want %q", store.findCompletedCorrID, req.CorrelationID)
 	}
 }
 

--- a/publication-service/internal/unpublish/types.go
+++ b/publication-service/internal/unpublish/types.go
@@ -49,6 +49,6 @@ type SitemapRemover interface {
 }
 
 type ResultStore interface {
-	FindCompleted(ctx context.Context, kind pub.Kind, publicationID string) (Result, bool, error)
+	FindCompleted(ctx context.Context, kind pub.Kind, tenantID string, correlationID string) (Result, bool, error)
 	MarkSucceeded(ctx context.Context, eventID string, result Result) error
 }

--- a/publication-service/internal/workflowresult/repo.go
+++ b/publication-service/internal/workflowresult/repo.go
@@ -1,0 +1,86 @@
+package workflowresult
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	pub "publication-service/internal/publish"
+)
+
+type CompletedAt[R any] struct {
+	Get func(*R) time.Time
+	Set func(*R, time.Time)
+}
+
+type Repo[R any] struct {
+	pool        *pgxpool.Pool
+	name        string
+	completedAt CompletedAt[R]
+}
+
+func NewRepo[R any](pool *pgxpool.Pool, name string, completedAt CompletedAt[R]) *Repo[R] {
+	return &Repo[R]{pool: pool, name: name, completedAt: completedAt}
+}
+
+func (r *Repo[R]) FindCompleted(ctx context.Context, kind pub.Kind, tenantID string, correlationID string) (R, bool, error) {
+	const q = `
+SELECT result
+FROM workflow_request
+WHERE state='completed'
+  AND kind=$1
+  AND tenant_id=$2
+  AND correlation_id=$3
+  AND result IS NOT NULL
+ORDER BY completed_at DESC NULLS LAST
+LIMIT 1`
+	var zero R
+	var raw []byte
+	err := r.pool.QueryRow(ctx, q, string(kind), tenantID, correlationID).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return zero, false, nil
+	}
+	if err != nil {
+		return zero, false, fmt.Errorf("%s.FindCompleted: %w", r.name, err)
+	}
+	var result R
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return zero, false, fmt.Errorf("%s.FindCompleted: unmarshal result: %w", r.name, err)
+	}
+	return result, true, nil
+}
+
+func (r *Repo[R]) MarkSucceeded(ctx context.Context, eventID string, result R) error {
+	completedAt := r.completedAt.Get(&result)
+	if completedAt.IsZero() {
+		completedAt = time.Now().UTC()
+		r.completedAt.Set(&result, completedAt)
+	}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("%s.MarkSucceeded: marshal result: %w", r.name, err)
+	}
+	const q = `
+UPDATE workflow_request
+SET state='completed',
+    completed_at=$2,
+    last_error=NULL,
+    last_error_class=NULL,
+    error_hash=NULL,
+    error_hash_repeat=0,
+    result=$3
+WHERE event_id=$1`
+	tag, err := r.pool.Exec(ctx, q, eventID, completedAt, raw)
+	if err != nil {
+		return fmt.Errorf("%s.MarkSucceeded: %w", r.name, err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("%s.MarkSucceeded: %s not found", r.name, eventID)
+	}
+	return nil
+}

--- a/publication-service/internal/workflowtest/request_repo_suite.go
+++ b/publication-service/internal/workflowtest/request_repo_suite.go
@@ -1,0 +1,170 @@
+//go:build integration
+
+package workflowtest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	pub "publication-service/internal/publish"
+	pg "publication-service/internal/storage/postgres"
+)
+
+type RequestRepo[R comparable] interface {
+	FindCompleted(ctx context.Context, kind pub.Kind, tenantID string, correlationID string) (R, bool, error)
+	MarkSucceeded(ctx context.Context, eventID string, result R) error
+}
+
+type RequestRepoSuite[R comparable] struct {
+	NewRepo      func(*pgxpool.Pool) RequestRepo[R]
+	ClaimRequest func(eventID string, correlationID string) pub.ClaimRequest
+	SampleResult func() R
+	Kind         pub.Kind
+	OtherKind    pub.Kind
+	TenantID     string
+}
+
+func RunRequestRepoSuite[R comparable](t *testing.T, suite RequestRepoSuite[R]) {
+	t.Helper()
+	t.Run("FindCompletedFalseBeforeSuccess", func(t *testing.T) {
+		repo, pubRepo, _ := setupRequestRepo(t, suite.NewRepo)
+		claimRequest(t, pubRepo, suite.ClaimRequest(testEventID, "corr-1"))
+
+		_, ok, err := repo.FindCompleted(context.Background(), suite.Kind, suite.TenantID, "corr-1")
+		if err != nil {
+			t.Fatalf("FindCompleted: %v", err)
+		}
+		if ok {
+			t.Fatal("FindCompleted returned true before success")
+		}
+	})
+
+	t.Run("MarkSucceededStoresFullResult", func(t *testing.T) {
+		repo, pubRepo, pool := setupRequestRepo(t, suite.NewRepo)
+		claimRequest(t, pubRepo, suite.ClaimRequest(testEventID, "corr-1"))
+		result := suite.SampleResult()
+
+		if err := repo.MarkSucceeded(context.Background(), testEventID, result); err != nil {
+			t.Fatalf("MarkSucceeded: %v", err)
+		}
+
+		var state string
+		var raw []byte
+		if err := pool.QueryRow(context.Background(),
+			`SELECT state, result FROM workflow_request WHERE event_id=$1`, testEventID,
+		).Scan(&state, &raw); err != nil {
+			t.Fatalf("query stored result: %v", err)
+		}
+		if state != "completed" {
+			t.Fatalf("state = %q, want completed", state)
+		}
+		var stored R
+		if err := json.Unmarshal(raw, &stored); err != nil {
+			t.Fatalf("unmarshal stored result: %v", err)
+		}
+		if stored != result {
+			t.Fatalf("stored result mismatch:\n got: %#v\nwant: %#v", stored, result)
+		}
+	})
+
+	t.Run("FindCompletedReturnsStoredResultByKindTenantAndCorrelationID", func(t *testing.T) {
+		repo, pubRepo, _ := setupRequestRepo(t, suite.NewRepo)
+		claimRequest(t, pubRepo, suite.ClaimRequest(testEventID, "corr-1"))
+		want := suite.SampleResult()
+		if err := repo.MarkSucceeded(context.Background(), testEventID, want); err != nil {
+			t.Fatalf("MarkSucceeded: %v", err)
+		}
+
+		got, ok, err := repo.FindCompleted(context.Background(), suite.Kind, suite.TenantID, "corr-1")
+		if err != nil {
+			t.Fatalf("FindCompleted: %v", err)
+		}
+		if !ok {
+			t.Fatal("FindCompleted returned false after success")
+		}
+		if got != want {
+			t.Fatalf("FindCompleted result mismatch:\n got: %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("FindCompletedDoesNotMatchDifferentCorrelationID", func(t *testing.T) {
+		repo, pubRepo, _ := setupRequestRepo(t, suite.NewRepo)
+		claimRequest(t, pubRepo, suite.ClaimRequest(testEventID, "corr-original"))
+		if err := repo.MarkSucceeded(context.Background(), testEventID, suite.SampleResult()); err != nil {
+			t.Fatalf("MarkSucceeded: %v", err)
+		}
+
+		_, ok, err := repo.FindCompleted(context.Background(), suite.Kind, suite.TenantID, "corr-new")
+		if err != nil {
+			t.Fatalf("FindCompleted: %v", err)
+		}
+		if ok {
+			t.Fatal("FindCompleted returned true for a different correlation ID")
+		}
+	})
+
+	t.Run("FindCompletedDoesNotMatchDifferentKind", func(t *testing.T) {
+		repo, pubRepo, _ := setupRequestRepo(t, suite.NewRepo)
+		claimRequest(t, pubRepo, suite.ClaimRequest(testEventID, "corr-1"))
+		if err := repo.MarkSucceeded(context.Background(), testEventID, suite.SampleResult()); err != nil {
+			t.Fatalf("MarkSucceeded: %v", err)
+		}
+
+		_, ok, err := repo.FindCompleted(context.Background(), suite.OtherKind, suite.TenantID, "corr-1")
+		if err != nil {
+			t.Fatalf("FindCompleted: %v", err)
+		}
+		if ok {
+			t.Fatal("FindCompleted returned true for a different kind")
+		}
+	})
+}
+
+const testEventID = "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d90"
+
+func setupRequestRepo[R comparable](
+	t *testing.T,
+	newRepo func(*pgxpool.Pool) RequestRepo[R],
+) (RequestRepo[R], *pub.Repo, *pgxpool.Pool) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	c, err := tcpostgres.Run(ctx, "postgres:16-alpine",
+		tcpostgres.WithDatabase("foi"),
+		tcpostgres.WithUsername("foi"),
+		tcpostgres.WithPassword("foi"),
+		tcpostgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Fatalf("postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
+	dsn, err := c.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	if err := pg.Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return newRepo(pool), pub.NewRepo(pool), pool
+}
+
+func claimRequest(t *testing.T, repo *pub.Repo, req pub.ClaimRequest) {
+	t.Helper()
+	if req.Now.IsZero() {
+		req.Now = time.Now().UTC()
+	}
+	if _, err := repo.Claim(context.Background(), req); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+}


### PR DESCRIPTION
This PR updates completed-result lookup behavior for sitemap and unpublish workflows to use workflow execution identity instead of only the publication identity.

Previously, completed lookups used:

* `kind + publication_id`

This could incorrectly reuse completed results across different workflow executions for the same publication, especially in republish-after-unpublish scenarios.

The lookup now uses:

* `kind + tenant_id + correlation_id`

---

## Changes

* Change sitemap and unpublish `FindCompleted` lookups from:

  * `kind + publication_id`
  * to `kind + tenant_id + correlation_id`
* Keep `publication_id` as the stable publication/business identifier
* Use `correlation_id` as the workflow execution/idempotency identifier
* Update writer/service interfaces and repository queries to use the new lookup key
* Update test fakes and mocks to support the new lookup behavior
* Add integration coverage to ensure completed results are not reused across:

  * different correlation IDs
  * different workflow kinds

---

## Why

`publication_id` represents the stable business identity of the publication/request. It identifies which publication the workflow is operating on. In this flow, publishing again after an unpublish is considered a new workflow attempt for the same publication, so reusing the same `publication_id` is expected and correct.

`correlation_id` represents the workflow execution itself. It identifies a specific processing attempt. Completed-result lookups should therefore use this workflow identity; otherwise, a previous completed publish, sitemap, or unpublish operation could incorrectly cause a later attempt for the same publication to be skipped.

Including `tenant_id` ensures the lookup remains tenant-scoped and avoids accidental cross-tenant matches. Including `kind` keeps different workflow types isolated from one another.

The ownership model becomes:

* `publication_id`

  * stable business/publication identity
* `kind + tenant_id + correlation_id`

  * workflow execution identity and idempotency lookup key

This preserves the public meaning of `publication_id` while ensuring republish-after-unpublish workflows behave correctly.
