### PR TITLE
Ticket 2470: Normalization of request_data before hashing

### DIFF
--- a/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
+++ b/request-management-api/request_api/services/deduplicate_request_service/request_deduplication_service.py
@@ -42,5 +42,10 @@ class RequestDeduplicationService:
             return False
         
     def _hash_payload(self):
+        self._normalize_request_data(self.request_payload)
         serialized_data = json.dumps(self.request_payload, sort_keys=True, separators=(',', ':'))
         return hashlib.sha256(serialized_data.encode('utf-8')).hexdigest()
+    
+    def _normalize_request_data(self, request_data):
+        request_data.pop("requestId", None)
+        request_data.pop("receivedDateUF", None)

--- a/request-management-api/request_api/services/rawrequestservice.py
+++ b/request-management-api/request_api/services/rawrequestservice.py
@@ -120,7 +120,7 @@ class rawrequestservice:
         skip_unopened_applicantprofile_creation = currentstatus is not None and nextstate is not None and ((currentstatus == StateName.unopened.value and nextstate == StateName.closed.value) or (nextstate == StateName.unopened.value and currentstatus == StateName.closed.value))    
         
         # LDD Extension Checks
-        if currentstatus is not (None, ""):
+        if currentstatus not in (None, ""):
             # Check for App Fee Owing
             state_offhold_date = datetimehandler().gettoday()
             if currentstatus == StateName.appfeeowing.value:

--- a/request-management-api/request_api/services/requestservice.py
+++ b/request-management-api/request_api/services/requestservice.py
@@ -53,7 +53,7 @@ class requestservice:
     ):
         # LDD Extension Checks
         currentstatus = foirequestschema["currentState"] if "currentState" in foirequestschema else None
-        if currentstatus is not (None, ""):
+        if currentstatus not in (None, ""):
             state_offhold_date = datetimehandler().gettoday()
             if currentstatus == StateName.appfeeowing.value:
                 appfeeowing_transition_date = foirequestschema["lastStatusUpdateDate"]


### PR DESCRIPTION
1. requestId and receivedDateUF (timestamp of when the request was submitted) are varying from request to request and are determined systematically by our FOI systems. Therefore to create a stable hash these are removed, so that the data that is being hashed, then compared is stable. 
2. adjusted a if condiiton that was causing warnings in api (sytnax issues)