### PR TITLE
Ticket 2470: Creation of Redis Dedupe Service

### DIFF
--- a/request-management-api/request_api/resources/request.py
+++ b/request-management-api/request_api/resources/request.py
@@ -238,7 +238,7 @@ class FOIRawRequests(Resource):
                 if result.success:
                     documentservice().uploadpersonaldocuments(result.identifier, attachments)                   
                 return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
-            return {'status': False, 'message':"Duplicate Request. Request was not processed."} , 200
+            return {'status': False, 'message':"Duplicate Request. Request was not processed, please try again later.", "id": None} , 200
         except TypeError:
             return {'status': "TypeError", 'message':"Error while parsing JSON in request"}, 500   
         except BusinessException as exception:            

--- a/request-management-api/request_api/resources/request.py
+++ b/request-management-api/request_api/resources/request.py
@@ -238,7 +238,7 @@ class FOIRawRequests(Resource):
                 if result.success:
                     documentservice().uploadpersonaldocuments(result.identifier, attachments)                   
                 return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
-            return {'status': False, 'message':"Duplicate Request. Request was not processed, please try again later.", "id": None} , 200
+            return {'status': False, 'message':"Duplicate Request. Request was not processed, please try again later."}, 409
         except TypeError:
             return {'status': "TypeError", 'message':"Error while parsing JSON in request"}, 500   
         except BusinessException as exception:            

--- a/request-management-api/request_api/resources/request.py
+++ b/request-management-api/request_api/resources/request.py
@@ -26,6 +26,7 @@ from request_api.services.rawrequestservice import rawrequestservice
 from request_api.services.documentservice import documentservice
 from request_api.services.eventservice import eventservice
 from request_api.services.unopenedreportservice import unopenedreportservice
+from request_api.services.deduplicate_request_service.request_deduplication_service import RequestDeduplicationService
 from request_api.utils.enums import StateName
 import json
 import asyncio
@@ -216,24 +217,28 @@ class FOIRawRequests(Resource):
         """ POST Method for capturing RAW FOI requests before processing"""
         try:
             request_json = request.get_json()
-            requestdatajson = request_json['requestData']  
+            requestdatajson = request_json['requestData']
+            # Call dedupe request service to ensure foi request sent from foirequests webform is not a duplicate
+            request_dedupe_service = RequestDeduplicationService(requestdatajson)
+            is_duplicate_request = request_dedupe_service.dedupe_service()
+            if not is_duplicate_request:
+                #add received date to json
+                receiveddatetext = requestdatajson["receivedDateUF"] if 'receivedDateUF' in requestdatajson else datetime.now(pytz.timezone("America/Vancouver")).strftime(LONG_DATE_FORMAT)
+                receiveddate = _skiptoworkday(receiveddatetext, 0)
+                requestdatajson['receivedDate'] = receiveddate.strftime(SHORT_DATE_FORMAT)
+                requestdatajson['receivedDateUF'] = receiveddate.strftime(LONG_DATE_FORMAT)
 
-            #add received date to json
-            receiveddatetext = requestdatajson["receivedDateUF"] if 'receivedDateUF' in requestdatajson else datetime.now(pytz.timezone("America/Vancouver")).strftime(LONG_DATE_FORMAT)
-            receiveddate = _skiptoworkday(receiveddatetext, 0)
-            requestdatajson['receivedDate'] = receiveddate.strftime(SHORT_DATE_FORMAT)
-            requestdatajson['receivedDateUF'] = receiveddate.strftime(LONG_DATE_FORMAT)
-
-            #get attachments
-            attachments = requestdatajson['Attachments'] if 'Attachments' in requestdatajson else None
-            notes = 'Request submission from FOI WebForm'
-            #save request
-            if attachments is not None:
-                requestdatajson.pop('Attachments')
-            result = rawrequestservice().saverawrequest(requestdatajson=requestdatajson,sourceofsubmission="onlineform",userid=None,notes=notes)
-            if result.success:
-                documentservice().uploadpersonaldocuments(result.identifier, attachments)                   
-            return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
+                #get attachments
+                attachments = requestdatajson['Attachments'] if 'Attachments' in requestdatajson else None
+                notes = 'Request submission from FOI WebForm'
+                #save request
+                if attachments is not None:
+                    requestdatajson.pop('Attachments')
+                result = rawrequestservice().saverawrequest(requestdatajson=requestdatajson,sourceofsubmission="onlineform",userid=None,notes=notes)
+                if result.success:
+                    documentservice().uploadpersonaldocuments(result.identifier, attachments)                   
+                return {'status': result.success, 'message':result.message,'id':result.identifier} , 200
+            return {'status': False, 'message':"Duplicate Request. Request was not processed."} , 200
         except TypeError:
             return {'status': "TypeError", 'message':"Error while parsing JSON in request"}, 500   
         except BusinessException as exception:            

--- a/request-management-api/request_api/services/deduplicate_request_service/__init__.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/__init__.py
@@ -1,0 +1,1 @@
+"""Request Duplicate Validation Service"""

--- a/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
@@ -1,0 +1,55 @@
+import os
+import logging
+from datetime import datetime
+import redis
+from request_api.models.default_method_result import DefaultMethodResult
+from walrus import Database
+
+REDIS_KEY_TTL_SECONDS = 1800
+KEY_PREFIX = "foirequest-dedupe:"
+
+class RedisService:
+    """Redis service to connect, store and find keys in foiflow redis"""
+    def __init__(self):
+        self.host = os.getenv("PUBLICATION_REDIS_HOST", "localhost")
+        self.port = int(os.getenv("PUBLICATION_REDIS_PORT", 6379))
+        self.password = os.getenv("PUBLICATION_REDIS_PASSWORD")
+        self.client = redis.Redis(
+            host=self.host,
+            port=self.password,
+            db=0,
+            password=self.password,
+            decode_responses=True
+        )
+
+    def add_key(self, hashed_payload):
+        try:
+            logging.info(
+                "Adding foirequest-dedupe key to redis | ",
+                "redis_key=%s",
+                KEY_PREFIX + hashed_payload
+            )
+            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            self.client.set(KEY_PREFIX + hashed_payload, timestamp, ex=REDIS_KEY_TTL_SECONDS)
+            return DefaultMethodResult(True, 'Key added to redis service', KEY_PREFIX + hashed_payload)
+        except Exception as exception:
+           logging.exception(
+               "Error in accessing to Redis",
+                exception,
+            )
+           raise exception
+
+    def find_key(self, hashed_payload):
+        try:
+            logging.info(
+                "Looking for foirequest-dedupe key in redis | "
+                "redis_key=%s",
+                KEY_PREFIX + hashed_payload
+            )
+            return self.client.exists(KEY_PREFIX + hashed_payload)
+        except Exception as exception:
+            logging.exception(
+               "Error in accessing to Redis",
+                exception,
+            )
+            raise exception

--- a/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
@@ -16,7 +16,7 @@ class RedisService:
         self.password = os.getenv("PUBLICATION_REDIS_PASSWORD")
         self.client = redis.Redis(
             host=self.host,
-            port=self.password,
+            port=self.port,
             db=0,
             password=self.password,
             decode_responses=True
@@ -25,19 +25,16 @@ class RedisService:
     def add_key(self, hashed_payload):
         try:
             logging.info(
-                "Adding foirequest-dedupe key to redis | ",
+                "Adding foirequest-dedupe key to redis | "
                 "redis_key=%s",
                 KEY_PREFIX + hashed_payload
             )
             timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            self.client.set(KEY_PREFIX + hashed_payload, timestamp, ex=REDIS_KEY_TTL_SECONDS)
+            self.client.set(KEY_PREFIX + hashed_payload, timestamp, ex=int(REDIS_KEY_TTL_SECONDS))
             return DefaultMethodResult(True, 'Key added to redis service', KEY_PREFIX + hashed_payload)
-        except Exception as exception:
-           logging.exception(
-               "Error in accessing Redis",
-                exception,
-            )
-           raise exception
+        except Exception:
+           logging.exception("Error in accessing Redis")
+           raise
 
     def find_key(self, hashed_payload):
         try:
@@ -47,9 +44,6 @@ class RedisService:
                 KEY_PREFIX + hashed_payload
             )
             return self.client.exists(KEY_PREFIX + hashed_payload)
-        except Exception as exception:
-            logging.exception(
-               "Error in accessing Redis",
-                exception,
-            )
-            raise exception
+        except Exception:
+            logging.exception("Error in accessing Redis")
+            raise

--- a/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
@@ -34,7 +34,7 @@ class RedisService:
             return DefaultMethodResult(True, 'Key added to redis service', KEY_PREFIX + hashed_payload)
         except Exception as exception:
            logging.exception(
-               "Error in accessing to Redis",
+               "Error in accessing Redis",
                 exception,
             )
            raise exception
@@ -49,7 +49,7 @@ class RedisService:
             return self.client.exists(KEY_PREFIX + hashed_payload)
         except Exception as exception:
             logging.exception(
-               "Error in accessing to Redis",
+               "Error in accessing Redis",
                 exception,
             )
             raise exception

--- a/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
@@ -43,7 +43,7 @@ class RedisService:
                 "redis_key=%s",
                 KEY_PREFIX + hashed_payload
             )
-            return self.client.exists(KEY_PREFIX + hashed_payload)
+            return bool(self.client.exists(KEY_PREFIX + hashed_payload))
         except Exception:
             logging.exception("Error in accessing Redis")
             raise

--- a/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
@@ -5,7 +5,7 @@ import redis
 from request_api.models.default_method_result import DefaultMethodResult
 from walrus import Database
 
-REDIS_KEY_TTL_SECONDS = 1800
+REDIS_KEY_TTL_SECONDS = os.getenv("FOIREQUEST_DEDUPE_REDIS_KEY_TTL", 1800)
 KEY_PREFIX = "foirequest-dedupe:"
 
 class RedisService:

--- a/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/redis_service.py
@@ -5,7 +5,7 @@ import redis
 from request_api.models.default_method_result import DefaultMethodResult
 from walrus import Database
 
-REDIS_KEY_TTL_SECONDS = os.getenv("FOIREQUEST_DEDUPE_REDIS_KEY_TTL", 1800)
+REDIS_KEY_TTL_SECONDS = os.getenv("FOIREQUEST_DEDUPE_REDIS_KEY_TTL", "1800")
 KEY_PREFIX = "foirequest-dedupe:"
 
 class RedisService:

--- a/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
@@ -1,33 +1,33 @@
-from redis_service import RedisService
+from .redis_service import RedisService
 import hashlib
 import logging
 import json
 from request_api.models.default_method_result import DefaultMethodResult
 
 class RequestDeduplicationService:
-    """Validate/deduplicate FOI request received from foirequests webform by pushhing and retrieving hashed request payloads from redis stream"""
+    """Validate/deduplicate FOI request received from foirequests webform by caching and checking a hash of the request payload in Redis."""
+    
     def __init__(self, request_payload, redis_service = None):
-        self.request_paylod = request_payload
+        self.request_payload = request_payload
         self.redis_service = redis_service or RedisService()
 
     def dedupe_service(self):
         try:
-            if self.request_paylod in ({}, None):
-                raise Exception
+            if self.request_payload in ({}, None):
+                logging.info("FOI request dedupe service skipped: empty request payload")
+                return False
             logging.info(
-                "FOI request dedupe service started | ",
+                "FOI request dedupe service started | "
                 "request_data=%s",
-                self.request_paylod
+                self.request_payload
             )
             encrypted_payload = self._hash_payload()
             duplicate_payload = self.redis_service.find_key(encrypted_payload)
             if not duplicate_payload:
                 logging.info(
-                    "No duplicate FOI request found | ",
+                    "No duplicate FOI request found | "
                     "hash=%s",
                     encrypted_payload,
-                    "request_data=%s",
-                    self.request_paylod
                 )
                 self.redis_service.add_key(encrypted_payload)
                 return False
@@ -35,17 +35,12 @@ class RequestDeduplicationService:
                 "Duplicate FOI request found | "
                 "hash=%s",
                 encrypted_payload
-                "request_data=%s"
-                self.request_paylod
             )
             return True
-        except Exception as exception:
-            logging.exception(
-                "Error in foi request deduplication process. Deduplication skipped",
-                exception,
-            )
+        except Exception:
+            logging.exception("FOI request dedupe service skipped: Error in foi request deduplication process")
             return False
         
     def _hash_payload(self):
-        serialized_data = json.dumps(self.request_paylod, sort_keys=True, separators=(',', ':'))
+        serialized_data = json.dumps(self.request_payload, sort_keys=True, separators=(',', ':'))
         return hashlib.sha256(serialized_data.encode('utf-8')).hexdigest()

--- a/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
@@ -6,8 +6,6 @@ from request_api.models.default_method_result import DefaultMethodResult
 
 class RequestDeduplicationService:
     """Validate/deduplicate FOI request received from foirequests webform by pushhing and retrieving hashed request payloads from redis stream"""
-    # ADD LOGS TO ERROR HANLDINGS AND PROCESS OF REDIS AND SEVICE AND ADD LOGS TO HELP FIND THE ROOT ISSUE
-    # ADDRESS issue 1 from copilot - > race condiiton
     def __init__(self, request_payload, redis_service = None):
         self.request_paylod = request_payload
         self.redis_service = redis_service or RedisService()

--- a/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
@@ -13,7 +13,7 @@ class RequestDeduplicationService:
 
     def dedupe_service(self):
         try:
-            if self.request_payload in ({}, None):
+            if self.request_payload is None or self.request_payload == {}:
                 logging.info("FOI request dedupe service skipped: empty request payload")
                 return False
             logging.info(
@@ -21,20 +21,20 @@ class RequestDeduplicationService:
                 "request_data=%s",
                 self.request_payload
             )
-            encrypted_payload = self._hash_payload()
-            duplicate_payload = self.redis_service.find_key(encrypted_payload)
+            hashed_payload = self._hash_payload()
+            duplicate_payload = self.redis_service.find_key(hashed_payload)
             if not duplicate_payload:
                 logging.info(
                     "No duplicate FOI request found | "
                     "hash=%s",
-                    encrypted_payload,
+                    hashed_payload,
                 )
-                self.redis_service.add_key(encrypted_payload)
+                self.redis_service.add_key(hashed_payload)
                 return False
             logging.info(
                 "Duplicate FOI request found | "
                 "hash=%s",
-                encrypted_payload
+                hashed_payload
             )
             return True
         except Exception:

--- a/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
@@ -1,0 +1,53 @@
+from redis_service import RedisService
+import hashlib
+import logging
+import json
+from request_api.models.default_method_result import DefaultMethodResult
+
+class RequestDeduplicationService:
+    """Validate/deduplicate FOI request received from foirequests webform by pushhing and retrieving hashed request payloads from redis stream"""
+    # ADD LOGS TO ERROR HANLDINGS AND PROCESS OF REDIS AND SEVICE AND ADD LOGS TO HELP FIND THE ROOT ISSUE
+    # ADDRESS issue 1 from copilot - > race condiiton
+    def __init__(self, request_payload, redis_service = None):
+        self.request_paylod = request_payload
+        self.redis_service = redis_service or RedisService()
+
+    def dedupe_service(self):
+        try:
+            if self.request_paylod in ({}, None):
+                raise Exception
+            logging.info(
+                "FOI request dedupe service started | ",
+                "request_data=%s",
+                self.request_paylod
+            )
+            encrypted_payload = self._hash_payload()
+            duplicate_payload = self.redis_service.find_key(encrypted_payload)
+            if not duplicate_payload:
+                logging.info(
+                    "No duplicate FOI request found | ",
+                    "hash=%s",
+                    encrypted_payload,
+                    "request_data=%s",
+                    self.request_paylod
+                )
+                self.redis_service.add_key(encrypted_payload)
+                return False
+            logging.info(
+                "Duplicate FOI request found | "
+                "hash=%s",
+                encrypted_payload
+                "request_data=%s"
+                self.request_paylod
+            )
+            return True
+        except Exception as exception:
+            logging.exception(
+                "Error in foi request deduplication process. Deduplication skipped",
+                exception,
+            )
+            return False
+        
+    def _hash_payload(self):
+        serialized_data = json.dumps(self.request_paylod, sort_keys=True, separators=(',', ':'))
+        return hashlib.sha256(serialized_data.encode('utf-8')).hexdigest()


### PR DESCRIPTION
To address the issue of duplicate raw requests being created via webform -> a deduplication request redis service is created.

Solution → Create a redis service that hashes rawrequest payload data which is cached for 30mins. Implement this redis service at endpoint where raw requests are created. 

Before a raw request is created, verify if new request payload data does not exist in redis cache (where previous rawrequest payloads have been hashed and saved) → if data exists, skip rawrequest creation → if data does not exist, hash and cache the payload to redis and continue with creation of rawrequest. If duplicate exists, FE user on webform app is alerted with a message stating duplicate exsits, if no duplicate, FE user on webform app continues on with process (payment etc)

If any error occurs with deduplication service (with redis etc) do not mark request as duplicate and add to DB. 