### PR TITLE
Release 25.15: Ticket 5193 Observation 1 + Ticket 4920 Observation 9 Fix

### DIFF
--- a/forms-flow-web/src/components/FOI/Dashboard/IAO/AdvancedSearch/DataGridAdvancedSearch.js
+++ b/forms-flow-web/src/components/FOI/Dashboard/IAO/AdvancedSearch/DataGridAdvancedSearch.js
@@ -472,6 +472,8 @@ const DataGridAdvancedSearch = ({ userDetail }) => {
     {
       field: "reportPeriod",
       headerName: "REPORT PERIOD",
+      sortable: false,
+      filterable: false,
       flex: 1,
       headerAlign: "left",
       valueGetter: (params) => (params.row.requestType == "PD" || params.row.requestType == "proactive disclosure") ?

--- a/forms-flow-web/src/components/FOI/Dashboard/IAO/AdvancedSearch/DataGridAdvancedSearch.js
+++ b/forms-flow-web/src/components/FOI/Dashboard/IAO/AdvancedSearch/DataGridAdvancedSearch.js
@@ -280,7 +280,7 @@ const DataGridAdvancedSearch = ({ userDetail }) => {
         try {
           const ministryJSON = JSON.parse(params.row.selectedMinistries);
           if (!Array.isArray(ministryJSON) || ministryJSON.length === 0) return "None";
-          let firstMinistry = ministryJSON[0]?.code ?? "None";
+          let firstMinistry = ministryJSON[0]?.iaocode ?? ministryJSON[0]?.code ?? "None";
           const count = ministryJSON.length;
           return firstMinistry + (count > 1 ? ` (${count})` : "");
         } catch {

--- a/forms-flow-web/src/components/FOI/Dashboard/IAO/columns.js
+++ b/forms-flow-web/src/components/FOI/Dashboard/IAO/columns.js
@@ -319,6 +319,8 @@ const OITeamColumns = [
   {
     field: "reportPeriod",
     headerName: "REPORT PERIOD",
+    sortable: false,
+    filterable: false,
     flex: 1,
     headerAlign: "left",
     valueGetter: (params) => (params.row.requestType == "PD" || params.row.requestType == "proactive disclosure") ?

--- a/forms-flow-web/src/components/FOI/Dashboard/IAO/columns.js
+++ b/forms-flow-web/src/components/FOI/Dashboard/IAO/columns.js
@@ -139,7 +139,7 @@ const IntakeTeamColumns = [
       try {
         const ministryJSON = JSON.parse(params.row.selectedMinistries);
         if (!Array.isArray(ministryJSON) || ministryJSON.length === 0) return "None";
-        let firstMinistry = ministryJSON[0]?.code ?? "None";
+        let firstMinistry = ministryJSON[0]?.iaocode ?? ministryJSON[0]?.code ?? "None";
         const count = ministryJSON.length;
         return firstMinistry + (count > 1 ? ` (${count})` : "");
       } catch {

--- a/forms-flow-web/src/components/FOI/Dashboard/utils.js
+++ b/forms-flow-web/src/components/FOI/Dashboard/utils.js
@@ -345,13 +345,13 @@ export const selectedMinTooltipRender = (params) => {
     if (!Array.isArray(ministryJSON) || ministryJSON.length === 0) {
       return <span className="table-cell-truncate">None</span>;
     }
-    let firstMinistry = ministryJSON[0]?.code ?? "None";
+    let firstMinistry = ministryJSON[0]?.iaocode ?? ministryJSON[0]?.code ?? "None";
     const count = ministryJSON.length;
     let selectedMinistries = [];
 
     for (let ministry of ministryJSON) {
       if (ministry.isSelected || ministry.selected) {
-        selectedMinistries.push(ministry.code)
+        selectedMinistries.push(ministry.iaocode)
       }
     }
     return <LightTooltip placement="bottom-start" title={

--- a/request-management-api/request_api/models/FOIRawRequests.py
+++ b/request-management-api/request_api/models/FOIRawRequests.py
@@ -1064,7 +1064,6 @@ class FOIRawRequest(db.Model):
                 if(FOIRawRequest.validatefield(field)):
                     order = sortingorders.pop(0)
                     if field == 'selectedMinistries':
-                        print("BANG")
                         sort_expr = literal_column("""
                         COALESCE(
                             (SELECT pa."iaocode"

--- a/request-management-api/request_api/models/FOIRawRequests.py
+++ b/request-management-api/request_api/models/FOIRawRequests.py
@@ -1064,7 +1064,18 @@ class FOIRawRequest(db.Model):
                 if(FOIRawRequest.validatefield(field)):
                     order = sortingorders.pop(0)
                     if field == 'selectedMinistries':
-                        sort_expr = literal_column("""CASE WHEN "selectedMinistries" LIKE '[%' THEN ("selectedMinistries"::jsonb -> 0 ->> 'code') ELSE "selectedMinistries" END""")
+                        print("BANG")
+                        sort_expr = literal_column("""
+                        COALESCE(
+                            (SELECT pa."iaocode"
+                            FROM public."ProgramAreas" pa
+                            WHERE pa."bcgovcode" = 
+                                CASE WHEN "selectedMinistries" LIKE '[%' THEN ("selectedMinistries"::jsonb -> 0 ->> 'code') ELSE "selectedMinistries" END
+                            LIMIT 1
+                            ),
+                            CASE WHEN "selectedMinistries" LIKE '[%' THEN ("selectedMinistries"::jsonb -> 0 ->> 'code') ELSE "selectedMinistries" END
+                        )
+                        """)
                         if order == 'desc':
                             sortingcondition.append(nullslast(sort_expr.desc()))
                         else:

--- a/request-management-api/request_api/services/dashboardservice.py
+++ b/request-management-api/request_api/services/dashboardservice.py
@@ -5,6 +5,7 @@ from request_api.models.FOIRawRequestWatchers import FOIRawRequestWatcher
 from request_api.models.FOIRequestWatchers import FOIRequestWatcher
 from request_api.models.FOIOpenInformationRequests import FOIOpenInformationRequests
 from request_api.utils.enums import OIStatusEnum
+from request_api.models.ProgramAreas import ProgramArea
 from dateutil import tz, parser
 import datetime as dt
 from pytz import timezone
@@ -13,6 +14,7 @@ import maya
 from request_api.auth import AuthHelper
 import holidays
 import logging
+import json
 
 from flask import jsonify
 
@@ -35,7 +37,7 @@ class dashboardservice:
 
     """
 
-    def __preparefoirequestinfo(self, request, receiveddate, receiveddateuf, idnumberprefix = ''):
+    def __preparefoirequestinfo(self, request, receiveddate, receiveddateuf, updated_selectedministries, idnumberprefix = ''):
         idnumber = self.__getidnumber(idnumberprefix, request.axisRequestId, request.idNumber)
         baserequestinfo = self.__preparebaserequestinfo(
             request.id, 
@@ -113,12 +115,15 @@ class dashboardservice:
                 requestqueue.append(self.__handle_oi_request(request))
             else:
                 # Handle Raw requests format
+                # Update corresponding IAO code to selectedMinistries data
+                updated_selectedministries = self.__format_selectedministries(request)
+
                 if(request.receivedDateUF is None): #request from online form has no received date in json
                     _receiveddate = maya.parse(request.created_at).datetime(to_timezone='America/Vancouver', naive=False)
                 else:
                     _receiveddate = parser.parse(request.receivedDateUF)
                 if(request.ministryrequestid == None):                
-                    unopenrequest = self.__preparefoirequestinfo(request, _receiveddate.strftime(SHORT_DATEFORMAT), _receiveddate.strftime(LONG_DATEFORMAT), idnumberprefix= 'U-00')
+                    unopenrequest = self.__preparefoirequestinfo(request, _receiveddate.strftime(SHORT_DATEFORMAT), _receiveddate.strftime(LONG_DATEFORMAT), updated_selectedministries, idnumberprefix= 'U-00')
                     unopenrequest.update({'assignedToFormatted': request.assignedToFormatted})
                     unopenrequest.update({'isiaorestricted': request.isiaorestricted}) 
 
@@ -130,7 +135,7 @@ class dashboardservice:
                     requestqueue.append(unopenrequest) 
 
                 else:
-                    _openrequest = self.__preparefoirequestinfo(request, _receiveddate.strftime(SHORT_DATEFORMAT), _receiveddate.strftime(LONG_DATEFORMAT))
+                    _openrequest = self.__preparefoirequestinfo(request, _receiveddate.strftime(SHORT_DATEFORMAT), _receiveddate.strftime(LONG_DATEFORMAT), updated_selectedministries)
                     _openrequest.update({'ministryrequestid': request.ministryrequestid})
                     _openrequest.update({'extensions': request.extensions})
                     _openrequest.update({'assignedToFormatted': request.assignedToFormatted})
@@ -212,13 +217,16 @@ class dashboardservice:
         
         requestqueue = []
         for request in requests.items:
+            # Update corresponding IAO code to selectedMinistries data
+            updated_selectedministries = self.__format_selectedministries(request)
+
             if(request.receivedDateUF is None): #request from online form has no received date in json
                 _receiveddate = maya.parse(request.created_at).datetime(to_timezone='America/Vancouver', naive=False)
             else:
                 _receiveddate = parser.parse(request.receivedDateUF)
 
             if(request.ministryrequestid == None):
-                unopenrequest = self.__preparefoirequestinfo(request, _receiveddate.strftime(SHORT_DATEFORMAT), _receiveddate.strftime(LONG_DATEFORMAT), idnumberprefix= 'U-00')
+                unopenrequest = self.__preparefoirequestinfo(request, _receiveddate.strftime(SHORT_DATEFORMAT), _receiveddate.strftime(LONG_DATEFORMAT), updated_selectedministries, idnumberprefix= 'U-00')
                 unopenrequest.update({'description':request.description})
                 unopenrequest.update({'assignedToFormatted': request.assignedToFormatted})
                 unopenrequest.update({'isiaorestricted': request.isiaorestricted})
@@ -233,7 +241,7 @@ class dashboardservice:
 
                 requestqueue.append(unopenrequest)
             else:
-                _openrequest = self.__preparefoirequestinfo(request,  _receiveddate.strftime(SHORT_DATEFORMAT), _receiveddate.strftime(LONG_DATEFORMAT))
+                _openrequest = self.__preparefoirequestinfo(request,  _receiveddate.strftime(SHORT_DATEFORMAT), updated_selectedministries, _receiveddate.strftime(LONG_DATEFORMAT))
                 _openrequest.update({'ministryrequestid':request.ministryrequestid})
                 _openrequest.update({'extensions': request.extensions})
                 _openrequest.update({'description':request.description})
@@ -338,3 +346,16 @@ class dashboardservice:
         _cfrduedate = request.cfrduedate.strftime("%b %d %Y") if request.cfrduedate else None
             
         return self.__preparefoioirequestinfo(request, _receiveddate, _publicationdate, _from_closed, _cfrduedate)
+
+    def __format_selectedministries(self, request):
+        if (request.selectedMinistries):
+            programarea_mapping = {
+                programarea["bcgovcode"]: programarea["iaocode"] for programarea in ProgramArea.getprogramareas()
+            }
+            parsed_selectedministries = json.loads(request.selectedMinistries)
+            for selectedministry in parsed_selectedministries:
+                if selectedministry["code"] in programarea_mapping:
+                    selectedministry["iaocode"] = programarea_mapping[selectedministry["code"]]
+            return parsed_selectedministries
+
+        return []

--- a/request-management-api/request_api/services/dashboardservice.py
+++ b/request-management-api/request_api/services/dashboardservice.py
@@ -241,7 +241,7 @@ class dashboardservice:
 
                 requestqueue.append(unopenrequest)
             else:
-                _openrequest = self.__preparefoirequestinfo(request,  _receiveddate.strftime(SHORT_DATEFORMAT), updated_selectedministries, _receiveddate.strftime(LONG_DATEFORMAT))
+                _openrequest = self.__preparefoirequestinfo(request,  _receiveddate.strftime(SHORT_DATEFORMAT), _receiveddate.strftime(LONG_DATEFORMAT), updated_selectedministries)
                 _openrequest.update({'ministryrequestid':request.ministryrequestid})
                 _openrequest.update({'extensions': request.extensions})
                 _openrequest.update({'description':request.description})

--- a/request-management-api/request_api/services/dashboardservice.py
+++ b/request-management-api/request_api/services/dashboardservice.py
@@ -74,7 +74,7 @@ class dashboardservice:
         isoipcreview = request.isoipcreview if request.isoipcreview == True else False
         baserequestinfo.update({'isoipcreview': isoipcreview})
         baserequestinfo.update({'isphasedrelease': request.isphasedrelease if request.isphasedrelease == True else False})
-        baserequestinfo.update({'selectedMinistries': request.selectedMinistries})
+        baserequestinfo.update({'selectedMinistries': updated_selectedministries if len(updated_selectedministries) > 0 else request.selectedMinistries})
         baserequestinfo.update({'reportperiod': request.reportperiod})
         
         proactivecategory = ""

--- a/request-management-api/request_api/services/dashboardservice.py
+++ b/request-management-api/request_api/services/dashboardservice.py
@@ -38,6 +38,7 @@ class dashboardservice:
     """
 
     def __preparefoirequestinfo(self, request, receiveddate, receiveddateuf, updated_selectedministries, idnumberprefix = ''):
+        print("SNAKE", updated_selectedministries)
         idnumber = self.__getidnumber(idnumberprefix, request.axisRequestId, request.idNumber)
         baserequestinfo = self.__preparebaserequestinfo(
             request.id, 
@@ -115,6 +116,7 @@ class dashboardservice:
                 requestqueue.append(self.__handle_oi_request(request))
             else:
                 # Handle Raw requests format
+                print("ODD", request)
                 # Update corresponding IAO code to selectedMinistries data
                 updated_selectedministries = self.__format_selectedministries(request)
 

--- a/request-management-api/request_api/services/dashboardservice.py
+++ b/request-management-api/request_api/services/dashboardservice.py
@@ -38,7 +38,6 @@ class dashboardservice:
     """
 
     def __preparefoirequestinfo(self, request, receiveddate, receiveddateuf, updated_selectedministries, idnumberprefix = ''):
-        print("SNAKE", updated_selectedministries)
         idnumber = self.__getidnumber(idnumberprefix, request.axisRequestId, request.idNumber)
         baserequestinfo = self.__preparebaserequestinfo(
             request.id, 
@@ -116,7 +115,6 @@ class dashboardservice:
                 requestqueue.append(self.__handle_oi_request(request))
             else:
                 # Handle Raw requests format
-                print("ODD", request)
                 # Update corresponding IAO code to selectedMinistries data
                 updated_selectedministries = self.__format_selectedministries(request)
 


### PR DESCRIPTION
Ticket 5193 Obs 1 Fix:
1. adjusted sorting logic for ministry selected queue column by joining Program area and then finding corresponding iao code based on selected ministry code (the bcgovcode) and then sorting based on iaocode. 
2. adjusted request queried results by mapping through program areas and adding corresponding iaocode value to selectedministry object to be sent and use in FE
3. adjusted queues in FE to use this newly returned "iaocode" value in selectedministry obj

Ticket 4920 Obs 9 Fix:
1. disabled sorting + filtering for report period column