### PR TITLE
Cherry-picks PR #6260 from dev to main.

### DIFF
--- a/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
+++ b/forms-flow-web/src/components/FOI/FOIRequest/FOIRequest.js
@@ -2302,6 +2302,7 @@ const FOIRequest = React.memo(({ userDetail, openApplicantProfileModal }) => {
             >
               {!isLoading && applicantCorrespondence ? (
                 <ContactApplicant
+                  key={`${requestId}-${ministryId}`}
                   requestNumber={requestNumber}
                   requestState={requestState}
                   ministryId={ministryId}

--- a/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.test.tsx
+++ b/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import { ContactApplicant } from "./index";
+
+const mockStore = configureStore([]);
+
+const baseState = {
+  foiRequests: {
+    foiRequestDetail: { bcgovcode: "MIN", currentState: "Open" },
+    foiRequestCFRFormHistory: [],
+    foiRequestExtesions: [],
+    foiFullCorrespondenceTemplates: [],
+    foiEmailTemplates: [],
+    foiRequestCFRForm: {},
+    isCorrespondenceLoading: false,
+    foiPDFStitchStatusForResponsePackage: null,
+  },
+  user: { userDetail: { preferred_username: "tester" } },
+};
+
+const baseProps = (overrides: Partial<any> = {}) => ({
+  requestNumber: "MIN-2026-00001",
+  requestState: "Open",
+  ministryId: 1,
+  ministryCode: "MIN",
+  applicantCorrespondence: [],
+  requestId: 100,
+  isProactiveDisclosure: false,
+  ...overrides,
+});
+
+describe("ContactApplicant state isolation (FOIMOD-4270)", () => {
+  it("mounts with empty files list", () => {
+    const store = mockStore(baseState);
+    render(
+      <Provider store={store}>
+        <ContactApplicant {...baseProps()} />
+      </Provider>
+    );
+    // No attachment chips should be present on initial render
+    expect(screen.queryByTestId("attachment-chip")).toBeNull();
+  });
+
+  it("clears files when requestId changes (defensive reset)", () => {
+    const store = mockStore(baseState);
+    const { rerender } = render(
+      <Provider store={store}>
+        <ContactApplicant {...baseProps({ requestId: 100 })} />
+      </Provider>
+    );
+    rerender(
+      <Provider store={store}>
+        <ContactApplicant {...baseProps({ requestId: 200 })} />
+      </Provider>
+    );
+    expect(screen.queryByTestId("attachment-chip")).toBeNull();
+  });
+});
+
+import * as ossServices from "../../../../apiManager/services/FOI/foiOSSServices";
+
+jest.mock("../../../../apiManager/services/FOI/foiOSSServices", () => ({
+  getOSSHeaderDetails: jest.fn(),
+  saveFilesinS3: jest.fn(),
+  getFileFromS3: jest.fn(),
+}));
+
+describe("saveAttachments filename-collision pairing (FOIMOD-4270)", () => {
+  it("pairs two same-named files by index, not by filename", async () => {
+    const fileA = new File(["A"], "P-Acknowledgement.pdf", { type: "application/pdf" });
+    const fileB = new File(["B"], "P-Acknowledgement.pdf", { type: "application/pdf" });
+
+    (ossServices.getOSSHeaderDetails as jest.Mock).mockResolvedValue({
+      data: [
+        { filename: "P-Acknowledgement.pdf", filepath: "s3://.../MIN/MIN-2026-00001/a" },
+        { filename: "P-Acknowledgement.pdf", filepath: "s3://.../MIN/MIN-2026-00001/b" },
+      ],
+    });
+
+    const captured: Array<{ file: File; header: any }> = [];
+    (ossServices.saveFilesinS3 as jest.Mock).mockImplementation(
+      async (header: any, file: File, _dispatch: any, cb: any) => {
+        captured.push({ file, header });
+        cb(null, 200);
+      }
+    );
+
+    const { saveAttachmentsPure } = await import("./saveAttachments");
+    const result = await saveAttachmentsPure(
+      [fileA, fileB],
+      { ministryCode: "MIN", requestNumber: "MIN-2026-00001", requestId: 100, dispatch: () => {} }
+    );
+
+    expect(captured).toHaveLength(2);
+    expect(captured[0].file).toBe(fileA);
+    expect(captured[1].file).toBe(fileB);
+    expect(result[0].url).toContain("/a");
+    expect(result[1].url).toContain("/b");
+  });
+});

--- a/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.test.tsx
+++ b/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.test.tsx
@@ -98,4 +98,44 @@ describe("saveAttachments filename-collision pairing (FOIMOD-4270)", () => {
     expect(result[0].url).toContain("/a");
     expect(result[1].url).toContain("/b");
   });
+
+  it("aborts upload and returns empty list when header count does not match file count", async () => {
+    const fileA = new File(["A"], "a.pdf", { type: "application/pdf" });
+    const fileB = new File(["B"], "b.pdf", { type: "application/pdf" });
+
+    (ossServices.getOSSHeaderDetails as jest.Mock).mockResolvedValue({
+      // Only one header returned for two files → must not upload either.
+      data: [{ filename: "a.pdf", filepath: "s3://.../MIN/MIN-2026-00001/a" }],
+    });
+    (ossServices.saveFilesinS3 as jest.Mock).mockImplementation(
+      async (_header: any, _file: File, _dispatch: any, cb: any) => {
+        cb(null, 200);
+      }
+    );
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await saveAttachmentsPure(
+      [fileA, fileB],
+      { ministryCode: "MIN", requestNumber: "MIN-2026-00001", requestId: 100, dispatch: () => {} }
+    );
+
+    expect(result).toEqual([]);
+    expect(ossServices.saveFilesinS3).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("returns empty list without calling OSS when there are no files", async () => {
+    (ossServices.getOSSHeaderDetails as jest.Mock).mockClear();
+    (ossServices.saveFilesinS3 as jest.Mock).mockClear();
+
+    const result = await saveAttachmentsPure(
+      [{ notAFile: true }],
+      { ministryCode: "MIN", requestNumber: "MIN-2026-00001", requestId: 100, dispatch: () => {} }
+    );
+
+    expect(result).toEqual([]);
+    expect(ossServices.getOSSHeaderDetails).not.toHaveBeenCalled();
+    expect(ossServices.saveFilesinS3).not.toHaveBeenCalled();
+  });
 });

--- a/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.test.tsx
+++ b/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { ContactApplicant } from "./index";
@@ -40,20 +40,29 @@ const baseProps = (overrides: Partial<any> = {}) => ({
 });
 
 describe("ContactApplicant state isolation (FOIMOD-4270)", () => {
-  it("mounts with empty files list", () => {
+  // NOTE: these are smoke/regression tests. ContactApplicant renders attachments
+  // via `<div className="email-attachment-item">` and its `files` state is only
+  // populated by user interaction with the internal file picker, which is not
+  // easily driven from a unit test. Full end-to-end validation of the
+  // request-switch reset lives in the manual smoke checklist for FOIMOD-4270.
+  // What these tests do assert:
+  //   1. The component mounts cleanly with an empty file list.
+  //   2. Rerendering with a different requestId does not throw and produces
+  //      zero attachment items in the DOM (the useEffect + parent key prop
+  //      guarantee a fresh render).
+  it("mounts with no attachment items in the DOM", () => {
     const store = mockStore(baseState);
-    render(
+    const { container } = render(
       <Provider store={store}>
         <ContactApplicant {...baseProps()} />
       </Provider>
     );
-    // No attachment chips should be present on initial render
-    expect(screen.queryByTestId("attachment-chip")).toBeNull();
+    expect(container.querySelectorAll(".email-attachment-item")).toHaveLength(0);
   });
 
-  it("clears files when requestId changes (defensive reset)", () => {
+  it("renders cleanly with zero attachment items after switching requestId", () => {
     const store = mockStore(baseState);
-    const { rerender } = render(
+    const { rerender, container } = render(
       <Provider store={store}>
         <ContactApplicant {...baseProps({ requestId: 100 })} />
       </Provider>
@@ -63,7 +72,7 @@ describe("ContactApplicant state isolation (FOIMOD-4270)", () => {
         <ContactApplicant {...baseProps({ requestId: 200 })} />
       </Provider>
     );
-    expect(screen.queryByTestId("attachment-chip")).toBeNull();
+    expect(container.querySelectorAll(".email-attachment-item")).toHaveLength(0);
   });
 });
 

--- a/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.test.tsx
+++ b/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.test.tsx
@@ -3,6 +3,14 @@ import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { ContactApplicant } from "./index";
+import * as ossServices from "../../../../apiManager/services/FOI/foiOSSServices";
+import { saveAttachmentsPure } from "./saveAttachments";
+
+jest.mock("../../../../apiManager/services/FOI/foiOSSServices", () => ({
+  getOSSHeaderDetails: jest.fn(),
+  saveFilesinS3: jest.fn(),
+  getFileFromS3: jest.fn(),
+}));
 
 const mockStore = configureStore([]);
 
@@ -59,14 +67,6 @@ describe("ContactApplicant state isolation (FOIMOD-4270)", () => {
   });
 });
 
-import * as ossServices from "../../../../apiManager/services/FOI/foiOSSServices";
-
-jest.mock("../../../../apiManager/services/FOI/foiOSSServices", () => ({
-  getOSSHeaderDetails: jest.fn(),
-  saveFilesinS3: jest.fn(),
-  getFileFromS3: jest.fn(),
-}));
-
 describe("saveAttachments filename-collision pairing (FOIMOD-4270)", () => {
   it("pairs two same-named files by index, not by filename", async () => {
     const fileA = new File(["A"], "P-Acknowledgement.pdf", { type: "application/pdf" });
@@ -87,7 +87,6 @@ describe("saveAttachments filename-collision pairing (FOIMOD-4270)", () => {
       }
     );
 
-    const { saveAttachmentsPure } = await import("./saveAttachments");
     const result = await saveAttachmentsPure(
       [fileA, fileB],
       { ministryCode: "MIN", requestNumber: "MIN-2026-00001", requestId: 100, dispatch: () => {} }

--- a/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.tsx
+++ b/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.tsx
@@ -22,7 +22,7 @@ import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import CommunicationStructure from './CommunicationStructure'
 import AttachmentModal from '../Attachments/AttachmentModal';
-import { getOSSHeaderDetails, saveFilesinS3, getFileFromS3 } from "../../../../apiManager/services/FOI/foiOSSServices";
+import { getOSSHeaderDetails, getFileFromS3 } from "../../../../apiManager/services/FOI/foiOSSServices";
 import { saveAttachmentsPure } from "./saveAttachments";
 import { dueDateCalculation } from '../../FOIRequest/BottomButtonGroup/utils';
 import { PAYMENT_EXPIRY_DAYS } from "../../../../constants/FOI/constants";

--- a/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.tsx
+++ b/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/index.tsx
@@ -23,6 +23,7 @@ import 'react-quill/dist/quill.snow.css';
 import CommunicationStructure from './CommunicationStructure'
 import AttachmentModal from '../Attachments/AttachmentModal';
 import { getOSSHeaderDetails, saveFilesinS3, getFileFromS3 } from "../../../../apiManager/services/FOI/foiOSSServices";
+import { saveAttachmentsPure } from "./saveAttachments";
 import { dueDateCalculation } from '../../FOIRequest/BottomButtonGroup/utils';
 import { PAYMENT_EXPIRY_DAYS } from "../../../../constants/FOI/constants";
 import { PreviewModal } from './PreviewModal';
@@ -577,6 +578,12 @@ export const ContactApplicant = ({
   const requestExtensions: any = useSelector((state: any) => state.foiRequests.foiRequestExtesions);
 
   const [files, setFiles] = useState<any[]>([]);
+
+  useEffect(() => {
+    clearcorrespondence();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requestId, ministryId]);
+
   const [templates, setTemplates] = useState<any[]>([{ value: "", label: "", templateid: null, text: "", disabled: true, created_at: "" }]);
   const [initialTemplates, setInitialTemplates] = useState<any[]>([{ value: "", label: "", templateid: null, text: "", disabled: true, created_at: "" }]);
 
@@ -851,37 +858,12 @@ export const ContactApplicant = ({
   };
 
   const saveAttachments = async (attachmentfiles: any) => {
-    attachmentfiles = attachmentfiles.filter((file: any) => {
-      return file instanceof File
-    }
-    )
-    const fileInfoList = attachmentfiles?.map((file: any) => {
-      return {
-        ministrycode: ministryCode,
-        requestnumber: requestNumber ? requestNumber : `U-00${requestId}`,
-        filestatustransition: 'email-attachment',
-        filename: file.filename ? file.filename : file.name,
-      }
+    return saveAttachmentsPure(attachmentfiles, {
+      ministryCode,
+      requestNumber,
+      requestId,
+      dispatch,
     });
-    let attachments: any = [];
-    try {
-      const response = await getOSSHeaderDetails(fileInfoList, dispatch);
-      for (let header of response.data) {
-        const _file = attachmentfiles.find((file: any) => file.filename === header.filename);
-        await saveFilesinS3(header, _file, dispatch, (_err: any, _res: any) => {
-          if (_res === 200) {
-            attachments.push({ filename: header.filename, url: header.filepath })
-            console.log("success")
-          }
-          else {
-            console.log("failure")
-          }
-        })
-      }
-    } catch (error) {
-      console.log(error)
-    }
-    return attachments
   }
 
   // send email

--- a/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/saveAttachments.ts
+++ b/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/saveAttachments.ts
@@ -1,0 +1,42 @@
+import {
+  getOSSHeaderDetails,
+  saveFilesinS3,
+} from "../../../../apiManager/services/FOI/foiOSSServices";
+
+export interface SaveAttachmentsCtx {
+  ministryCode: string;
+  requestNumber?: string;
+  requestId: number | string;
+  dispatch: any;
+}
+
+export async function saveAttachmentsPure(
+  attachmentfiles: any[],
+  ctx: SaveAttachmentsCtx
+): Promise<Array<{ filename: string; url: string }>> {
+  const onlyFiles = attachmentfiles.filter((file: any) => file instanceof File);
+  const fileInfoList = onlyFiles.map((file: any) => ({
+    ministrycode: ctx.ministryCode,
+    requestnumber: ctx.requestNumber ? ctx.requestNumber : `U-00${ctx.requestId}`,
+    filestatustransition: "email-attachment",
+    filename: file.filename ? file.filename : file.name,
+  }));
+
+  const attachments: Array<{ filename: string; url: string }> = [];
+  try {
+    const response = await getOSSHeaderDetails(fileInfoList, ctx.dispatch);
+    for (let i = 0; i < response.data.length; i++) {
+      const header = response.data[i];
+      const _file = onlyFiles[i]; // index-based pairing — filenames may collide
+      await saveFilesinS3(header, _file, ctx.dispatch, (_err: any, _res: any) => {
+        if (_res === 200) {
+          attachments.push({ filename: header.filename, url: header.filepath });
+        }
+      });
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error);
+  }
+  return attachments;
+}

--- a/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/saveAttachments.ts
+++ b/forms-flow-web/src/components/FOI/customComponents/ContactApplicant/saveAttachments.ts
@@ -23,10 +23,26 @@ export async function saveAttachmentsPure(
   }));
 
   const attachments: Array<{ filename: string; url: string }> = [];
+  if (onlyFiles.length === 0) {
+    return attachments;
+  }
   try {
     const response = await getOSSHeaderDetails(fileInfoList, ctx.dispatch);
-    for (let i = 0; i < response.data.length; i++) {
-      const header = response.data[i];
+    const headers: any[] = Array.isArray(response?.data) ? response.data : [];
+    // Fail safe: if the OSS service returned a different number of headers
+    // than files, we cannot trust index-based pairing (would mis-wire or
+    // pass undefined to saveFilesinS3). Abort the whole batch and log —
+    // the caller sees an empty attachments list rather than a silent
+    // cross-request leak.
+    if (headers.length !== onlyFiles.length) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `saveAttachmentsPure: OSS returned ${headers.length} headers for ${onlyFiles.length} files; aborting upload to prevent mis-pairing.`
+      );
+      return attachments;
+    }
+    for (let i = 0; i < headers.length; i++) {
+      const header = headers[i];
       const _file = onlyFiles[i]; // index-based pairing — filenames may collide
       await saveFilesinS3(header, _file, ctx.dispatch, (_err: any, _res: any) => {
         if (_res === 200) {

--- a/forms-flow-web/src/types/redux-mock-store.d.ts
+++ b/forms-flow-web/src/types/redux-mock-store.d.ts
@@ -1,0 +1,6 @@
+// Minimal ambient declaration so CRA's TypeScript build does not fail on
+// tests that import redux-mock-store. The package ships no types, and the
+// @types/redux-mock-store dev-dependency is not installed in the Docker
+// build image; a bare module declaration is enough because tests only use
+// the default export as a factory.
+declare module "redux-mock-store";

--- a/request-management-api/request_api/services/communicationwrapperservice.py
+++ b/request-management-api/request_api/services/communicationwrapperservice.py
@@ -115,10 +115,19 @@ class communicationwrapperservice:
                     requestnumber,
                 )
             else:
-                logger.warning(
-                    "Skipping attachment ownership check: missing ministrycode/requestnumber "
-                    "for ministryrequestid=%s", ministryrequestid
+                # Fail closed: if we cannot resolve the request's ownership
+                # coordinates we cannot verify any attachment belongs to it.
+                # Drop them all rather than leak a foreign attachment. Log at
+                # ERROR so this is alertable — it should never happen for a
+                # valid ministryrequestid.
+                original_count = len(applicantcorrespondencelog.get('attachments') or [])
+                logger.error(
+                    "Attachment ownership check could not resolve requestnumber/ministrycode "
+                    "for ministryrequestid=%s (requestnumber=%r ministrycode=%r); "
+                    "dropping %d attachment(s) to fail closed.",
+                    ministryrequestid, requestnumber, ministrycode, original_count,
                 )
+                applicantcorrespondencelog['attachments'] = []
         # Save correspondence log based on request type
         if ministryrequestid == 'None' or ministryrequestid is None or ("israwrequest" in applicantcorrespondencelog and applicantcorrespondencelog["israwrequest"]) is True:
             result = applicantcorrespondenceservice().saveapplicantcorrespondencelogforrawrequest(rawrequestid, applicantcorrespondencelog, AuthHelper.getuserid())

--- a/request-management-api/request_api/services/communicationwrapperservice.py
+++ b/request-management-api/request_api/services/communicationwrapperservice.py
@@ -9,6 +9,7 @@ import maya
 import json
 import logging
 from enum import Enum
+from urllib.parse import unquote, urlsplit
 from request_api.services.applicantcorrespondence.applicantcorrespondencelog import applicantcorrespondenceservice 
 from request_api.services.requestservice import requestservice
 from request_api.services.cfrfeeservice import cfrfeeservice
@@ -29,16 +30,31 @@ class communicationwrapperservice:
         """Filter out attachments whose S3 URL does not belong to this request.
 
         Expected S3 path convention: .../{ministrycode}/{requestnumber}/...
-        Any attachment whose URL does not contain that prefix is dropped
-        and logged as a WARNING (cross-request ownership violation).
+        The match is case-insensitive, path-segment bounded (leading and
+        trailing '/'), and evaluated against the URL path only — the
+        querystring and fragment are stripped so signed-URL parameters
+        (e.g. ?X-Amz-...) cannot cause false positives, and raw S3 keys
+        without a scheme are still accepted. Any attachment whose URL does
+        not contain that prefix is dropped and logged as a WARNING.
         """
         if not attachments:
             return attachments or []
-        expected_prefix = f"{ministrycode}/{requestnumber}/"
+        expected_segment = f"/{ministrycode}/{requestnumber}/".lower()
         valid, rejected = [], []
         for att in attachments:
-            url = att.get('url') or att.get('documenturipath') or ''
-            if expected_prefix in url:
+            raw = att.get('url') or att.get('documenturipath') or ''
+            if not raw:
+                rejected.append(att)
+                continue
+            # Extract just the path portion; for scheme-less raw keys
+            # urlsplit puts the whole string in .path.
+            path = urlsplit(raw).path or raw
+            # Normalize percent-encoding and ensure a leading slash so the
+            # first path segment is bounded on both sides for the match.
+            normalized = unquote(path).lower()
+            if not normalized.startswith('/'):
+                normalized = '/' + normalized
+            if expected_segment in normalized:
                 valid.append(att)
             else:
                 rejected.append(att)

--- a/request-management-api/request_api/services/communicationwrapperservice.py
+++ b/request-management-api/request_api/services/communicationwrapperservice.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import dateutil.parser
 import maya
 import json
+import logging
 from enum import Enum
 from request_api.services.applicantcorrespondence.applicantcorrespondencelog import applicantcorrespondenceservice 
 from request_api.services.requestservice import requestservice
@@ -18,9 +19,37 @@ from request_api.services.email.templates.templateconfig import templateconfig
 from request_api.services.emailservice import emailservice
 from request_api.schemas.foiemail import  FOIEmailSchema
 
+logger = logging.getLogger(__name__)
+
 class communicationwrapperservice:
     """ FOI communication wrapper service
     """
+
+    def _validate_attachment_ownership(self, attachments, ministrycode, requestnumber):
+        """Filter out attachments whose S3 URL does not belong to this request.
+
+        Expected S3 path convention: .../{ministrycode}/{requestnumber}/...
+        Any attachment whose URL does not contain that prefix is dropped
+        and logged as a WARNING (cross-request ownership violation).
+        """
+        if not attachments:
+            return attachments or []
+        expected_prefix = f"{ministrycode}/{requestnumber}/"
+        valid, rejected = [], []
+        for att in attachments:
+            url = att.get('url') or att.get('documenturipath') or ''
+            if expected_prefix in url:
+                valid.append(att)
+            else:
+                rejected.append(att)
+        if rejected:
+            logger.warning(
+                "Attachment ownership violation blocked: requestnumber=%s ministrycode=%s "
+                "rejected_count=%d rejected_filenames=%s",
+                requestnumber, ministrycode, len(rejected),
+                [a.get('filename') for a in rejected]
+            )
+        return valid
 
     def send_email(self, requestid, rawrequestid, ministryrequestid, applicantcorrespondencelog):
         # Get the correct email subject
@@ -42,6 +71,37 @@ class communicationwrapperservice:
         else:
             emailsubject = templateconfig().getsubject(template.name, attributes)
         applicantcorrespondencelog['emailsubject'] = emailsubject
+        # FOIMOD-4270 — reject attachments that do not belong to this request
+        if ministryrequestid not in ('None', None):
+            ministry = FOIMinistryRequest.getrequest(ministryrequestid) or {}
+            requestnumber = ministry.get('filenumber')
+            ministrycode = ministry.get('bcgovcode')
+            if not ministrycode:
+                # bcgovcode is joined via ProgramArea; fall back to direct SQL if missing
+                from request_api.models.db import db
+                from sqlalchemy import text
+                row = db.session.execute(
+                    text(
+                        'SELECT lower(pa.bcgovcode) AS bcgovcode '
+                        'FROM "FOIMinistryRequests" mr '
+                        'JOIN "ProgramAreas" pa ON pa.programareaid = mr.programareaid '
+                        'WHERE mr.foiministryrequestid = :mid '
+                        'ORDER BY mr.version DESC LIMIT 1'
+                    ),
+                    {"mid": ministryrequestid},
+                ).fetchone()
+                ministrycode = row[0] if row else None
+            if requestnumber and ministrycode:
+                applicantcorrespondencelog['attachments'] = self._validate_attachment_ownership(
+                    applicantcorrespondencelog.get('attachments', []),
+                    ministrycode,
+                    requestnumber,
+                )
+            else:
+                logger.warning(
+                    "Skipping attachment ownership check: missing ministrycode/requestnumber "
+                    "for ministryrequestid=%s", ministryrequestid
+                )
         # Save correspondence log based on request type
         if ministryrequestid == 'None' or ministryrequestid is None or ("israwrequest" in applicantcorrespondencelog and applicantcorrespondencelog["israwrequest"]) is True:
             result = applicantcorrespondenceservice().saveapplicantcorrespondencelogforrawrequest(rawrequestid, applicantcorrespondencelog, AuthHelper.getuserid())

--- a/request-management-api/request_api/services/communicationwrapperservice.py
+++ b/request-management-api/request_api/services/communicationwrapperservice.py
@@ -87,8 +87,9 @@ class communicationwrapperservice:
         else:
             emailsubject = templateconfig().getsubject(template.name, attributes)
         applicantcorrespondencelog['emailsubject'] = emailsubject
-        # FOIMOD-4270 — reject attachments that do not belong to this request
-        if ministryrequestid not in ('None', None):
+        # FOIMOD-4270 — reject attachments that do not belong to this request.
+        # Skip the DB lookup entirely when there are no attachments to check.
+        if ministryrequestid not in ('None', None) and applicantcorrespondencelog.get('attachments'):
             ministry = FOIMinistryRequest.getrequest(ministryrequestid) or {}
             requestnumber = ministry.get('filenumber')
             ministrycode = ministry.get('bcgovcode')

--- a/request-management-api/request_api/services/email/senderservice.py
+++ b/request-management-api/request_api/services/email/senderservice.py
@@ -41,6 +41,14 @@ class senderservice:
         return self.send(subject, content, _messageattachmentlist, requestjson["email"])
 
     def send(self, subject, content, _messageattachmentlist, emails, ccemails = None, from_email = None):
+        logger.info(
+            "Sending email: subject=%s to_count=%d cc_count=%d attachment_count=%d attachment_filenames=%s",
+            subject,
+            len(emails) if isinstance(emails, list) else 1,
+            len(ccemails) if isinstance(ccemails, list) else (1 if ccemails else 0),
+            len(_messageattachmentlist) if _messageattachmentlist else 0,
+            [a.get('filename') for a in (_messageattachmentlist or [])],
+        )
         logging.debug("Begin: Send email for request ")
 
         content = content.replace('src=\\\"', 'src="')

--- a/request-management-api/tests/restapi/test_communicationwrapperservice.py
+++ b/request-management-api/tests/restapi/test_communicationwrapperservice.py
@@ -1,8 +1,6 @@
 import logging
 from unittest.mock import patch, MagicMock
 
-import pytest
-
 from request_api.services.communicationwrapperservice import communicationwrapperservice
 
 

--- a/request-management-api/tests/restapi/test_communicationwrapperservice.py
+++ b/request-management-api/tests/restapi/test_communicationwrapperservice.py
@@ -1,0 +1,119 @@
+import logging
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from request_api.services.communicationwrapperservice import communicationwrapperservice
+
+
+class TestValidateAttachmentOwnership:
+    def test_valid_attachment_is_retained(self):
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "ack.pdf",
+             "url": "https://bucket.example/forms-bucket/MIN/MIN-2026-00001/ack.pdf"},
+        ]
+        result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert result == attachments
+
+    def test_foreign_attachment_is_rejected(self):
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "ours.pdf",
+             "url": "https://bucket.example/forms-bucket/MIN/MIN-2026-00001/ours.pdf"},
+            {"filename": "leaked.pdf",
+             "url": "https://bucket.example/forms-bucket/OTHER/OTHER-2026-99999/leaked.pdf"},
+        ]
+        result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert len(result) == 1
+        assert result[0]["filename"] == "ours.pdf"
+
+    def test_rejection_is_logged_as_warning(self, caplog):
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "leaked.pdf",
+             "url": "https://bucket.example/forms-bucket/OTHER/OTHER-2026-99999/leaked.pdf"},
+        ]
+        with caplog.at_level(logging.WARNING):
+            svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert any(
+            "Attachment ownership violation" in rec.getMessage() and "leaked.pdf" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    def test_documenturipath_field_is_also_checked(self):
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "ack.pdf",
+             "documenturipath": "https://bucket.example/forms-bucket/MIN/MIN-2026-00001/ack.pdf"},
+        ]
+        result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert result == attachments
+
+    def test_empty_or_missing_url_is_rejected(self):
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "no-url.pdf"},
+            {"filename": "empty.pdf", "url": ""},
+        ]
+        result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert result == []
+
+
+class TestSendEmailStripsForeignAttachments:
+    @patch("request_api.services.communicationwrapperservice.AuthHelper")
+    @patch("request_api.services.communicationwrapperservice.communicationemailservice")
+    @patch("request_api.services.communicationwrapperservice.applicantcorrespondenceservice")
+    @patch("request_api.services.communicationwrapperservice.FOIMinistryRequest")
+    def test_foreign_attachment_never_saved_or_sent(
+        self, mock_ministry, mock_appservice, mock_emailservice, mock_auth
+    ):
+        # Arrange — request belongs to MIN / MIN-2026-00001
+        mock_auth.getuserid.return_value = "tester"
+        mock_ministry.getrequest.return_value = {
+            "filenumber": "MIN-2026-00001",
+            "bcgovcode": "MIN",
+        }
+        save_result = MagicMock(success=True, identifier=42, message="ok")
+        mock_appservice.return_value.saveapplicantcorrespondencelog.return_value = save_result
+        # gettemplatebyid returns None for templatename branch, and later the
+        # non-fee path calls it again — return a template-like object regardless.
+        tpl = MagicMock()
+        tpl.name = "GENERIC"
+        mock_appservice.return_value.gettemplatebyid.return_value = tpl
+        mock_emailservice.return_value.send.return_value = {
+            "success": True, "from_email": "noreply@gov.bc.ca"
+        }
+
+        payload = {
+            "correspondencemessagejson": '{"body":"hi"}',
+            "attributes": [{}],
+            "correspondencesubject": "S",
+            "templatename": "GENERIC",
+            "templateid": None,
+            "emails": ["a@x.com"],
+            "attachments": [
+                {"filename": "ours.pdf",
+                 "url": "https://bucket/forms/MIN/MIN-2026-00001/ours.pdf"},
+                {"filename": "leaked.pdf",
+                 "url": "https://bucket/forms/OTHER/OTHER-2026-99999/leaked.pdf"},
+            ],
+        }
+
+        # Act
+        communicationwrapperservice().send_email(
+            requestid=1, rawrequestid=None, ministryrequestid=99,
+            applicantcorrespondencelog=payload,
+        )
+
+        # Assert — the saved log received only the owned attachment
+        saved_call = mock_appservice.return_value.saveapplicantcorrespondencelog.call_args
+        saved_log = saved_call.args[2] if len(saved_call.args) >= 3 else saved_call.kwargs["applicantcorrespondencelog"]
+        assert len(saved_log["attachments"]) == 1
+        assert saved_log["attachments"][0]["filename"] == "ours.pdf"
+
+        # Assert — the email service also received only the owned attachment
+        sent_call = mock_emailservice.return_value.send.call_args
+        sent_log = sent_call.args[1]
+        assert len(sent_log["attachments"]) == 1
+        assert sent_log["attachments"][0]["filename"] == "ours.pdf"

--- a/request-management-api/tests/restapi/test_communicationwrapperservice.py
+++ b/request-management-api/tests/restapi/test_communicationwrapperservice.py
@@ -165,3 +165,38 @@ class TestSendEmailStripsForeignAttachments:
         sent_log = sent_call.args[1]
         assert len(sent_log["attachments"]) == 1
         assert sent_log["attachments"][0]["filename"] == "ours.pdf"
+
+    @patch("request_api.services.communicationwrapperservice.AuthHelper")
+    @patch("request_api.services.communicationwrapperservice.communicationemailservice")
+    @patch("request_api.services.communicationwrapperservice.applicantcorrespondenceservice")
+    @patch("request_api.services.communicationwrapperservice.FOIMinistryRequest")
+    def test_no_attachments_skips_ministry_lookup(
+        self, mock_ministry, mock_appservice, mock_emailservice, mock_auth
+    ):
+        """When there are no attachments the ownership check must not run a DB lookup."""
+        mock_auth.getuserid.return_value = "tester"
+        save_result = MagicMock(success=True, identifier=42, message="ok")
+        mock_appservice.return_value.saveapplicantcorrespondencelog.return_value = save_result
+        tpl = MagicMock()
+        tpl.name = "GENERIC"
+        mock_appservice.return_value.gettemplatebyid.return_value = tpl
+        mock_emailservice.return_value.send.return_value = {
+            "success": True, "from_email": "noreply@gov.bc.ca"
+        }
+
+        payload = {
+            "correspondencemessagejson": '{"body":"hi"}',
+            "attributes": [{}],
+            "correspondencesubject": "S",
+            "templatename": "GENERIC",
+            "templateid": None,
+            "emails": ["a@x.com"],
+            "attachments": [],
+        }
+
+        communicationwrapperservice().send_email(
+            requestid=1, rawrequestid=None, ministryrequestid=99,
+            applicantcorrespondencelog=payload,
+        )
+
+        mock_ministry.getrequest.assert_not_called()

--- a/request-management-api/tests/restapi/test_communicationwrapperservice.py
+++ b/request-management-api/tests/restapi/test_communicationwrapperservice.py
@@ -59,6 +59,54 @@ class TestValidateAttachmentOwnership:
         result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
         assert result == []
 
+    def test_match_is_case_insensitive(self):
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "ack.pdf",
+             "url": "https://bucket.example/forms-bucket/min/min-2026-00001/ack.pdf"},
+        ]
+        result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert result == attachments
+
+    def test_querystring_containing_prefix_does_not_match(self):
+        """A malicious/misplaced querystring must not satisfy ownership."""
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "leaked.pdf",
+             "url": "https://bucket.example/forms-bucket/OTHER/OTHER-2026-99999/leaked.pdf"
+                    "?ref=/MIN/MIN-2026-00001/x"},
+        ]
+        result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert result == []
+
+    def test_partial_segment_does_not_match(self):
+        """MIN-2026-00001 must not match a request whose number is MIN-2026-000010."""
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "leaked.pdf",
+             "url": "https://bucket.example/forms-bucket/MIN/MIN-2026-000010/leaked.pdf"},
+        ]
+        result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert result == []
+
+    def test_percent_encoded_path_is_matched(self):
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "ack.pdf",
+             "url": "https://bucket.example/forms-bucket/%4D%49%4E/MIN-2026-00001/ack.pdf"},
+        ]
+        result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert result == attachments
+
+    def test_raw_s3_key_without_scheme_is_matched(self):
+        svc = communicationwrapperservice()
+        attachments = [
+            {"filename": "ack.pdf",
+             "url": "forms-bucket/MIN/MIN-2026-00001/ack.pdf"},
+        ]
+        result = svc._validate_attachment_ownership(attachments, "MIN", "MIN-2026-00001")
+        assert result == attachments
+
 
 class TestSendEmailStripsForeignAttachments:
     @patch("request_api.services.communicationwrapperservice.AuthHelper")

--- a/request-management-api/tests/restapi/test_communicationwrapperservice.py
+++ b/request-management-api/tests/restapi/test_communicationwrapperservice.py
@@ -198,3 +198,65 @@ class TestSendEmailStripsForeignAttachments:
         )
 
         mock_ministry.getrequest.assert_not_called()
+
+    @patch("request_api.services.communicationwrapperservice.AuthHelper")
+    @patch("request_api.services.communicationwrapperservice.communicationemailservice")
+    @patch("request_api.services.communicationwrapperservice.applicantcorrespondenceservice")
+    @patch("request_api.services.communicationwrapperservice.FOIMinistryRequest")
+    def test_fails_closed_when_ownership_coordinates_cannot_be_resolved(
+        self, mock_ministry, mock_appservice, mock_emailservice, mock_auth, caplog
+    ):
+        """If we cannot resolve ministrycode/requestnumber, drop all attachments."""
+        import logging as _logging
+
+        mock_auth.getuserid.return_value = "tester"
+        # Simulate an unresolvable request — getrequest returns None so both
+        # filenumber and bcgovcode are missing. The fallback SQL is also
+        # patched to return nothing via a broken db import path; simplest is
+        # to have getrequest return {} and monkeypatch db.session.execute
+        # inside the module to yield no row. We rely on the {}-return path
+        # plus a patched db.
+        mock_ministry.getrequest.return_value = {}
+
+        save_result = MagicMock(success=True, identifier=42, message="ok")
+        mock_appservice.return_value.saveapplicantcorrespondencelog.return_value = save_result
+        tpl = MagicMock()
+        tpl.name = "GENERIC"
+        mock_appservice.return_value.gettemplatebyid.return_value = tpl
+        mock_emailservice.return_value.send.return_value = {
+            "success": True, "from_email": "noreply@gov.bc.ca"
+        }
+
+        payload = {
+            "correspondencemessagejson": '{"body":"hi"}',
+            "attributes": [{}],
+            "correspondencesubject": "S",
+            "templatename": "GENERIC",
+            "templateid": None,
+            "emails": ["a@x.com"],
+            "attachments": [
+                {"filename": "unknown.pdf",
+                 "url": "https://bucket/forms/WHO/KNOWS/unknown.pdf"},
+            ],
+        }
+
+        # Patch the fallback SQL lookup to also return nothing.
+        with patch("request_api.models.db.db") as mock_db:
+            mock_db.session.execute.return_value.fetchone.return_value = None
+            with caplog.at_level(_logging.ERROR):
+                communicationwrapperservice().send_email(
+                    requestid=1, rawrequestid=None, ministryrequestid=99,
+                    applicantcorrespondencelog=payload,
+                )
+
+        # Fail-closed: the saved log must have zero attachments.
+        saved_call = mock_appservice.return_value.saveapplicantcorrespondencelog.call_args
+        saved_log = saved_call.args[2] if len(saved_call.args) >= 3 else saved_call.kwargs["applicantcorrespondencelog"]
+        assert saved_log["attachments"] == []
+
+        # And an ERROR log was emitted so this is alertable.
+        assert any(
+            "Attachment ownership check could not resolve" in r.getMessage()
+            and "fail closed" in r.getMessage()
+            for r in caplog.records
+        )

--- a/request-management-api/tests/services/email/test_senderservice_logging.py
+++ b/request-management-api/tests/services/email/test_senderservice_logging.py
@@ -1,0 +1,28 @@
+import logging
+from unittest.mock import patch, MagicMock
+
+
+def test_send_logs_email_metadata(caplog):
+    from request_api.services.email.senderservice import senderservice
+    fake_download = MagicMock()
+    fake_download.content = b"file-bytes"
+    with patch("request_api.services.email.senderservice.smtplib.SMTP") as smtp_ctx, \
+         patch("request_api.services.email.senderservice.storageservice") as storage, \
+         patch("request_api.services.email.senderservice.embeddedimagehandler") as eimg:
+        smtp_ctx.return_value.__enter__.return_value.sendmail.return_value = {}
+        storage.return_value.download.return_value = fake_download
+        eimg.return_value.formatembeddedimage.return_value = ("hi", [])
+        with caplog.at_level(logging.INFO, logger="request_api.services.email.senderservice"):
+            senderservice().send(
+                subject="Test subject",
+                content="hi",
+                _messageattachmentlist=[{"filename": "a.pdf", "url": "u"}],
+                emails=["to@x.com"],
+                ccemails=["cc@x.com"],
+            )
+    assert any(
+        "Sending email" in r.getMessage()
+        and "Test subject" in r.getMessage()
+        and "a.pdf" in r.getMessage()
+        for r in caplog.records
+    )


### PR DESCRIPTION
This change fixes an issue where correspondence attachments could persist across FOI requests and potentially be associated with the wrong request. It also resolves attachment filename collisions by matching S3 signed URL headers by index instead of filename.

Includes additional validation, structured logging, and test coverage.  

https://github.com/bcgov/foi-flow/pull/6260