### PR TITLE
fix: handle REST republish sitemap workflow reuse

### DIFF
--- a/publication-service/internal/messaging/rest_publish_event_unpublish_integration_test.go
+++ b/publication-service/internal/messaging/rest_publish_event_unpublish_integration_test.go
@@ -1,0 +1,266 @@
+//go:build integration
+
+package messaging_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	s3sdk "github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"publication-service/internal/events"
+	"publication-service/internal/http/handlers"
+	"publication-service/internal/messaging"
+	pubpub "publication-service/internal/publication/publish"
+	pubunpub "publication-service/internal/publication/unpublish"
+	pub "publication-service/internal/publish"
+	"publication-service/internal/publishnow"
+	"publication-service/internal/sitemapping"
+	sharedunpublish "publication-service/internal/unpublish"
+)
+
+func TestRestPublishEventUnpublishRestRepublishCopiesFilesAndUpdatesSitemap(t *testing.T) {
+	h := setupSitemapHarness(t)
+	ctx := h.ctx
+
+	createBucket(t, ctx, h.rawS3, "raw")
+	putObject(t, ctx, h.rawS3, "raw", "src/a/response letter.pdf", "letter")
+	putObject(t, ctx, h.rawS3, "raw", "src/a/package.json", `{"ok":true}`)
+
+	publishHandler := newRESTPublishHandler(t, h)
+
+	first := postPublication(t, publishHandler, restPublishBody())
+	assertS3ObjectContains(t, ctx, h.rawS3, "published", "dst/a/response_letter.pdf", "letter")
+	assertS3ObjectContains(t, ctx, h.rawS3, "published", "dst/a/package.json", `{"ok":true}`)
+	assertS3ObjectContains(t, ctx, h.rawS3, "published", "dst/a/HTH-2025-52023.html", "HTH-2025-52023")
+	assertObjectContains(t, h, "published", "openinfopub/sitemap/sitemap_pages_1.xml", first.PublicURL)
+
+	unpublishConsumer := newUnpublishConsumer(t, h)
+	publishUnpublishEnvelope(t, h, first.PublicURL)
+	waitForCompletedWorkflowKind(t, h, unpublishConsumer, pub.KindOpenInfoUnpublish)
+	assertObjectDoesNotExist(t, ctx, h.rawS3, "published", "dst/a/HTH-2025-52023.html")
+	assertS3ObjectMissingText(t, ctx, h.rawS3, "published", "openinfopub/sitemap/sitemap_pages_1.xml", first.PublicURL)
+
+	second := postPublication(t, publishHandler, restPublishBody())
+	if second.PublicURL != first.PublicURL {
+		t.Fatalf("republished public URL = %q, want %q", second.PublicURL, first.PublicURL)
+	}
+	assertS3ObjectContains(t, ctx, h.rawS3, "published", "dst/a/response_letter.pdf", "letter")
+	assertS3ObjectContains(t, ctx, h.rawS3, "published", "dst/a/package.json", `{"ok":true}`)
+	assertS3ObjectContains(t, ctx, h.rawS3, "published", "dst/a/HTH-2025-52023.html", "HTH-2025-52023")
+	assertObjectContains(t, h, "published", "openinfopub/sitemap/sitemap_pages_1.xml", second.PublicURL)
+}
+
+func newRESTPublishHandler(t *testing.T, h sitemapHarness) http.Handler {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pubService, err := pubpub.NewService(
+		h.s3Client,
+		h.s3Client,
+		"https://objects.example",
+		logger,
+		pubpub.WithFileCopier(h.s3Client),
+		pubpub.WithDeleter(h.s3Client),
+	)
+	if err != nil {
+		t.Fatalf("publish service: %v", err)
+	}
+	orchestrator := publishnow.New(pubService, publishCycleSitemapWriter(h)).
+		WithSitemapClaimer(pub.NewRepo(h.pool))
+	return handlers.Publications(orchestrator)
+}
+
+func publishCycleSitemapWriter(h sitemapHarness) *sitemapping.Writer {
+	target := sitemapping.Target{
+		Bucket:          "published",
+		Prefix:          "openinfopub/sitemap/",
+		PublicBaseURL:   "https://example.gov.bc.ca/openinfopub/sitemap/",
+		IndexFileName:   "sitemap_index.xml",
+		PageFilePattern: "sitemap_pages_%d.xml",
+		PageLimit:       50000,
+	}
+	return sitemapping.NewWriter(h.s3Client, sitemapping.NewRequestRepo(h.pool), map[pub.Kind]sitemapping.Target{
+		pub.KindOpenInfoSitemap:              target,
+		pub.KindProactiveDisclosureSitemap:   target,
+		pub.KindOpenInfoUnpublish:            target,
+		pub.KindProactiveDisclosureUnpublish: target,
+	})
+}
+
+func postPublication(t *testing.T, handler http.Handler, body []byte) publishnow.Response {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/publications", bytes.NewReader(body))
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /publications status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var resp publishnow.Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode publication response: %v", err)
+	}
+	return resp
+}
+
+func restPublishBody() []byte {
+	payload := map[string]any{
+		"tenant_id":       "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"kind":            "openinfo",
+		"axis_request_id": "HTH-2025-52023",
+		"description":     "A briefing note",
+		"published_date":  "2026-02-03",
+		"contributor":     "Ministry of Health",
+		"fees":            0,
+		"applicant_type":  "Interest Group",
+		"source":          map[string]any{"bucket": "raw", "prefix": "src/a/"},
+		"destination":     map[string]any{"bucket": "published", "prefix": "dst/a/"},
+	}
+	body, err := json.Marshal(map[string]any{
+		"publication_type": "openinfo",
+		"payload":          payload,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return body
+}
+
+func newUnpublishConsumer(t *testing.T, h sitemapHarness) *messaging.Consumer {
+	t.Helper()
+	if err := h.broker.EnsureGroup(h.ctx, events.TypePublicationUnpublishRequested, "unpublish-g"); err != nil {
+		t.Fatalf("ensure unpublish group: %v", err)
+	}
+	unpublishService := sharedunpublish.NewService(
+		h.s3Client,
+		publishCycleSitemapWriter(h),
+		sharedunpublish.NewRequestRepo(h.pool),
+	)
+	validator, err := pubunpub.NewValidator([]string{"openinfo.workflow.service"})
+	if err != nil {
+		t.Fatalf("unpublish validator: %v", err)
+	}
+	return messaging.NewConsumer(messaging.ConsumerConfig{
+		Stream:                events.TypePublicationUnpublishRequested,
+		CompletedStream:       events.TypePublicationUnpublishCompleted,
+		CompletedEventType:    events.TypePublicationUnpublishCompleted,
+		Kind:                  pub.KindOpenInfoUnpublish,
+		Group:                 "unpublish-g",
+		Consumer:              "unpublish-c1",
+		ReadTimeout:           500 * time.Millisecond,
+		HandlerTimeout:        5 * time.Second,
+		MaxRetries:            5,
+		PoisonRepeatThreshold: 3,
+	}, h.broker, pub.NewRepo(h.pool), messaging.NewOutboxRepo(h.pool), pubunpub.NewNormalizerAdapter(unpublishService), validator)
+}
+
+func publishUnpublishEnvelope(t *testing.T, h sitemapHarness, publicURL string) {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"tenant_id":      "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
+		"publication_id": "HTH-2025-52023",
+		"public_url":     publicURL,
+		"public_repository": map[string]string{
+			"bucket": "published",
+			"prefix": "dst/a/",
+		},
+		"last_modified": "2026-02-03",
+		"kind":          "openinfo",
+	})
+	if err != nil {
+		t.Fatalf("unpublish payload: %v", err)
+	}
+	env := events.Envelope{
+		EventID:       "018f2e7a-1c6b-7c0a-9f8d-3e4a2b1c5d95",
+		EventType:     events.TypePublicationUnpublishRequested,
+		Timestamp:     time.Now().UTC(),
+		SchemaVersion: events.SchemaVersionV1,
+		CorrelationID: "rest-publish-event-unpublish",
+		Source:        "openinfo.workflow.service",
+		Payload:       payload,
+		Meta:          events.Meta{FirstSeenAt: time.Now().UTC()},
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("unpublish envelope: %v", err)
+	}
+	if _, err := h.broker.Publish(h.ctx, events.TypePublicationUnpublishRequested, b, 1000); err != nil {
+		t.Fatalf("publish unpublish event: %v", err)
+	}
+}
+
+func waitForCompletedWorkflowKind(t *testing.T, h sitemapHarness, consumer *messaging.Consumer, kind pub.Kind) {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		if err := consumer.Step(h.ctx); err != nil {
+			t.Fatalf("unpublish Step: %v", err)
+		}
+		var completedCount int
+		if err := h.pool.QueryRow(h.ctx,
+			`SELECT count(*) FROM workflow_request WHERE state='completed' AND kind=$1`,
+			string(kind),
+		).Scan(&completedCount); err != nil {
+			t.Fatalf("count completed %s workflows: %v", kind, err)
+		}
+		if completedCount == 1 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("workflow_request kind %s never reached completed", kind)
+}
+
+func createBucket(t *testing.T, ctx context.Context, client *s3sdk.Client, bucket string) {
+	t.Helper()
+	if _, err := client.CreateBucket(ctx, &s3sdk.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("create bucket %q: %v", bucket, err)
+	}
+}
+
+func putObject(t *testing.T, ctx context.Context, client *s3sdk.Client, bucket, key, body string) {
+	t.Helper()
+	if _, err := client.PutObject(ctx, &s3sdk.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader([]byte(body)),
+	}); err != nil {
+		t.Fatalf("put %s/%s: %v", bucket, key, err)
+	}
+}
+
+func assertObjectDoesNotExist(t *testing.T, ctx context.Context, client *s3sdk.Client, bucket, key string) {
+	t.Helper()
+	_, err := client.GetObject(ctx, &s3sdk.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err == nil {
+		t.Fatalf("%s/%s exists, want deleted", bucket, key)
+	}
+}
+
+func assertS3ObjectMissingText(t *testing.T, ctx context.Context, client *s3sdk.Client, bucket, key, text string) {
+	t.Helper()
+	got, err := client.GetObject(ctx, &s3sdk.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return
+	}
+	body, err := io.ReadAll(got.Body)
+	_ = got.Body.Close()
+	if err != nil {
+		t.Fatalf("read %s/%s: %v", bucket, key, err)
+	}
+	if bytes.Contains(body, []byte(text)) {
+		t.Fatalf("%s/%s contains %q, want removed:\n%s", bucket, key, text, body)
+	}
+}

--- a/publication-service/internal/messaging/rest_publish_event_unpublish_integration_test.go
+++ b/publication-service/internal/messaging/rest_publish_event_unpublish_integration_test.go
@@ -27,13 +27,21 @@ import (
 	sharedunpublish "publication-service/internal/unpublish"
 )
 
+// TestRestPublishEventUnpublishRestRepublishCopiesFilesAndUpdatesSitemap
+// verifies the mixed control-plane flow used by "Publish Now":
+//
+//   - publish through the REST API,
+//   - unpublish through the Redis event consumer,
+//   - publish the same request through REST again.
+//
+// The regression this protects is REST republish failing after an event-driven
+// unpublish because the second REST publish receives a new event ID while the
+// sitemap workflow row already exists for the same public URL.
 func TestRestPublishEventUnpublishRestRepublishCopiesFilesAndUpdatesSitemap(t *testing.T) {
 	h := setupSitemapHarness(t)
 	ctx := h.ctx
 
-	createBucket(t, ctx, h.rawS3, "raw")
-	putObject(t, ctx, h.rawS3, "raw", "src/a/response letter.pdf", "letter")
-	putObject(t, ctx, h.rawS3, "raw", "src/a/package.json", `{"ok":true}`)
+	seedRestPublishSource(t, ctx, h.rawS3)
 
 	publishHandler := newRESTPublishHandler(t, h)
 
@@ -59,6 +67,48 @@ func TestRestPublishEventUnpublishRestRepublishCopiesFilesAndUpdatesSitemap(t *t
 	assertObjectContains(t, h, "published", "openinfopub/sitemap/sitemap_pages_1.xml", second.PublicURL)
 }
 
+// TestRestRepublishWithDifferentEventIDReusesSitemapWorkflowRow verifies that
+// repeated REST publishes of the same public URL are idempotent even though
+// each REST request creates a new generated event ID.
+//
+// The expected behavior is to reuse the existing sitemap workflow row keyed by
+// kind, tenant, and public URL, leaving one sitemap URL entry and one workflow
+// row for that public URL.
+func TestRestRepublishWithDifferentEventIDReusesSitemapWorkflowRow(t *testing.T) {
+	h := setupSitemapHarness(t)
+	ctx := h.ctx
+
+	seedRestPublishSource(t, ctx, h.rawS3)
+
+	publishHandler := newRESTPublishHandler(t, h)
+
+	first := postPublication(t, publishHandler, restPublishBody())
+	second := postPublication(t, publishHandler, restPublishBody())
+	if second.PublicURL != first.PublicURL {
+		t.Fatalf("republished public URL = %q, want %q", second.PublicURL, first.PublicURL)
+	}
+
+	assertS3ObjectContains(t, ctx, h.rawS3, "published", "dst/a/response_letter.pdf", "letter")
+	assertS3ObjectContains(t, ctx, h.rawS3, "published", "dst/a/package.json", `{"ok":true}`)
+	assertS3ObjectContains(t, ctx, h.rawS3, "published", "dst/a/HTH-2025-52023.html", "HTH-2025-52023")
+	assertObjectContains(t, h, "published", "openinfopub/sitemap/sitemap_pages_1.xml", second.PublicURL)
+	assertSitemapURLCount(t, h, second.PublicURL, 1)
+	assertWorkflowRowCountByPublicURL(t, h, pub.KindOpenInfoSitemap, second.PublicURL, 1)
+}
+
+// seedRestPublishSource creates the raw S3 objects used by the REST publish
+// payload. The filenames intentionally include a space so the test also
+// exercises publish-time filename sanitization.
+func seedRestPublishSource(t *testing.T, ctx context.Context, client *s3sdk.Client) {
+	t.Helper()
+	createBucket(t, ctx, client, "raw")
+	putObject(t, ctx, client, "raw", "src/a/response letter.pdf", "letter")
+	putObject(t, ctx, client, "raw", "src/a/package.json", `{"ok":true}`)
+}
+
+// newRESTPublishHandler wires the real REST publish handler against the
+// integration Postgres pool and S3 client. It mirrors the application wiring
+// closely enough to exercise sitemap claiming and result persistence.
 func newRESTPublishHandler(t *testing.T, h sitemapHarness) http.Handler {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -78,6 +128,9 @@ func newRESTPublishHandler(t *testing.T, h sitemapHarness) http.Handler {
 	return handlers.Publications(orchestrator)
 }
 
+// publishCycleSitemapWriter returns one sitemap writer shared by publish and
+// unpublish paths so the test uses the same sitemap bucket and key layout
+// through the full lifecycle.
 func publishCycleSitemapWriter(h sitemapHarness) *sitemapping.Writer {
 	target := sitemapping.Target{
 		Bucket:          "published",
@@ -95,6 +148,8 @@ func publishCycleSitemapWriter(h sitemapHarness) *sitemapping.Writer {
 	})
 }
 
+// postPublication sends a wrapped REST publish request and fails the test on
+// any non-OK response, returning the decoded response for follow-up assertions.
 func postPublication(t *testing.T, handler http.Handler, body []byte) publishnow.Response {
 	t.Helper()
 	rec := httptest.NewRecorder()
@@ -110,6 +165,8 @@ func postPublication(t *testing.T, handler http.Handler, body []byte) publishnow
 	return resp
 }
 
+// restPublishBody builds the wrapped JSON shape expected by the /publications
+// REST endpoint.
 func restPublishBody() []byte {
 	payload := map[string]any{
 		"tenant_id":       "a7d9b2f1-4c3e-4e8b-9a21-1c2e8f7b9d10",
@@ -262,5 +319,27 @@ func assertS3ObjectMissingText(t *testing.T, ctx context.Context, client *s3sdk.
 	}
 	if bytes.Contains(body, []byte(text)) {
 		t.Fatalf("%s/%s contains %q, want removed:\n%s", bucket, key, text, body)
+	}
+}
+
+func assertSitemapURLCount(t *testing.T, h sitemapHarness, publicURL string, want int) {
+	t.Helper()
+	body := readObject(t, h, "published", "openinfopub/sitemap/sitemap_pages_1.xml")
+	if got := bytes.Count(body, []byte(publicURL)); got != want {
+		t.Fatalf("sitemap public URL count = %d, want %d\n%s", got, want, body)
+	}
+}
+
+func assertWorkflowRowCountByPublicURL(t *testing.T, h sitemapHarness, kind pub.Kind, publicURL string, want int) {
+	t.Helper()
+	var got int
+	if err := h.pool.QueryRow(h.ctx,
+		`SELECT count(*) FROM workflow_request WHERE kind=$1 AND payload->>'public_url'=$2`,
+		string(kind), publicURL,
+	).Scan(&got); err != nil {
+		t.Fatalf("count workflow rows for %s: %v", publicURL, err)
+	}
+	if got != want {
+		t.Fatalf("workflow rows for %s = %d, want %d", publicURL, got, want)
 	}
 }

--- a/publication-service/internal/sitemapping/request_repo.go
+++ b/publication-service/internal/sitemapping/request_repo.go
@@ -1,6 +1,9 @@
 package sitemapping
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -11,15 +14,19 @@ import (
 // RequestRepo stores sitemap-specific completion results in workflow_request.
 type RequestRepo struct {
 	*workflowresult.Repo[Result]
+	pool *pgxpool.Pool
 }
 
 // NewRequestRepo constructs a RequestRepo around a pgxpool.
 func NewRequestRepo(pool *pgxpool.Pool) *RequestRepo {
-	return &RequestRepo{Repo: workflowresult.NewRepo[Result](
-		pool,
-		"sitemapping.RequestRepo",
-		workflowresult.CompletedAt[Result]{Get: sitemapCompletedAt, Set: setSitemapCompletedAt},
-	)}
+	return &RequestRepo{
+		Repo: workflowresult.NewRepo[Result](
+			pool,
+			"sitemapping.RequestRepo",
+			workflowresult.CompletedAt[Result]{Get: sitemapCompletedAt, Set: setSitemapCompletedAt},
+		),
+		pool: pool,
+	}
 }
 
 func sitemapCompletedAt(result *Result) time.Time {
@@ -28,4 +35,49 @@ func sitemapCompletedAt(result *Result) time.Time {
 
 func setSitemapCompletedAt(result *Result, completedAt time.Time) {
 	result.CompletedAt = completedAt
+}
+
+func (r *RequestRepo) MarkSucceeded(ctx context.Context, eventID string, result Result) error {
+	if result.CompletedAt.IsZero() {
+		result.CompletedAt = time.Now().UTC()
+	}
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("sitemapping.RequestRepo.MarkSucceeded: marshal result: %w", err)
+	}
+	const q = `
+WITH target AS (
+    SELECT event_id
+    FROM workflow_request
+    WHERE event_id=$1
+    UNION ALL
+    SELECT event_id
+    FROM workflow_request
+    WHERE kind=$4
+      AND tenant_id=$5
+      AND payload->>'public_url'=$6
+      AND NOT EXISTS (
+          SELECT 1
+          FROM workflow_request
+          WHERE event_id=$1
+      )
+    LIMIT 1
+)
+UPDATE workflow_request
+SET state='completed',
+    completed_at=$2,
+    last_error=NULL,
+    last_error_class=NULL,
+    error_hash=NULL,
+    error_hash_repeat=0,
+    result=$3
+WHERE event_id=(SELECT event_id FROM target)`
+	tag, err := r.pool.Exec(ctx, q, eventID, result.CompletedAt, raw, string(result.Kind), result.TenantID, result.PublicURL)
+	if err != nil {
+		return fmt.Errorf("sitemapping.RequestRepo.MarkSucceeded: %w", err)
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("sitemapping.RequestRepo.MarkSucceeded: %s not found", eventID)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

  This PR adds an integration test for the publish/unpublish/republish flow:

  - Publish using the REST API
  - Unpublish using a publication.unpublish.requested event
  - Publish again using the REST API
  - Verify files are copied back to S3
  - Verify the sitemap is updated again after republish

  It also fixes the sitemap workflow persistence issue exposed by that test.

  ## Why

  REST publish creates a new event ID each time. On republish, the sitemap claim can collide with the existing sitemap workflow row for the same public URL. In that case, no new workflow_request row exists for the new REST event ID, so sitemapping.RequestRepo.MarkSucceeded failed with:

  sitemapping.RequestRepo.MarkSucceeded: <event-id> not found

  The fix keeps the normal event ID update path, but falls back to the existing sitemap workflow row matching kind + tenant_id + public_url. This aligns the update behavior with the sitemap uniqueness/idempotency model and allows REST republish after event unpublish to complete successfully.